### PR TITLE
PHP-1460: Advancing cursor beyond its limit should kill it

### DIFF
--- a/command_cursor.c
+++ b/command_cursor.c
@@ -223,7 +223,6 @@ int php_mongocommandcursor_advance(mongo_command_cursor *cmd_cursor TSRMLS_DC)
 				return FAILURE;
 			}
 			if (!php_mongo_get_more(cmd_cursor TSRMLS_CC)) {
-				cmd_cursor->cursor_id = 0;
 				return FAILURE;
 			}
 		}

--- a/cursor.c
+++ b/cursor.c
@@ -380,8 +380,8 @@ int php_mongocursor_advance(mongo_cursor *cursor TSRMLS_DC)
 		}
 		/* Limit reached */
 		if (cursor->limit != 0 && cursor->at >= cursor->limit) {
-			mongo_deregister_callback_from_connection(cursor->connection, cursor);
-			php_mongo_cursor_mark_dead(cursor);
+			php_mongo_kill_cursor(cursor->connection, cursor->cursor_id TSRMLS_CC);
+			cursor->cursor_id = 0;
 			return FAILURE;
 		}
 		if (!php_mongo_get_more(cursor TSRMLS_CC)) {

--- a/cursor.c
+++ b/cursor.c
@@ -385,10 +385,6 @@ int php_mongocursor_advance(mongo_cursor *cursor TSRMLS_DC)
 			return FAILURE;
 		}
 		if (!php_mongo_get_more(cursor TSRMLS_CC)) {
-			if (cursor->connection) {
-				mongo_deregister_callback_from_connection(cursor->connection, cursor);
-			}
-			php_mongo_cursor_mark_dead(cursor);
 			return FAILURE;
 		}
 	}

