### PR TITLE
PHPC-632: Define MONGOC_NO_AUTOMATIC_GLOBALS when bundling libmongoc

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -357,7 +357,7 @@ PHP_ARG_WITH(libmongoc, whether to use system libmongoc,
     PHP_EVAL_LIBLINE($LIBMONGOC_LIB, MONGODB_SHARED_LIBADD)
     AC_DEFINE(HAVE_SYSTEM_LIBMONGOC, 1, [Use system libmongoc])
   else
-    CPPFLAGS="$CPPFLAGS -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE"
+    CPPFLAGS="$CPPFLAGS -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DMONGOC_NO_AUTOMATIC_GLOBALS"
 
     PHP_ADD_SOURCES_X(PHP_EXT_DIR(mongodb)[src/libmongoc/src/mongoc], $MONGOC_SOURCES,      [$STD_CFLAGS], shared_objects_mongodb, yes)
     PHP_ADD_SOURCES_X(PHP_EXT_DIR(mongodb)[src/libmongoc/src/mongoc], $MONGOC_SOURCES_SSL,  [$STD_CFLAGS], shared_objects_mongodb, yes)


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-632

This ensures that libmongoc's automatic destructor is disabled and will avoid segfaults during abrupt FPM shutdowns for static builds. Those using the driver with system libmongoc will need to wait for [CDRIVER-1160](https://jira.mongodb.org/browse/CDRIVER-1160) to be released in order to resolve this issue.

This fixes #209 and #258 (for bundled libmongoc). It may also fix #212, #213, and #215.