### PR TITLE
PHPC-667: Fix check for existing "_id" field during BulkWrite::insert()

### DIFF
--- a/src/bson.c
+++ b/src/bson.c
@@ -1232,7 +1232,7 @@ PHONGO_API void phongo_zval_to_bson(zval *data, php_phongo_bson_flags_t flags, b
 				}
 
 				if (flags & PHONGO_BSON_ADD_ID) {
-					if (!strncmp(member ? ZSTR_VAL(member) : ZSTR_VAL(string_key), "_id", sizeof("_id")-1)) {
+					if (!strcmp(member ? ZSTR_VAL(member) : ZSTR_VAL(string_key), "_id")) {
 						flags &= ~PHONGO_BSON_ADD_ID;
 					}
 				}
@@ -1247,7 +1247,7 @@ PHONGO_API void phongo_zval_to_bson(zval *data, php_phongo_bson_flags_t flags, b
 				}
 			} else {
 				if (flags & PHONGO_BSON_ADD_ID) {
-					if (!strncmp(ZSTR_VAL(string_key), "_id", sizeof("_id")-1)) {
+					if (!strcmp(ZSTR_VAL(string_key), "_id")) {
 						flags &= ~PHONGO_BSON_ADD_ID;
 					}
 				}
@@ -1292,7 +1292,7 @@ PHONGO_API void phongo_zval_to_bson(zval *data, php_phongo_bson_flags_t flags, b
 			}
 
 			if (flags & PHONGO_BSON_ADD_ID) {
-				if (!strncmp(string_key, "_id", sizeof("_id")-1)) {
+				if (!strcmp(string_key, "_id")) {
 					flags &= ~PHONGO_BSON_ADD_ID;
 				}
 			}

--- a/tests/bulk/bug0667.phpt
+++ b/tests/bulk/bug0667.phpt
@@ -1,0 +1,25 @@
+--TEST--
+PHPC-667: BulkWrite::insert() does not generate ObjectID if another field has "_id" prefix
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$bulk = new MongoDB\Driver\BulkWrite;
+var_dump($bulk->insert(['_ids' => 1]));
+var_dump($bulk->insert((object) ['_ids' => 1]));
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+object(MongoDB\BSON\ObjectID)#%d (%d) {
+  ["oid"]=>
+  string(24) "%x"
+}
+object(MongoDB\BSON\ObjectID)#%d (%d) {
+  ["oid"]=>
+  string(24) "%x"
+}
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-667 and https://github.com/mongodb/mongo-php-driver/issues/281