### PR TITLE
PHP-1427 and PHP-1433: distinct() query param handling

### DIFF
--- a/tests/generic/mongocollection-distinct-001.phpt
+++ b/tests/generic/mongocollection-distinct-001.phpt
@@ -1,0 +1,27 @@
+--TEST--
+MongoCollection::distinct()
+--SKIPIF--
+<?php require_once "tests/utils/standalone.inc"; ?>
+--FILE--
+<?php require_once "tests/utils/server.inc"; ?>
+<?php
+
+$host = MongoShellServer::getStandaloneInfo();
+$m = new MongoClient($host);
+$c = $m->selectCollection(dbname(), collname(__FILE__));
+$c->drop();
+
+$c->insert(array('x' => 1));
+$c->insert(array('x' => 2));
+$c->insert(array('x' => 2));
+$c->insert(array('x' => 3));
+
+printf("Distinct x values: %s\n", json_encode($c->distinct('x')));
+printf("Distinct x values where x >= 2: %s\n", json_encode($c->distinct('x', array('x' => array('$gte' => 2)))));
+
+?>
+===DONE===
+--EXPECT--
+Distinct x values: [1,2,3]
+Distinct x values where x >= 2: [2,3]
+===DONE===

--- a/tests/generic/mongocollection-distinct_error-001.phpt
+++ b/tests/generic/mongocollection-distinct_error-001.phpt
@@ -1,0 +1,31 @@
+--TEST--
+MongoCollection::distinct() requires query to be a hash
+--SKIPIF--
+<?php require_once "tests/utils/standalone.inc"; ?>
+--FILE--
+<?php require_once "tests/utils/server.inc"; ?>
+<?php
+
+$host = MongoShellServer::getStandaloneInfo();
+$m = new MongoClient($host);
+$c = $m->selectCollection(dbname(), collname(__FILE__));
+$c->drop();
+
+$c->insert(array('x' => 1));
+$c->insert(array('x' => 2));
+$c->insert(array('x' => 2));
+$c->insert(array('x' => 3));
+
+echo json_encode($c->distinct('x', array())), "\n";
+echo json_encode($c->distinct('x', new stdClass)), "\n";
+echo json_encode($c->distinct('x', 1)), "\n";
+
+?>
+===DONE===
+--EXPECTF--
+[1,2,3]
+[1,2,3]
+
+Warning: MongoCollection::distinct() expects parameter 2 to be array, integer given in %s on line %d
+null
+===DONE===


### PR DESCRIPTION
 * https://jira.mongodb.org/browse/PHP-1427
 * https://jira.mongodb.org/browse/PHP-1433

----

An empty query parameter should be omitted from the command document (consistent with other helpers). This will avoid the case where an empty array is serialized as a BSON array and the server complains that a BSON object was not provided.

Additionally, relax ZPP parsing to allow arrays or objects for the query (also consistent with other helpers).