### PR TITLE
PHP-1361: Load command result document before php_mongo_handle_error()

### DIFF
--- a/db.c
+++ b/db.c
@@ -1187,17 +1187,18 @@ zval *php_mongo_runcommand(zval *zmongoclient, mongo_read_preference *read_prefe
 		return NULL;
 	}
 
+	/* Find return value */
+	if (php_mongocursor_load_current_element(cursor_tmp TSRMLS_CC) == FAILURE) {
+		zval_ptr_dtor(&cursor);
+		return NULL;
+	}
+
 	if (php_mongo_handle_error(cursor_tmp TSRMLS_CC)) {
 		/* do not free anything here, as php_mongo_handle_error already does
 		 * that upon error */
 		return NULL;
 	}
 
-	/* Find return value */
-	if (php_mongocursor_load_current_element(cursor_tmp TSRMLS_CC) == FAILURE) {
-		zval_ptr_dtor(&cursor);
-		return NULL;
-	}
 	if (!php_mongocursor_is_valid(cursor_tmp)) {
 		zval_ptr_dtor(&cursor);
 		return NULL;


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHP-1361

----

php_mongo_handle_error() tries to inspect the first result document for an $err field, which is impossible if we never load it first. This makes php_mongo_runcommand() consistent with php_mongo_collection_findone().