### PR TITLE
Fix PHPC-631

### DIFF
--- a/php_phongo.c
+++ b/php_phongo.c
@@ -2029,7 +2029,7 @@ void php_phongo_new_datetime_from_utcdatetime(zval *object, int64_t milliseconds
 	datetime_obj = Z_PHPDATE_P(object);
 	php_date_initialize(datetime_obj, sec, sec_len, NULL, NULL, 0 TSRMLS_CC);
 	efree(sec);
-	datetime_obj->time->f = milliseconds % 1000;
+	datetime_obj->time->f = (double) (milliseconds % 1000) / 1000;
 } /* }}} */
 void php_phongo_new_timestamp_from_increment_and_timestamp(zval *object, uint32_t increment, uint32_t timestamp TSRMLS_DC) /* {{{ */
 {

--- a/tests/bson/bson-utcdatetime-todatetime-002.phpt
+++ b/tests/bson/bson-utcdatetime-todatetime-002.phpt
@@ -1,0 +1,22 @@
+--TEST--
+BSON BSON\UTCDateTime::toDateTime()
+--INI--
+date.timezone=America/Los_Angeles
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+--FILE--
+<?php
+use MongoDB\BSON as BSON;
+
+require_once __DIR__ . "/../utils/basic.inc";
+
+$utcdatetime = new BSON\UTCDateTime("1416445411987");
+$datetime = $utcdatetime->toDateTime();
+var_dump($datetime->format("u"));
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+string(6) "987000"
+===DONE===


### PR DESCRIPTION
Fixed  timelib_time.fraction init int php_phongo_new_datetime_from_utcdatetime 
according to [PHPC-631](https://jira.mongodb.org/browse/PHPC-631)