### PR TITLE
PHP-1445: Allow boolean false for MongoClient ssl option

### DIFF
--- a/mcon/parse.c
+++ b/mcon/parse.c
@@ -616,9 +616,6 @@ int mongo_store_option(mongo_con_manager *manager, mongo_servers *servers, char 
 		if (strcasecmp(option_value, "true") == 0 || strcmp(option_value, "1") == 0) {
 			value = MONGO_SSL_ENABLE;
 			mongo_manager_log(manager, MLOG_PARSE, MLOG_INFO, "- Found option 'ssl': true");
-		} else if (strcasecmp(option_value, "false") == 0 || strcmp(option_value, "0") == 0) {
-			value = MONGO_SSL_DISABLE;
-			mongo_manager_log(manager, MLOG_PARSE, MLOG_INFO, "- Found option 'ssl': false");
 		} else if (strcasecmp(option_value, "prefer") == 0 || atoi(option_value) == MONGO_SSL_PREFER) {
 			/* FIXME: MongoDB doesn't support "connection promotion" to SSL at
 			 * the moment, so we can't support this option properly */
@@ -627,9 +624,8 @@ int mongo_store_option(mongo_con_manager *manager, mongo_servers *servers, char 
 			*error_message = strdup("SSL=prefer is currently not supported by mongod");
 			return 3;
 		} else {
-			mongo_manager_log(manager, MLOG_PARSE, MLOG_INFO, "- Found option 'ssl': '%s'", option_name);
-			*error_message = strdup("SSL can only be 'true' or 'false'");
-			return 3;
+			value = MONGO_SSL_DISABLE;
+			mongo_manager_log(manager, MLOG_PARSE, MLOG_INFO, "- Found option 'ssl': false");
 		}
 
 		servers->options.ssl = value;

--- a/tests/no-servers/mongoclient-ssl-001.phpt
+++ b/tests/no-servers/mongoclient-ssl-001.phpt
@@ -1,0 +1,43 @@
+--TEST--
+MongoClient parses boolean ssl options
+--SKIPIF--
+<?php require_once dirname(__FILE__) . "/skipif.inc"; ?>
+--FILE--
+<?php include 'tests/utils/server.inc'; ?>
+<?php
+
+printLogs(MongoLog::PARSE, MongoLog::INFO, "/Found option 'ssl'/");
+
+echo "Testing ssl=true:\n";
+new MongoClient('mongodb://localhost:27017/?ssl=true', array('connect' => false));
+new MongoClient('mongodb://localhost:27017/?ssl=1', array('connect' => false));
+new MongoClient('mongodb://localhost:27017/', array('ssl' => 'true', 'connect' => false));
+new MongoClient('mongodb://localhost:27017/', array('ssl' => 1, 'connect' => false));
+new MongoClient('mongodb://localhost:27017/', array('ssl' => true, 'connect' => false));
+
+echo "\nTesting ssl=false:\n";
+new MongoClient('mongodb://localhost:27017/?ssl=false', array('connect' => false));
+new MongoClient('mongodb://localhost:27017/?ssl=0', array('connect' => false));
+new MongoClient('mongodb://localhost:27017/?ssl=', array('connect' => false));
+new MongoClient('mongodb://localhost:27017/', array('ssl' => 'false', 'connect' => false));
+new MongoClient('mongodb://localhost:27017/', array('ssl' => 0, 'connect' => false));
+new MongoClient('mongodb://localhost:27017/', array('ssl' => false, 'connect' => false));
+
+?>
+===DONE===
+--EXPECT--
+Testing ssl=true:
+- Found option 'ssl': true
+- Found option 'ssl': true
+- Found option 'ssl': true
+- Found option 'ssl': true
+- Found option 'ssl': true
+
+Testing ssl=false:
+- Found option 'ssl': false
+- Found option 'ssl': false
+- Found option 'ssl': false
+- Found option 'ssl': false
+- Found option 'ssl': false
+- Found option 'ssl': false
+===DONE===

--- a/tests/no-servers/mongoclient-ssl_error-001.phpt
+++ b/tests/no-servers/mongoclient-ssl_error-001.phpt
@@ -1,0 +1,49 @@
+--TEST--
+MongoClient does not support ssl "prefer" option
+--SKIPIF--
+<?php require_once dirname(__FILE__) . "/skipif.inc"; ?>
+--FILE--
+<?php include 'tests/utils/server.inc'; ?>
+<?php
+
+printLogs(MongoLog::PARSE, MongoLog::INFO, "/Found option 'ssl'/");
+
+echo "Testing ssl=prefer:\n";
+
+try {
+    new MongoClient('mongodb://localhost:27017/?ssl=prefer', array('connect' => false));
+} catch (MongoConnectionException $e) {
+    printf("Exception: %s\n", $e->getMessage());
+}
+
+try {
+    new MongoClient('mongodb://localhost:27017/?ssl=2', array('connect' => false));
+} catch (MongoConnectionException $e) {
+    printf("Exception: %s\n", $e->getMessage());
+}
+
+try {
+    new MongoClient('mongodb://localhost:27017/', array('ssl' => 'prefer', 'connect' => false));
+} catch (MongoConnectionException $e) {
+    printf("Exception: %s\n", $e->getMessage());
+}
+
+try {
+    new MongoClient('mongodb://localhost:27017/', array('ssl' => 2, 'connect' => false));
+} catch (MongoConnectionException $e) {
+    printf("Exception: %s\n", $e->getMessage());
+}
+
+?>
+===DONE===
+--EXPECT--
+Testing ssl=prefer:
+- Found option 'ssl': prefer
+Exception: SSL=prefer is currently not supported by mongod
+- Found option 'ssl': prefer
+Exception: SSL=prefer is currently not supported by mongod
+- Found option 'ssl': prefer
+Exception: SSL=prefer is currently not supported by mongod
+- Found option 'ssl': prefer
+Exception: SSL=prefer is currently not supported by mongod
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHP-1445

To be consistent with other boolean options (e.g. fsync, journal), non-truthy strings should be parsed as a false value. With this change, we can remove the error message that ssl must be true/false; however, we'll keep error reporting for the unsupported "prefer" option value.