### PR TITLE
Fixed PHPC-543: MongoDB\BSON\UTCDateTime on 32 bit platforms parse argument wrong

### DIFF
--- a/src/BSON/UTCDateTime.c
+++ b/src/BSON/UTCDateTime.c
@@ -62,18 +62,19 @@ PHP_METHOD(UTCDateTime, __construct)
 	zend_replace_error_handling(EH_THROW, phongo_exception_from_phongo_domain(PHONGO_ERROR_INVALID_ARGUMENT), &error_handling TSRMLS_CC);
 	intern = Z_UTCDATETIME_OBJ_P(getThis());
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &milliseconds) == FAILURE) {
-		zend_restore_error_handling(&error_handling TSRMLS_CC);
-		return;
-	}
 #if SIZEOF_LONG == 4
-	if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "s", &s_milliseconds, &s_milliseconds_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &s_milliseconds, &s_milliseconds_len) == FAILURE) {
 		zend_restore_error_handling(&error_handling TSRMLS_CC);
 		return;
 	}
 
 	intern->milliseconds = STRTOLL(s_milliseconds);
 #else
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &milliseconds) == FAILURE) {
+		zend_restore_error_handling(&error_handling TSRMLS_CC);
+		return;
+	}
+
 	intern->milliseconds = milliseconds;
 #endif
 

--- a/tests/bson/bson-utcdatetime-int-size.phpt
+++ b/tests/bson/bson-utcdatetime-int-size.phpt
@@ -1,0 +1,45 @@
+--TEST--
+Test for UTCDateTime and integer parsing
+--INI--
+date.timezone=UTC
+error_reporting=-1
+dislay_errors=1
+--FILE--
+<?php
+echo "As number:\n";
+$utcdatetime = new MongoDB\BSON\UTCDateTime(1416445411987);
+var_dump($utcdatetime);
+var_dump($utcdatetime->toDateTime());
+
+echo "As string:\n";
+$utcdatetime = new MongoDB\BSON\UTCDateTime('1416445411987');
+var_dump($utcdatetime);
+var_dump($utcdatetime->toDateTime());
+?>
+--EXPECTF--
+As number:
+object(MongoDB\BSON\UTCDateTime)#%d (1) {
+  ["milliseconds"]=>
+  %r(string\(13\) "|int\()%r1416445411987%r("|\))%r
+}
+object(DateTime)#%d (3) {
+  ["date"]=>
+  string(29) "2014-11-20 01:03:31.987000000"
+  ["timezone_type"]=>
+  int(1)
+  ["timezone"]=>
+  string(6) "+00:00"
+}
+As string:
+object(MongoDB\BSON\UTCDateTime)#%d (1) {
+  ["milliseconds"]=>
+  %r(string\(13\) "|int\()%r1416445411987%r("|\))%r
+}
+object(DateTime)#%d (3) {
+  ["date"]=>
+  string(29) "2014-11-20 01:03:31.987000000"
+  ["timezone_type"]=>
+  int(1)
+  ["timezone"]=>
+  string(6) "+00:00"
+}


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-543