### PR TITLE
PHP-1358: Allow command cursor option to be array or object

### DIFF
--- a/tests/generic/bug01358.phpt
+++ b/tests/generic/bug01358.phpt
@@ -1,0 +1,96 @@
+--TEST--
+Test for PHP-1358: Allow command cursor option to be array or object
+--SKIPIF--
+<?php $needs = "2.8.0-RC3"; $needsOp = "ge"; ?>
+<?php require_once "tests/utils/standalone.inc"; ?>
+--FILE--
+<?php
+require_once "tests/utils/server.inc";
+
+function log_query($server, $query, $info) {
+    printf("Issuing command: %s\n", key($query));
+
+    if (isset($query['cursor'])) {
+        echo "Cursor option:\n";
+        var_dump($query['cursor']);
+    }
+}
+
+$ctx = stream_context_create(array(
+    'mongodb' => array(
+        'log_query' => 'log_query',
+    ),
+));
+
+$host = MongoShellServer::getStandaloneInfo();
+$mc = new MongoClient($host, array(), array('context' => $ctx));
+
+$db = $mc->selectDB(dbname());
+
+$collection = $db->selectCollection(collname(__FILE__));
+$collection->drop();
+$collection->insert(array('x' => 1));
+
+echo "\nTesting aggregate command enforces default batch size:\n";
+
+$cursor = $collection->aggregateCursor(
+    array(array('$match' => array('x' => 1))),
+    array('cursor' => (object) array())
+);
+$cursor->rewind();
+
+echo "\nTesting aggregate command with custom batch size:\n";
+
+$cursor = $collection->aggregateCursor(
+    array(array('$match' => array('x' => 1))),
+    array('cursor' => (object) array('batchSize' => 1))
+);
+$cursor->rewind();
+
+echo "\nTesting listCollections command enforces its own batch size:\n";
+
+$collections = $db->listCollections(
+    array('cursor' => (object) array())
+);
+
+echo "\nTesting listCollections command with custom batch size:\n";
+
+$collections = $db->listCollections(
+    array('cursor' => (object) array('batchSize' => 1))
+);
+
+?>
+===DONE===
+--EXPECTF--
+Issuing command: drop
+
+Testing aggregate command enforces default batch size:
+Issuing command: aggregate
+Cursor option:
+object(stdClass)#%d (1) {
+  ["batchSize"]=>
+  int(101)
+}
+
+Testing aggregate command with custom batch size:
+Issuing command: aggregate
+Cursor option:
+object(stdClass)#%d (1) {
+  ["batchSize"]=>
+  int(1)
+}
+
+Testing listCollections command enforces its own batch size:
+Issuing command: listCollections
+Cursor option:
+object(stdClass)#%d (0) {
+}
+
+Testing listCollections command with custom batch size:
+Issuing command: listCollections
+Cursor option:
+object(stdClass)#%d (1) {
+  ["batchSize"]=>
+  int(1)
+}
+===DONE===

--- a/tests/generic/mongocollection-aggregatecursor_error-001.phpt
+++ b/tests/generic/mongocollection-aggregatecursor_error-001.phpt
@@ -29,6 +29,6 @@ try {
 ?>
 ===DONE===
 --EXPECT--
-exception message: The cursor command's 'cursor' element is not an array
+exception message: The cursor command's 'cursor' element is not an array or object
 exception code: 32
 ===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHP-1358