### PR TITLE
PHP-1365: Validate cursor command option, but don't enforce batchSize

### DIFF
--- a/collection.c
+++ b/collection.c
@@ -2064,6 +2064,9 @@ void mongo_collection_list_indexes_command(zval *this_ptr, zval *return_value TS
 	array_init(z_cmd);
 	add_assoc_string(z_cmd, "listIndexes", Z_STRVAL_P(c->name), 1);
 
+	/* Note: when this function is enhanced to support command options,
+	 * php_mongo_validate_cursor_on_command() should be used here. */
+
 	retval = php_mongo_runcommand(c->link, &c->read_pref, Z_STRVAL_P(db->name), Z_STRLEN_P(db->name), z_cmd, NULL, 0, &connection TSRMLS_CC);
 	
 	zval_ptr_dtor(&z_cmd);
@@ -2651,9 +2654,9 @@ static zval* create_aggregate_command_from_pipeline(char *collname, zval *pipeli
 		zend_hash_merge(HASH_P(command), HASH_P(options), (void (*)(void*))zval_add_ref, &temp, sizeof(zval*), 1);
 	}
 
-	/* Make sure we have a cursor/batchSize object, if this fails,
+	/* Ensure that the command's cursor option is set and valid. If this fails,
 	 * EG(exception) is set. */
-	if (!php_mongo_enforce_batch_size_on_command(command, MONGO_DEFAULT_COMMAND_BATCH_SIZE TSRMLS_CC)) {
+	if (!php_mongo_enforce_cursor_on_command(command TSRMLS_CC)) {
 		zval_ptr_dtor(&command);
 		return NULL;
 	}

--- a/command_cursor.h
+++ b/command_cursor.h
@@ -16,8 +16,6 @@
 #ifndef __MONGO_CURSOR_H__
 #define __MONGO_CURSOR_H__ 1
 
-#define MONGO_DEFAULT_COMMAND_BATCH_SIZE 101
-
 void mongo_init_MongoCommandCursor(TSRMLS_D);
 zval *php_mongo_commandcursor_instantiate(zval *object TSRMLS_DC);
 void mongo_command_cursor_init(mongo_command_cursor *cmd_cursor, char *ns, zval *zlink, zval *zcommand TSRMLS_DC);
@@ -25,7 +23,8 @@ int php_mongocommandcursor_is_valid(mongo_command_cursor *cmd_cursor);
 int php_mongocommandcursor_load_current_element(mongo_command_cursor *cmd_cursor TSRMLS_DC);
 int php_mongocommandcursor_advance(mongo_command_cursor *cmd_cursor TSRMLS_DC);
 void php_mongocommandcursor_fetch_batch_if_first_is_empty(mongo_cursor *cmd_cursor TSRMLS_DC);
-int php_mongo_enforce_batch_size_on_command(zval *command, int size TSRMLS_DC);
+int php_mongo_validate_cursor_on_command(zval *command TSRMLS_DC);
+int php_mongo_enforce_cursor_on_command(zval *command TSRMLS_DC);
 
 void php_mongo_command_cursor_init_from_document(zval *zlink, mongo_command_cursor *cmd_cursor, char *hash, zval *document TSRMLS_DC);
 #endif

--- a/db.c
+++ b/db.c
@@ -615,6 +615,13 @@ static void mongo_db_list_collections_command(zval *this_ptr, zval *options, int
 		zend_hash_merge(HASH_P(z_cmd), HASH_P(options), (copy_ctor_func_t) zval_add_ref, &temp, sizeof(zval*), 1);
 	}
 
+	/* Ensure that the command's cursor option, if set, is valid. If this fails,
+	 * EG(exception) is set. */
+	if (!php_mongo_validate_cursor_on_command(z_cmd TSRMLS_CC)) {
+		zval_ptr_dtor(&z_cmd);
+		return;
+	}
+
 	PHP_MONGO_GET_DB(getThis());
 
 	retval = php_mongo_runcommand(db->link, &db->read_pref, Z_STRVAL_P(db->name), Z_STRLEN_P(db->name), z_cmd, NULL, 0, &connection TSRMLS_CC);

--- a/tests/generic/bug01358.phpt
+++ b/tests/generic/bug01358.phpt
@@ -31,7 +31,7 @@ $collection = $db->selectCollection(collname(__FILE__));
 $collection->drop();
 $collection->insert(array('x' => 1));
 
-echo "\nTesting aggregate command enforces default batch size:\n";
+echo "\nTesting aggregate command with empty cursor option:\n";
 
 $cursor = $collection->aggregateCursor(
     array(array('$match' => array('x' => 1))),
@@ -47,7 +47,7 @@ $cursor = $collection->aggregateCursor(
 );
 $cursor->rewind();
 
-echo "\nTesting listCollections command enforces its own batch size:\n";
+echo "\nTesting listCollections command with empty cursor option:\n";
 
 $collections = $db->listCollections(
     array('cursor' => (object) array())
@@ -64,12 +64,10 @@ $collections = $db->listCollections(
 --EXPECTF--
 Issuing command: drop
 
-Testing aggregate command enforces default batch size:
+Testing aggregate command with empty cursor option:
 Issuing command: aggregate
 Cursor option:
-object(stdClass)#%d (1) {
-  ["batchSize"]=>
-  int(101)
+object(stdClass)#%d (0) {
 }
 
 Testing aggregate command with custom batch size:
@@ -80,7 +78,7 @@ object(stdClass)#%d (1) {
   int(1)
 }
 
-Testing listCollections command enforces its own batch size:
+Testing listCollections command with empty cursor option:
 Issuing command: listCollections
 Cursor option:
 object(stdClass)#%d (0) {

--- a/tests/generic/mongocollection-aggregatecursor-004.phpt
+++ b/tests/generic/mongocollection-aggregatecursor-004.phpt
@@ -9,8 +9,9 @@ require "tests/utils/server.inc";
 function log_query($server, $query, $info) {
     printf("Issuing command: %s\n", key($query));
 
-    if (isset($query['cursor']['batchSize'])) {
-        printf("Cursor batch size: %d\n", $query['cursor']['batchSize']);
+    if (isset($query['cursor'])) {
+        echo "Cursor option:\n";
+        var_dump($query['cursor']);
     }
 }
 
@@ -52,7 +53,9 @@ foreach ($cursor as $key => $record) {
 Issuing command: drop
 Cursor class: MongoCommandCursor
 Issuing command: aggregate
-Cursor batch size: 101
+Cursor option:
+object(stdClass)#4 (0) {
+}
 int(0)
 array(2) {
   ["_id"]=>

--- a/tests/generic/mongocollection-aggregatecursor-005.phpt
+++ b/tests/generic/mongocollection-aggregatecursor-005.phpt
@@ -9,8 +9,9 @@ require "tests/utils/server.inc";
 function log_query($server, $query, $info) {
     printf("Issuing command: %s\n", key($query));
 
-    if (isset($query['cursor']['batchSize'])) {
-        printf("Cursor batch size: %d\n", $query['cursor']['batchSize']);
+    if (isset($query['cursor'])) {
+        echo "Cursor option:\n";
+        var_dump($query['cursor']);
     }
 }
 
@@ -53,7 +54,9 @@ foreach ($cursor as $key => $record) {
 Issuing command: drop
 Cursor class: MongoCommandCursor
 Issuing command: aggregate
-Cursor batch size: 101
+Cursor option:
+object(stdClass)#4 (0) {
+}
 int(0)
 array(2) {
   ["_id"]=>

--- a/tests/generic/mongocollection-aggregatecursor-006.phpt
+++ b/tests/generic/mongocollection-aggregatecursor-006.phpt
@@ -9,8 +9,9 @@ require "tests/utils/server.inc";
 function log_query($server, $query, $info) {
     printf("Issuing command: %s\n", key($query));
 
-    if (isset($query['cursor']['batchSize'])) {
-        printf("Cursor batch size: %d\n", $query['cursor']['batchSize']);
+    if (isset($query['cursor'])) {
+        echo "Cursor option:\n";
+        var_dump($query['cursor']);
     }
 }
 
@@ -46,7 +47,11 @@ printf("Total results: %d\n", count(iterator_to_array($cursor)));
 --EXPECTF--
 Issuing command: drop
 Issuing command: aggregate
-Cursor batch size: 0
+Cursor option:
+array(1) {
+  ["batchSize"]=>
+  int(0)
+}
 Issuing getmore
 Total results: 2
 ===DONE===

--- a/tests/generic/mongocollection-aggregatecursor-007.phpt
+++ b/tests/generic/mongocollection-aggregatecursor-007.phpt
@@ -9,8 +9,9 @@ require "tests/utils/server.inc";
 function log_query($server, $query, $info) {
     printf("Issuing command: %s\n", key($query));
 
-    if (isset($query['cursor']['batchSize'])) {
-        printf("Cursor batch size: %d\n", $query['cursor']['batchSize']);
+    if (isset($query['cursor'])) {
+        echo "Cursor option:\n";
+        var_dump($query['cursor']);
     }
 }
 
@@ -38,6 +39,7 @@ for ($i = 0; $i < 103; $i++) {
     $collection->insert(array('article_id' => $i));
 }
 
+// This assumes that the server's batch size defaults to 101 for aggregate
 $cursor = $collection->aggregateCursor(
     array(array('$limit' => 105))
 );
@@ -54,7 +56,9 @@ foreach ($cursor as $key => $record) {
 Issuing command: drop
 Cursor class: MongoCommandCursor
 Issuing command: aggregate
-Cursor batch size: 101
+Cursor option:
+object(stdClass)#4 (0) {
+}
 0
 1
 2


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHP-1365

----

The driver should not enforce the cursor.batchSize command option, as the server will already use its own default. We should validate that the cursor option is an array/object, and empty arrays should be converted to an object to ensure proper BSON serialization (the server requires an object type).

Only aggregateCursor() requires that we inject the cursor option if it is missing. Collection and index enumeration commands do not require the option at all, as they will always return cursors in 2.8.0-RC4+ and return inline results in earlier versions. RC3 can return an emulated cursor response with only a first batch, but it is practically equivalent to the result when the cursor option is not specified at all.