### PR TITLE
PHP-1442: Don't use server options for stream IO notification

### DIFF
--- a/io_stream.c
+++ b/io_stream.c
@@ -310,7 +310,7 @@ int php_mongo_io_stream_read(mongo_connection *con, mongo_server_options *option
 		mongo_manager_log(MonGlo(manager), MLOG_CON, MLOG_FINE, "No timeout changes for %s", con->hash);
 	}
 
-	php_mongo_stream_notify_io(options, MONGO_STREAM_NOTIFY_IO_READ, 0, size TSRMLS_CC);
+	php_mongo_stream_notify_io(con->socket, MONGO_STREAM_NOTIFY_IO_READ, 0, size TSRMLS_CC);
 
 	/* this can return FAILED if there is just no more data from db */
 	while (received < size && num > 0) {
@@ -367,7 +367,7 @@ int php_mongo_io_stream_read(mongo_connection *con, mongo_server_options *option
 	 * then that PHP will just buffer the rest, which is fine.  It could
 	 * confuse users a little, why their progress update was higher then the
 	 * max-bytes-expected though... */
-	php_mongo_stream_notify_io(options, MONGO_STREAM_NOTIFY_IO_COMPLETED, received, size TSRMLS_CC);
+	php_mongo_stream_notify_io(con->socket, MONGO_STREAM_NOTIFY_IO_COMPLETED, received, size TSRMLS_CC);
 
 	/* If the timeout was changed, revert to the previous value now */
 	if (revert_timeout) {
@@ -392,13 +392,13 @@ int php_mongo_io_stream_send(mongo_connection *con, mongo_server_options *option
 	zend_error_handling error_handler;
 	TSRMLS_FETCH();
 
-	php_mongo_stream_notify_io(options, MONGO_STREAM_NOTIFY_IO_WRITE, 0, size TSRMLS_CC);
+	php_mongo_stream_notify_io(con->socket, MONGO_STREAM_NOTIFY_IO_WRITE, 0, size TSRMLS_CC);
 
 	zend_replace_error_handling(EH_THROW, mongo_ce_ConnectionException, &error_handler TSRMLS_CC);
 	retval = php_stream_write(con->socket, (char *) data, size);
 	zend_restore_error_handling(&error_handler TSRMLS_CC);;
 	if (retval >= size) {
-		php_mongo_stream_notify_io(options, MONGO_STREAM_NOTIFY_IO_COMPLETED, size, size TSRMLS_CC);
+		php_mongo_stream_notify_io(con->socket, MONGO_STREAM_NOTIFY_IO_COMPLETED, size, size TSRMLS_CC);
 	}
 
 	return retval;

--- a/log_stream.c
+++ b/log_stream.c
@@ -262,16 +262,13 @@ void php_mongo_stream_notify_meta_write_reply(php_stream_context *ctx, zval *ser
 	zval_ptr_dtor(&args);
 }
 
-void php_mongo_stream_notify_io(mongo_server_options *opts, int code, int sofar, int max TSRMLS_DC)
+void php_mongo_stream_notify_io(php_stream *stream, int code, int sofar, int max TSRMLS_DC)
 {
-	php_stream_context *ctx;
+	php_stream_context *ctx = stream->context;
 
-
-	if (!(opts && (opts)->ctx && ((php_stream_context *)opts->ctx)->notifier)) {
+	if (!ctx || !ctx->notifier) {
 		return;
 	}
-
-	ctx = (php_stream_context *)opts->ctx;
 
 	switch (code) {
 		case MONGO_STREAM_NOTIFY_IO_READ:

--- a/log_stream.h
+++ b/log_stream.h
@@ -47,7 +47,7 @@
 #define MONGO_STREAM_NOTIFY_LOG_CMD_DELETE      222
 #define MONGO_STREAM_NOTIFY_LOG_WRITE_BATCH     223
 
-void php_mongo_stream_notify_io(mongo_server_options *opts, int code, int sofar, int max TSRMLS_DC);
+void php_mongo_stream_notify_io(php_stream *stream, int code, int sofar, int max TSRMLS_DC);
 void mongo_log_stream_insert(mongo_connection *connection, zval *document, zval *options TSRMLS_DC);
 void mongo_log_stream_query(mongo_connection *connection, mongo_cursor *cursor TSRMLS_DC);
 void mongo_log_stream_update(mongo_connection *connection, zval *ns, zval *criteria, zval *newobj, zval *options, int flags TSRMLS_DC);


### PR DESCRIPTION
This may address [PHP-1442](https://jira.mongodb.org/browse/PHP-1442) and possibly [PHP-1002](https://jira.mongodb.org/browse/PHP-1002) and [PHP-1417](https://jira.mongodb.org/browse/PHP-1417), too.

Server options are limited to the current request, while the stream itself is persistent. The context should only be accessed through the persistent stream.

Hat tip to @bjori for bringing this to light.

![](http://i.giphy.com/q2AwmVCtLIYFO.gif)