### PR TITLE
PHPC-414: Combine 32-bit and 64-bit UTCDateTime debug handler tests

### DIFF
--- a/tests/bson/bson-utcdatetime-002.phpt
+++ b/tests/bson/bson-utcdatetime-002.phpt
@@ -1,7 +1,6 @@
 --TEST--
-BSON BSON\UTCDateTime debug handler (32-bit)
+BSON BSON\UTCDateTime debug handler
 --SKIPIF--
-<?php if (4 !== PHP_INT_SIZE) { die('skip Only for 32-bit platform'); } ?>
 <?php require __DIR__ . "/../utils/basic-skipif.inc"?>
 --FILE--
 <?php
@@ -18,6 +17,6 @@ var_dump($utcdatetime);
 --EXPECTF--
 object(%SBSON\UTCDateTime)#%d (%d) {
   ["milliseconds"]=>
-  string(13) "1416445411987"
+  %rint\(|string\(13\) "|%r1416445411987%r"|\)%r
 }
 ===DONE===

--- a/tests/bson/bson-utcdatetime-003.phpt
+++ b/tests/bson/bson-utcdatetime-003.phpt
@@ -1,5 +1,5 @@
 --TEST--
-BSON BSON\UTCDateTime debug handler (64-bit)
+BSON BSON\UTCDateTime construction from 64-bit integer
 --SKIPIF--
 <?php if (8 !== PHP_INT_SIZE) { die('skip Only for 64-bit platform'); } ?>
 <?php require __DIR__ . "/../utils/basic-skipif.inc"?>


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-414

This removes a SKIPIF from the 32-bit test but leaves the 64-bit test in place, since it tests construction from a 64-bit integer type instead of a string.