### PR TITLE
PHPC-581: Use ConnectionTimeoutException for server selection failures

### DIFF
--- a/php_phongo.c
+++ b/php_phongo.c
@@ -121,6 +121,7 @@ zend_class_entry* phongo_exception_from_mongoc_domain(uint32_t /* mongoc_error_d
 		case 50: /* ExceededTimeLimit */
 			return php_phongo_executiontimeoutexception_ce;
 		case MONGOC_ERROR_STREAM_SOCKET:
+		case MONGOC_ERROR_SERVER_SELECTION_FAILURE:
 			return php_phongo_connectiontimeoutexception_ce;
 		case MONGOC_ERROR_CLIENT_AUTHENTICATE:
 			return php_phongo_authenticationexception_ce;

--- a/tests/manager/manager-executeBulkWrite_error-007.phpt
+++ b/tests/manager/manager-executeBulkWrite_error-007.phpt
@@ -14,21 +14,21 @@ $manager = new MongoDB\Driver\Manager('mongodb://invalid.host:27017', ['serverSe
 
 echo throws(function() use ($manager, $bulk) {
     $manager->executeBulkWrite(NS, $bulk);
-}, 'MongoDB\Driver\Exception\RuntimeException'), "\n";
+}, 'MongoDB\Driver\Exception\ConnectionTimeoutException'), "\n";
 
 // Valid host refuses connection
 $manager = new MongoDB\Driver\Manager('mongodb://localhost:54321', ['serverSelectionTimeoutMS' => 1]);
 
 echo throws(function() use ($manager, $bulk) {
     $manager->executeBulkWrite(NS, $bulk);
-}, 'MongoDB\Driver\Exception\RuntimeException'), "\n";
+}, 'MongoDB\Driver\Exception\ConnectionTimeoutException'), "\n";
 
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-OK: Got MongoDB\Driver\Exception\RuntimeException
+OK: Got MongoDB\Driver\Exception\ConnectionTimeoutException
 No suitable servers found (`serverselectiontryonce` set): %s
-OK: Got MongoDB\Driver\Exception\RuntimeException
+OK: Got MongoDB\Driver\Exception\ConnectionTimeoutException
 No suitable servers found (`serverselectiontryonce` set): %s
 ===DONE===

--- a/tests/manager/manager-executeCommand_error-001.phpt
+++ b/tests/manager/manager-executeCommand_error-001.phpt
@@ -13,21 +13,21 @@ $manager = new MongoDB\Driver\Manager('mongodb://invalid.host:27017', ['serverSe
 
 echo throws(function() use ($manager, $command) {
     $manager->executeCommand(DATABASE_NAME, $command);
-}, 'MongoDB\Driver\Exception\RuntimeException'), "\n";
+}, 'MongoDB\Driver\Exception\ConnectionTimeoutException'), "\n";
 
 // Valid host refuses connection
 $manager = new MongoDB\Driver\Manager('mongodb://localhost:54321', ['serverSelectionTimeoutMS' => 1]);
 
 echo throws(function() use ($manager, $command) {
     $manager->executeCommand(DATABASE_NAME, $command);
-}, 'MongoDB\Driver\Exception\RuntimeException'), "\n";
+}, 'MongoDB\Driver\Exception\ConnectionTimeoutException'), "\n";
 
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-OK: Got MongoDB\Driver\Exception\RuntimeException
+OK: Got MongoDB\Driver\Exception\ConnectionTimeoutException
 No suitable servers found (`serverselectiontryonce` set): %s
-OK: Got MongoDB\Driver\Exception\RuntimeException
+OK: Got MongoDB\Driver\Exception\ConnectionTimeoutException
 No suitable servers found (`serverselectiontryonce` set): %s
 ===DONE===

--- a/tests/manager/manager-executeQuery_error-001.phpt
+++ b/tests/manager/manager-executeQuery_error-001.phpt
@@ -13,21 +13,21 @@ $manager = new MongoDB\Driver\Manager('mongodb://invalid.host:27017', ['serverSe
 
 echo throws(function() use ($manager, $query) {
     $manager->executeQuery(NS, $query);
-}, 'MongoDB\Driver\Exception\RuntimeException'), "\n";
+}, 'MongoDB\Driver\Exception\ConnectionTimeoutException'), "\n";
 
 // Valid host refuses connection
 $manager = new MongoDB\Driver\Manager('mongodb://localhost:54321', ['serverSelectionTimeoutMS' => 1]);
 
 echo throws(function() use ($manager, $query) {
     $manager->executeQuery(NS, $query);
-}, 'MongoDB\Driver\Exception\RuntimeException'), "\n";
+}, 'MongoDB\Driver\Exception\ConnectionTimeoutException'), "\n";
 
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-OK: Got MongoDB\Driver\Exception\RuntimeException
+OK: Got MongoDB\Driver\Exception\ConnectionTimeoutException
 No suitable servers found (`serverselectiontryonce` set): %s
-OK: Got MongoDB\Driver\Exception\RuntimeException
+OK: Got MongoDB\Driver\Exception\ConnectionTimeoutException
 No suitable servers found (`serverselectiontryonce` set): %s
 ===DONE===

--- a/tests/manager/manager-selectserver_error-001.phpt
+++ b/tests/manager/manager-selectserver_error-001.phpt
@@ -13,21 +13,21 @@ $manager = new MongoDB\Driver\Manager('mongodb://invalid.host:27017', ['serverSe
 
 echo throws(function() use ($manager, $rp) {
     $manager->selectServer($rp);
-}, 'MongoDB\Driver\Exception\RuntimeException'), "\n";
+}, 'MongoDB\Driver\Exception\ConnectionTimeoutException'), "\n";
 
 // Valid host refuses connection
 $manager = new MongoDB\Driver\Manager('mongodb://localhost:54321', ['serverSelectionTimeoutMS' => 1]);
 
 echo throws(function() use ($manager, $rp) {
     $manager->selectServer($rp);
-}, 'MongoDB\Driver\Exception\RuntimeException'), "\n";
+}, 'MongoDB\Driver\Exception\ConnectionTimeoutException'), "\n";
 
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-OK: Got MongoDB\Driver\Exception\RuntimeException
+OK: Got MongoDB\Driver\Exception\ConnectionTimeoutException
 No suitable servers found (`serverselectiontryonce` set): %s
-OK: Got MongoDB\Driver\Exception\RuntimeException
+OK: Got MongoDB\Driver\Exception\ConnectionTimeoutException
 No suitable servers found (`serverselectiontryonce` set): %s
 ===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-581

Depends on #232, so please limit review to the final commit.