### PR TITLE
PHP-1357: Test case should require server >= 2.8.0-RC4

### DIFF
--- a/tests/generic/bug01357.phpt
+++ b/tests/generic/bug01357.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test for PHP-1357: Command cursor may cause log_response_header callback to segfault
 --SKIPIF--
-<?php $needs = "2.8.0-RC3"; $needsOp = "ge"; ?>
+<?php $needs = "2.8.0-RC4"; $needsOp = "ge"; ?>
 <?php require_once "tests/utils/standalone.inc"; ?>
 --FILE--
 <?php
@@ -53,4 +53,6 @@ Response header received, query is not null
 Issuing command: listCollections
 Cursor batch size: 0
 Response header received, query is not null
+Issuing getmore
+Response header received, query is null
 ===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHP-1357

----

While 2.8.0-RC3 does support the cursor option for listCollections, it does not respect batchSize and returns all results in a single firstBatch field. RC4 adds full support for batchSize, which makes it possible to test for getmore.