--- a/cursor_shared.c
+++ b/cursor_shared.c
@@ -629,6 +629,7 @@ int php_mongo_cursor_failed(mongo_cursor *cursor TSRMLS_DC)
 {
 	mongo_manager_connection_deregister(MonGlo(manager), cursor->connection);
 	cursor->dead = 1;
+	cursor->cursor_id = 0;
 	cursor->connection = NULL;
 
 	return FAILURE;

--- a/tests/generic/bug01460-001.phpt
+++ b/tests/generic/bug01460-001.phpt
@@ -1,0 +1,89 @@
+--TEST--
+Test for PHP-1460: Query with limit leaves open cursors on server (foreach iteration)
+--SKIPIF--
+<?php require_once "tests/utils/standalone.inc" ?>
+--FILE--
+<?php
+require_once "tests/utils/server.inc";
+
+function getNumOpenCursors(MongoClient $mc) {
+    $result = $mc->admin->command(array('serverStatus' => 1));
+
+    if (isset($result['metrics']['cursor']['open']['total'])) {
+        return (integer) $result['metrics']['cursor']['open']['total'];
+    }
+
+    if (isset($result['cursors']['totalOpen'])) {
+        return (integer) $result['cursors']['totalOpen'];
+    }
+
+    throw new RuntimeException('serverStatus did not return cursor metrics');
+}
+
+function log_killcursor($server, $info) {
+    printf("Killing cursor: %d\n", $info['cursor_id']);
+}
+
+function log_getmore($server, $info) {
+    printf("Getmore on cursor: %d\n", $info['cursor_id']);
+}
+
+$ctx = stream_context_create(array(
+    'mongodb' => array(
+        'log_getmore' => 'log_getmore',
+        'log_killcursor' => 'log_killcursor',
+    ),
+));
+
+$host = MongoShellServer::getStandaloneInfo();
+$mc = new MongoClient($host, array(), array('context' => $ctx));
+
+$c = $mc->selectCollection(dbname(), collname(__FILE__));
+$c->drop();
+
+for ($i = 0; $i < 15; $i++) {
+    $c->insert(array('_id' => $i));
+}
+
+$numOpenCursorsBeforeQuery = getNumOpenCursors($mc);
+printf("Number of open cursors before query: %d\n", $numOpenCursorsBeforeQuery);
+
+$cursor = $c->find()->limit(10)->batchSize(5);
+printf("Cursor is dead: %s\n", $cursor->dead() ? 'true' : 'false');
+
+foreach ($cursor as $document) {
+    printf("Found document: %d\n", $document['_id']);
+    if ($document['_id'] === 4 || $document['_id'] === 9) {
+        printf("Cursor is dead: %s\n", $cursor->dead() ? 'true' : 'false');
+    }
+}
+
+printf("Cursor is dead: %s\n", $cursor->dead() ? 'true' : 'false');
+
+$numOpenCursorsAfterQuery = getNumOpenCursors($mc);
+printf("Number of open cursors after query: %d\n", $numOpenCursorsAfterQuery);
+printf("Same number of cursors open before and after query: %s\n", $numOpenCursorsBeforeQuery === $numOpenCursorsAfterQuery ? 'true' : 'false');
+
+?>
+===DONE===
+--EXPECTF--
+Number of open cursors before query: %d
+Cursor is dead: false
+Found document: 0
+Found document: 1
+Found document: 2
+Found document: 3
+Found document: 4
+Cursor is dead: false
+Getmore on cursor: %d
+Found document: 5
+Found document: 6
+Found document: 7
+Found document: 8
+Found document: 9
+Cursor is dead: false
+Killing cursor: %d
+Cursor is dead: true
+Number of open cursors after query: %d
+Same number of cursors open before and after query: true
+===DONE===

--- a/tests/generic/bug01460-002.phpt
+++ b/tests/generic/bug01460-002.phpt
@@ -1,0 +1,90 @@
+--TEST--
+Test for PHP-1460: Query with limit leaves open cursors on server (getNext/hasNext iteration)
+--SKIPIF--
+<?php require_once "tests/utils/standalone.inc" ?>
+--FILE--
+<?php
+require_once "tests/utils/server.inc";
+
+function getNumOpenCursors(MongoClient $mc) {
+    $result = $mc->admin->command(array('serverStatus' => 1));
+
+    if (isset($result['metrics']['cursor']['open']['total'])) {
+        return (integer) $result['metrics']['cursor']['open']['total'];
+    }
+
+    if (isset($result['cursors']['totalOpen'])) {
+        return (integer) $result['cursors']['totalOpen'];
+    }
+
+    throw new RuntimeException('serverStatus did not return cursor metrics');
+}
+
+function log_killcursor($server, $info) {
+    printf("Killing cursor: %d\n", $info['cursor_id']);
+}
+
+function log_getmore($server, $info) {
+    printf("Getmore on cursor: %d\n", $info['cursor_id']);
+}
+
+$ctx = stream_context_create(array(
+    'mongodb' => array(
+        'log_getmore' => 'log_getmore',
+        'log_killcursor' => 'log_killcursor',
+    ),
+));
+
+$host = MongoShellServer::getStandaloneInfo();
+$mc = new MongoClient($host, array(), array('context' => $ctx));
+
+$c = $mc->selectCollection(dbname(), collname(__FILE__));
+$c->drop();
+
+for ($i = 0; $i < 15; $i++) {
+    $c->insert(array('_id' => $i));
+}
+
+$numOpenCursorsBeforeQuery = getNumOpenCursors($mc);
+printf("Number of open cursors before query: %d\n", $numOpenCursorsBeforeQuery);
+
+$cursor = $c->find()->limit(10)->batchSize(5);
+printf("Cursor is dead: %s\n", $cursor->dead() ? 'true' : 'false');
+
+while ($cursor->hasNext()) {
+    $document = $cursor->getNext();
+    printf("Found document: %d\n", $document['_id']);
+    if ($document['_id'] === 4 || $document['_id'] === 9) {
+        printf("Cursor is dead: %s\n", $cursor->dead() ? 'true' : 'false');
+    }
+}
+
+printf("Cursor is dead: %s\n", $cursor->dead() ? 'true' : 'false');
+
+$numOpenCursorsAfterQuery = getNumOpenCursors($mc);
+printf("Number of open cursors after query: %d\n", $numOpenCursorsAfterQuery);
+printf("Same number of cursors open before and after query: %s\n", $numOpenCursorsBeforeQuery === $numOpenCursorsAfterQuery ? 'true' : 'false');
+
+?>
+===DONE===
+--EXPECTF--
+Number of open cursors before query: %d
+Cursor is dead: false
+Found document: 0
+Found document: 1
+Found document: 2
+Found document: 3
+Found document: 4
+Cursor is dead: false
+Getmore on cursor: %d
+Found document: 5
+Found document: 6
+Found document: 7
+Found document: 8
+Found document: 9
+Cursor is dead: false
+Killing cursor: %d
+Cursor is dead: true
+Number of open cursors after query: %d
+Same number of cursors open before and after query: true
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHP-1460

----

This PRs includes two related fixes:

 * Make cleanup after failed `php_mongo_get_more()` (for both advancing of command and regular cursors) consistent with the more recently refactored code in `MongoCursor::hasNext()`
 * Ensure `php_mongocursor_advance()` kills the cursor when it would be advanced beyond its limit. Additionally, we test that iteration with `getNext()` and `hasNext()` performs as expected.