### PR TITLE
PHP-1360: php_mongocursor_is_valid() does not return success/failure constants

### DIFF
--- a/collection.c
+++ b/collection.c
@@ -1367,7 +1367,7 @@ void php_mongo_collection_findone(zval *this_ptr, zval *query, zval *fields, zva
 		RETURN_NULL();
 	}
 
-	if (php_mongocursor_is_valid(cursor) == FAILURE) {
+	if (!php_mongocursor_is_valid(cursor)) {
 		zval_ptr_dtor(&zcursor);
 		RETURN_NULL();
 	}

--- a/db.c
+++ b/db.c
@@ -1192,7 +1192,7 @@ zval *php_mongo_runcommand(zval *zmongoclient, mongo_read_preference *read_prefe
 		zval_ptr_dtor(&cursor);
 		return NULL;
 	}
-	if (php_mongocursor_is_valid(cursor_tmp) == FAILURE) {
+	if (!php_mongocursor_is_valid(cursor_tmp)) {
 		zval_ptr_dtor(&cursor);
 		return NULL;
 	}


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHP-1360