### PR TITLE
PHPC-512: Disable async stream connections

### DIFF
--- a/php_phongo.c
+++ b/php_phongo.c
@@ -1119,7 +1119,7 @@ mongoc_stream_t* phongo_stream_initiator(const mongoc_uri_t *uri, const mongoc_h
 	spprintf(&uniqid, 0, "%s:%d[%s]", host->host, host->port, mongoc_uri_get_string(uri));
 
 	MONGOC_DEBUG("Connecting to '%s'", uniqid);
-	stream = php_stream_xport_create(dsn, dsn_len, 0, STREAM_XPORT_CLIENT | STREAM_XPORT_CONNECT | STREAM_XPORT_CONNECT_ASYNC, uniqid, timeoutp, (php_stream_context *)user_data, &errmsg, &errcode);
+	stream = php_stream_xport_create(dsn, dsn_len, 0, STREAM_XPORT_CLIENT | STREAM_XPORT_CONNECT, uniqid, timeoutp, (php_stream_context *)user_data, &errmsg, &errcode);
 
 	if (!stream) {
 		bson_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_CONNECT, "Failed connecting to '%s:%d': %s", host->host, host->port, errmsg);


### PR DESCRIPTION
Fixes: #133, #112. See: https://jira.mongodb.org/browse/PHPC-512

When doing async connections we can't properly determine if we should connect over IPv6 or IPv4. PHP will unfortunately default to connecting over IPv6 (when compiled in support, with minor runtime check), while mongod does not support IPv6 by default.

When then creating the IPv6 connection asynchronously, PHP hits EINPROGRESS and will happily return the socket as valid.

There currently is no way to configure these functions to prefer IPv4. The best we can do for now is to not connect asynchronously as then we'll properly discover that the IPv6 socket failed, and then continue through the list of addrinfo and next pickup the IPv4 address which works.