### PR TITLE
PHPC-519: Add missing modifiers to final class methods

### DIFF
--- a/src/BSON/Binary.c
+++ b/src/BSON/Binary.c
@@ -120,9 +120,9 @@ ZEND_END_ARG_INFO();
 
 
 static zend_function_entry php_phongo_binary_me[] = {
-	PHP_ME(Binary, __construct, ai_Binary___construct, ZEND_ACC_PUBLIC)
-	PHP_ME(Binary, getData, ai_Binary_getData, ZEND_ACC_PUBLIC)
-	PHP_ME(Binary, getType, ai_Binary_getType, ZEND_ACC_PUBLIC)
+	PHP_ME(Binary, __construct, ai_Binary___construct, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+	PHP_ME(Binary, getData, ai_Binary_getData, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+	PHP_ME(Binary, getType, ai_Binary_getType, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	PHP_ME(Manager, __wakeUp, NULL, ZEND_ACC_PUBLIC)
 	PHP_FE_END
 };

--- a/src/BSON/ObjectID.c
+++ b/src/BSON/ObjectID.c
@@ -113,8 +113,8 @@ ZEND_END_ARG_INFO();
 
 
 static zend_function_entry php_phongo_objectid_me[] = {
-	PHP_ME(ObjectID, __construct, ai_ObjectID___construct, ZEND_ACC_PUBLIC)
-	PHP_ME(ObjectID, __toString, ai_ObjectID___toString, ZEND_ACC_PUBLIC)
+	PHP_ME(ObjectID, __construct, ai_ObjectID___construct, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+	PHP_ME(ObjectID, __toString, ai_ObjectID___toString, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	PHP_ME(Manager, __wakeUp, NULL, ZEND_ACC_PUBLIC)
 	PHP_FE_END
 };

--- a/src/BSON/Regex.c
+++ b/src/BSON/Regex.c
@@ -149,10 +149,10 @@ ZEND_END_ARG_INFO();
 
 
 static zend_function_entry php_phongo_regex_me[] = {
-	PHP_ME(Regex, __construct, ai_Regex___construct, ZEND_ACC_PUBLIC)
-	PHP_ME(Regex, getPattern, ai_Regex_getPattern, ZEND_ACC_PUBLIC)
-	PHP_ME(Regex, getFlags, ai_Regex_getFlags, ZEND_ACC_PUBLIC)
-	PHP_ME(Regex, __toString, ai_Regex___toString, ZEND_ACC_PUBLIC)
+	PHP_ME(Regex, __construct, ai_Regex___construct, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+	PHP_ME(Regex, getPattern, ai_Regex_getPattern, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+	PHP_ME(Regex, getFlags, ai_Regex_getFlags, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+	PHP_ME(Regex, __toString, ai_Regex___toString, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	PHP_ME(Manager, __wakeUp, NULL, ZEND_ACC_PUBLIC)
 	PHP_FE_END
 };

--- a/src/MongoDB/BulkWrite.c
+++ b/src/MongoDB/BulkWrite.c
@@ -257,11 +257,11 @@ ZEND_END_ARG_INFO();
 
 
 static zend_function_entry php_phongo_bulkwrite_me[] = {
-	PHP_ME(BulkWrite, __construct, ai_BulkWrite___construct, ZEND_ACC_PUBLIC)
-	PHP_ME(BulkWrite, insert, ai_BulkWrite_insert, ZEND_ACC_PUBLIC)
-	PHP_ME(BulkWrite, update, ai_BulkWrite_update, ZEND_ACC_PUBLIC)
-	PHP_ME(BulkWrite, delete, ai_BulkWrite_delete, ZEND_ACC_PUBLIC)
-	PHP_ME(BulkWrite, count, ai_BulkWrite_count, ZEND_ACC_PUBLIC)
+	PHP_ME(BulkWrite, __construct, ai_BulkWrite___construct, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+	PHP_ME(BulkWrite, insert, ai_BulkWrite_insert, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+	PHP_ME(BulkWrite, update, ai_BulkWrite_update, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+	PHP_ME(BulkWrite, delete, ai_BulkWrite_delete, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+	PHP_ME(BulkWrite, count, ai_BulkWrite_count, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	PHP_ME(Manager, __wakeUp, NULL, ZEND_ACC_PUBLIC)
 	PHP_FE_END
 };

--- a/tests/bulk/bulkwrite_error-001.phpt
+++ b/tests/bulk/bulkwrite_error-001.phpt
@@ -1,0 +1,15 @@
+--TEST--
+MongoDB\Driver\BulkWrite cannot be extended
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+class MyBulkWrite extends MongoDB\Driver\BulkWrite {}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+Fatal error: Class MyBulkWrite may not inherit from final class (MongoDB\Driver\BulkWrite) in %s on line %d

--- a/tests/cursor/cursor_error-001.phpt
+++ b/tests/cursor/cursor_error-001.phpt
@@ -1,0 +1,15 @@
+--TEST--
+MongoDB\Driver\Cursor cannot be extended
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+class MyCursor extends MongoDB\Driver\Cursor {}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+Fatal error: Class MyCursor may not inherit from final class (MongoDB\Driver\Cursor) in %s on line %d

--- a/tests/cursorid/cursorid_error-001.phpt
+++ b/tests/cursorid/cursorid_error-001.phpt
@@ -1,0 +1,15 @@
+--TEST--
+MongoDB\Driver\CursorId cannot be extended
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+class MyCursorId extends MongoDB\Driver\CursorId {}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+Fatal error: Class MyCursorId may not inherit from final class (MongoDB\Driver\CursorId) in %s on line %d

--- a/tests/manager/manager_error-001.phpt
+++ b/tests/manager/manager_error-001.phpt
@@ -1,0 +1,15 @@
+--TEST--
+MongoDB\Driver\Query cannot be extended
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+class MyQuery extends MongoDB\Driver\Query {}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+Fatal error: Class MyQuery may not inherit from final class (MongoDB\Driver\Query) in %s on line %d

--- a/tests/query/query_error-001.phpt
+++ b/tests/query/query_error-001.phpt
@@ -1,0 +1,15 @@
+--TEST--
+MongoDB\Driver\Query cannot be extended
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+class MyQuery extends MongoDB\Driver\Query {}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+Fatal error: Class MyQuery may not inherit from final class (MongoDB\Driver\Query) in %s on line %d

--- a/tests/readConcern/readconcern_error-001.phpt
+++ b/tests/readConcern/readconcern_error-001.phpt
@@ -1,0 +1,15 @@
+--TEST--
+MongoDB\Driver\ReadConcern cannot be extended
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+class MyReadConcern extends MongoDB\Driver\ReadConcern {}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+Fatal error: Class MyReadConcern may not inherit from final class (MongoDB\Driver\ReadConcern) in %s on line %d

--- a/tests/readPreference/readpreference_error-001.phpt
+++ b/tests/readPreference/readpreference_error-001.phpt
@@ -1,0 +1,15 @@
+--TEST--
+MongoDB\Driver\ReadPreference cannot be extended
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+class MyReadPreference extends MongoDB\Driver\ReadPreference {}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+Fatal error: Class MyReadPreference may not inherit from final class (MongoDB\Driver\ReadPreference) in %s on line %d

--- a/tests/server/server_error-001.phpt
+++ b/tests/server/server_error-001.phpt
@@ -1,0 +1,15 @@
+--TEST--
+MongoDB\Driver\Server cannot be extended
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+class MyServer extends MongoDB\Driver\Server {}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+Fatal error: Class MyServer may not inherit from final class (MongoDB\Driver\Server) in %s on line %d

--- a/tests/writeConcern/writeconcern_error-001.phpt
+++ b/tests/writeConcern/writeconcern_error-001.phpt
@@ -1,0 +1,15 @@
+--TEST--
+MongoDB\Driver\WriteConcern cannot be extended
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+class MyWriteConcern extends MongoDB\Driver\WriteConcern {}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+Fatal error: Class MyWriteConcern may not inherit from final class (MongoDB\Driver\WriteConcern) in %s on line %d


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-519

This is just being done for consistency. The classes are all already final (specified in their MINIT function). We also add some regression tests for extending these classes.