### PR TITLE
PHPC-496: Revert "Temporary workaround for warning in mongoc"

### DIFF
--- a/.travis.scripts/compile.sh
+++ b/.travis.scripts/compile.sh
@@ -20,7 +20,7 @@ build_lcov() {
 build_lcov
 
 phpize
-./configure --enable-developer-flags --enable-coverage CFLAGS="-Wno-type-limits"
+./configure --enable-developer-flags --enable-coverage
 make all -j4
 sudo make install
 echo "Use the most-up-to-date run-tests.. old ones like 5.3 don't report failure exit codes"


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-496


This reverts commit 873122fb78a9c7ca7e869090326a8122cd80354a.