### PR TITLE
Fix PHP 7 / 32bits build

### DIFF
--- a/phongo_compat.h
+++ b/phongo_compat.h
@@ -99,7 +99,8 @@
 		int tmp_len; \
 		mongoc_log(MONGOC_LOG_LEVEL_WARNING, MONGOC_LOG_DOMAIN, "Integer overflow detected on your platform: %lld", value); \
 		tmp_len = spprintf(&tmp, 0, "%lld", value); \
-		add_index_stringl(zval, index, tmp, tmp_len, 0); \
+		ADD_ASSOC_STRINGL(zval, index, tmp, tmp_len); \
+		efree(tmp); \
 	} else { \
 		add_index_long(zval, index, val); \
 	}
@@ -109,7 +110,8 @@
 		int tmp_len; \
 		mongoc_log(MONGOC_LOG_LEVEL_WARNING, MONGOC_LOG_DOMAIN, "Integer overflow detected on your platform: %lld", value); \
 		tmp_len = spprintf(&tmp, 0, "%lld", value); \
-		add_assoc_stringl(zval, key, tmp, tmp_len, 0); \
+		ADD_ASSOC_STRINGL(zval, key, tmp, tmp_len); \
+		efree(tmp); \
 	} else { \
 		add_assoc_long(zval, key, value); \
 	}


### PR DESCRIPTION
     /builddir/build/BUILD/php-pecl-mongodb-1.1.1/NTS/src/bson.c: In function 'php_phongo_bson_visit_int64':
     /builddir/build/BUILD/php-pecl-mongodb-1.1.1/NTS/src/bson.c:508:38: error: macro "add_assoc_stringl" passed 5 arguments, but takes just 4
       ADD_ASSOC_INT64(retval, key, v_int64);

As ADD_ASSOC_STRINGL imply string duplicate, also need  to free the temp (can perhaps be optimized for PHP 5... but more conditional for a race condition...)