### PR TITLE
PHP-1370: Fix arginfo test after re-ordering method declarations

### DIFF
--- a/tests/no-servers/bug00270-arginfo.phpt
+++ b/tests/no-servers/bug00270-arginfo.phpt
@@ -292,9 +292,9 @@ MongoCursor
   Method setReadPreference expects 2 parameters
     0: read_preference
     1: tags (optional)
+  Method doQuery expects 0 parameters
   Method timeout expects 1 parameters
     0: timeoutMS
-  Method doQuery expects 0 parameters
   Method info expects 0 parameters
   Method dead expects 0 parameters
   Method current expects 0 parameters


### PR DESCRIPTION
See: fabe53582ad221bd8d8354a60c43928202810bb6