### PR TITLE
PHPC-582: Manager::selectServer() should select exception class based on bson_error_t

### DIFF
--- a/php_phongo.h
+++ b/php_phongo.h
@@ -110,6 +110,7 @@ void phongo_throw_exception(php_phongo_error_domain_t domain TSRMLS_DC, const ch
 # endif
 #endif
 ;
+void phongo_throw_exception_from_bson_error_t(bson_error_t *error TSRMLS_DC);
 
 PHONGO_API zend_object_handlers *phongo_get_std_object_handlers(void);
 

--- a/src/MongoDB/Manager.c
+++ b/src/MongoDB/Manager.c
@@ -289,7 +289,7 @@ PHP_METHOD(Manager, selectServer)
 			return;
 		}
 
-		phongo_throw_exception(PHONGO_ERROR_RUNTIME TSRMLS_CC, "%s", error.message);
+		phongo_throw_exception_from_bson_error_t(&error TSRMLS_CC);
 	}
 }
 /* }}} */


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-582

Depends on #221, so please limit review to the final commit.