### PR TITLE
Fixed PHP-1462: Don't expose php_hash_copy by marking it static

### DIFF
--- a/contrib/crypto.c
+++ b/contrib/crypto.c
@@ -21,40 +21,40 @@
 #include "crypto.h"
 #include <ext/standard/sha1.h>
 
-static int php_hash_copy(const void *ops, void *orig_context, void *dest_context) /* {{{ */
+static int php_mongo_hash_copy(const void *ops, void *orig_context, void *dest_context) /* {{{ */
 {
-	php_hash_ops *hash_ops = (php_hash_ops *)ops;
+	php_mongo_hash_ops *hash_ops = (php_mongo_hash_ops *)ops;
 
 	memcpy(dest_context, orig_context, hash_ops->context_size);
 	return SUCCESS;
 }
 /* }}} */
 
-const php_hash_ops sha1_hash_ops = {
-	(php_hash_init_func_t) PHP_SHA1Init,
-	(php_hash_update_func_t) PHP_SHA1Update,
-	(php_hash_final_func_t) PHP_SHA1Final,
-	(php_hash_copy_func_t) php_hash_copy,
+const php_mongo_hash_ops sha1_hash_ops = {
+	(php_mongo_hash_init_func_t) PHP_SHA1Init,
+	(php_mongo_hash_update_func_t) PHP_SHA1Update,
+	(php_mongo_hash_final_func_t) PHP_SHA1Final,
+	(php_mongo_hash_copy_func_t) php_mongo_hash_copy,
 	20,
 	64,
 	sizeof(PHP_SHA1_CTX)
 };
 
-static inline void php_hash_string_xor_char(unsigned char *out, const unsigned char *in, const unsigned char xor_with, const int length) {
+static inline void php_mongo_hash_string_xor_char(unsigned char *out, const unsigned char *in, const unsigned char xor_with, const int length) {
 	int i;
 	for (i=0; i < length; i++) {
 		out[i] = in[i] ^ xor_with;
 	}
 }
 
-static inline void php_hash_string_xor(unsigned char *out, const unsigned char *in, const unsigned char *xor_with, const int length) {
+static inline void php_mongo_hash_string_xor(unsigned char *out, const unsigned char *in, const unsigned char *xor_with, const int length) {
 	int i;
 	for (i=0; i < length; i++) {
 		out[i] = in[i] ^ xor_with[i];
 	}
 }
 
-static inline void php_hash_hmac_prep_key(unsigned char *K, const php_hash_ops *ops, void *context, const unsigned char *key, const int key_len) {
+static inline void php_mongo_hash_hmac_prep_key(unsigned char *K, const php_mongo_hash_ops *ops, void *context, const unsigned char *key, const int key_len) {
 	memset(K, 0, ops->block_size);
 	if (key_len > ops->block_size) {
 		/* Reduce the key first */
@@ -65,10 +65,10 @@ static inline void php_hash_hmac_prep_key(unsigned char *K, const php_hash_ops *
 		memcpy(K, key, key_len);
 	}
 	/* XOR the key with 0x36 to get the ipad) */
-	php_hash_string_xor_char(K, K, 0x36, ops->block_size);
+	php_mongo_hash_string_xor_char(K, K, 0x36, ops->block_size);
 }
 
-static inline void php_hash_hmac_round(unsigned char *final, const php_hash_ops *ops, void *context, const unsigned char *key, const unsigned char *data, const long data_size) {
+static inline void php_mongo_hash_hmac_round(unsigned char *final, const php_mongo_hash_ops *ops, void *context, const unsigned char *key, const unsigned char *data, const long data_size) {
 	ops->hash_init(context);
 	ops->hash_update(context, key, ops->block_size);
 	ops->hash_update(context, data, data_size);
@@ -80,19 +80,19 @@ void php_mongo_hmac(unsigned char *data, int data_len, char *key, int key_len, u
 {
 	char *K;
 	void *context;
-	const php_hash_ops *ops = &sha1_hash_ops;
+	const php_mongo_hash_ops *ops = &sha1_hash_ops;
 
 	context = emalloc(ops->context_size);
 
 	K = emalloc(ops->block_size);
 
-	php_hash_hmac_prep_key((unsigned char *) K, ops, context, (unsigned char *) key, key_len);
+	php_mongo_hash_hmac_prep_key((unsigned char *) K, ops, context, (unsigned char *) key, key_len);
 
-	php_hash_hmac_round((unsigned char *) return_value, ops, context, (unsigned char *) K, (unsigned char *) data, data_len);
+	php_mongo_hash_hmac_round((unsigned char *) return_value, ops, context, (unsigned char *) K, (unsigned char *) data, data_len);
 
-	php_hash_string_xor_char((unsigned char *) K, (unsigned char *) K, 0x6A, ops->block_size);
+	php_mongo_hash_string_xor_char((unsigned char *) K, (unsigned char *) K, 0x6A, ops->block_size);
 
-	php_hash_hmac_round((unsigned char *) return_value, ops, context, (unsigned char *) K, (unsigned char *) return_value, ops->digest_size);
+	php_mongo_hash_hmac_round((unsigned char *) return_value, ops, context, (unsigned char *) K, (unsigned char *) return_value, ops->digest_size);
 
 	/* Zero the key */
 	memset(K, 0, ops->block_size);
@@ -118,7 +118,7 @@ int php_mongo_hash_pbkdf2_sha1(char *password, int password_len, unsigned char *
 	long loops, i, j, length = 0, digest_length;
 	zend_bool raw_output = 1;
 	void *context;
-	const php_hash_ops *ops = &sha1_hash_ops;
+	const php_mongo_hash_ops *ops = &sha1_hash_ops;
 
 
 	if (iterations <= 0) {
@@ -140,9 +140,9 @@ int php_mongo_hash_pbkdf2_sha1(char *password, int password_len, unsigned char *
 	temp = emalloc(ops->digest_size);
 
 	/* Setup Keys that will be used for all hmac rounds */
-	php_hash_hmac_prep_key(K1, ops, context, (unsigned char *) password, password_len);
+	php_mongo_hash_hmac_prep_key(K1, ops, context, (unsigned char *) password, password_len);
 	/* Convert K1 to opad -- 0x6A = 0x36 ^ 0x5C */
-	php_hash_string_xor_char(K2, K1, 0x6A, ops->block_size);
+	php_mongo_hash_string_xor_char(K2, K1, 0x6A, ops->block_size);
 
 	/* Setup Main Loop to build a long enough result */
 	if (length == 0) {
@@ -172,8 +172,8 @@ int php_mongo_hash_pbkdf2_sha1(char *password, int password_len, unsigned char *
 		computed_salt[salt_len + 2] = (unsigned char) ((i & 0xFF00) >> 8);
 		computed_salt[salt_len + 3] = (unsigned char) (i & 0xFF);
 
-		php_hash_hmac_round(digest, ops, context, K1, computed_salt, (long) salt_len + 4);
-		php_hash_hmac_round(digest, ops, context, K2, digest, ops->digest_size);
+		php_mongo_hash_hmac_round(digest, ops, context, K1, computed_salt, (long) salt_len + 4);
+		php_mongo_hash_hmac_round(digest, ops, context, K2, digest, ops->digest_size);
 		/* } */
 
 		/* temp = digest */
@@ -185,11 +185,11 @@ int php_mongo_hash_pbkdf2_sha1(char *password, int password_len, unsigned char *
 		 */
 		for (j = 1; j < iterations; j++) {
 			/* digest = hash_hmac(digest, password) { */
-			php_hash_hmac_round(digest, ops, context, K1, digest, ops->digest_size);
-			php_hash_hmac_round(digest, ops, context, K2, digest, ops->digest_size);
+			php_mongo_hash_hmac_round(digest, ops, context, K1, digest, ops->digest_size);
+			php_mongo_hash_hmac_round(digest, ops, context, K2, digest, ops->digest_size);
 			/* } */
 			/* temp ^= digest */
-			php_hash_string_xor(temp, temp, digest, ops->digest_size);
+			php_mongo_hash_string_xor(temp, temp, digest, ops->digest_size);
 		}
 		/* result += temp */
 		memcpy(result + ((i - 1) * ops->digest_size), temp, ops->digest_size);

--- a/contrib/crypto.c
+++ b/contrib/crypto.c
@@ -21,7 +21,7 @@
 #include "crypto.h"
 #include <ext/standard/sha1.h>
 
-int php_hash_copy(const void *ops, void *orig_context, void *dest_context) /* {{{ */
+static int php_hash_copy(const void *ops, void *orig_context, void *dest_context) /* {{{ */
 {
 	php_hash_ops *hash_ops = (php_hash_ops *)ops;
 

--- a/contrib/crypto.h
+++ b/contrib/crypto.h
@@ -23,22 +23,22 @@
 
 #include "php.h"
 
-typedef void (*php_hash_init_func_t)(void *context);
-typedef void (*php_hash_update_func_t)(void *context, const unsigned char *buf, unsigned int count);
-typedef void (*php_hash_final_func_t)(unsigned char *digest, void *context);
-typedef int  (*php_hash_copy_func_t)(const void *ops, void *orig_context, void *dest_context);
+typedef void (*php_mongo_hash_init_func_t)(void *context);
+typedef void (*php_mongo_hash_update_func_t)(void *context, const unsigned char *buf, unsigned int count);
+typedef void (*php_mongo_hash_final_func_t)(unsigned char *digest, void *context);
+typedef int  (*php_mongo_hash_copy_func_t)(const void *ops, void *orig_context, void *dest_context);
 
 
-typedef struct _php_hash_ops {
-	php_hash_init_func_t hash_init;
-	php_hash_update_func_t hash_update;
-	php_hash_final_func_t hash_final;
-	php_hash_copy_func_t hash_copy;
+typedef struct _php_mongo_hash_ops {
+	php_mongo_hash_init_func_t hash_init;
+	php_mongo_hash_update_func_t hash_update;
+	php_mongo_hash_final_func_t hash_final;
+	php_mongo_hash_copy_func_t hash_copy;
 
 	int digest_size;
 	int block_size;
 	int context_size;
-} php_hash_ops;
+} php_mongo_hash_ops;
 
 void php_mongo_sha1(const unsigned char *data, int data_len, unsigned char *return_value);
 void php_mongo_hmac(unsigned char *data, int data_len, char *key, int key_len, unsigned char *return_value, int *return_value_len);


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHP-1462