### PR TITLE
PHPC-609: Apply RC/RP/WC to mongoc_uri_t instead of mongoc_client_t

### DIFF
--- a/php_phongo.c
+++ b/php_phongo.c
@@ -28,7 +28,6 @@
 #include "bson.h"
 #include "mongoc.h"
 #include "mongoc-cursor-cursorid-private.h"
-#include "mongoc-read-prefs-private.h"
 #include "mongoc-bulk-operation-private.h"
 #include "mongoc-read-concern-private.h"
 #include "mongoc-write-concern-private.h"
@@ -1367,17 +1366,19 @@ void php_phongo_read_concern_to_zval(zval *retval, const mongoc_read_concern_t *
 
 void php_phongo_read_preference_to_zval(zval *retval, const mongoc_read_prefs_t *read_prefs) /* {{{ */
 {
+	const bson_t *tags = mongoc_read_prefs_get_tags(read_prefs);
 
 	array_init_size(retval, 2);
 
-	ADD_ASSOC_LONG_EX(retval, "mode", read_prefs->mode);
-	if (read_prefs->tags.len) {
+	ADD_ASSOC_LONG_EX(retval, "mode", mongoc_read_prefs_get_mode(read_prefs));
+
+	if (tags->len) {
 		php_phongo_bson_state  state = PHONGO_BSON_STATE_INITIALIZER;
 		/* Use native arrays for debugging output */
 		state.map.root_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
 		state.map.document_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
 
-		phongo_bson_to_zval_ex(bson_get_data(&read_prefs->tags), read_prefs->tags.len, &state);
+		phongo_bson_to_zval_ex(bson_get_data(tags), tags->len, &state);
 #if PHP_VERSION_ID >= 70000
 		ADD_ASSOC_ZVAL_EX(retval, "tags", &state.zchild);
 #else

--- a/src/MongoDB/Cursor.c
+++ b/src/MongoDB/Cursor.c
@@ -158,7 +158,7 @@ PHP_METHOD(Cursor, getServer)
 	}
 
 
-	phongo_server_init(return_value, intern->cursor->client, intern->server_id TSRMLS_CC);
+	phongo_server_init(return_value, intern->client, intern->server_id TSRMLS_CC);
 }
 /* }}} */
 

--- a/src/MongoDB/Manager.c
+++ b/src/MongoDB/Manager.c
@@ -48,8 +48,6 @@
 #include "php_phongo.h"
 #include "php_bson.h"
 
-#define PHONGO_MANAGER_URI_DEFAULT "mongodb://localhost:27017/"
-
 PHONGO_API zend_class_entry *php_phongo_manager_ce;
 
 zend_object_handlers php_phongo_handler_manager;

--- a/src/MongoDB/ReadPreference.c
+++ b/src/MongoDB/ReadPreference.c
@@ -27,7 +27,6 @@
 /* External libs */
 #include <bson.h>
 #include <mongoc.h>
-#include <mongoc-read-prefs-private.h>
 
 /* PHP Core stuff */
 #include <php.h>
@@ -117,6 +116,7 @@ PHP_METHOD(ReadPreference, getMode)
 PHP_METHOD(ReadPreference, getTagSets)
 {
 	php_phongo_readpreference_t *intern;
+	const bson_t                *tags;
 	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 	intern = Z_READPREFERENCE_OBJ_P(getThis());
@@ -125,13 +125,15 @@ PHP_METHOD(ReadPreference, getTagSets)
 		return;
 	}
 
-	if (intern->read_preference->tags.len) {
+	tags = mongoc_read_prefs_get_tags(intern->read_preference);
+
+	if (tags->len) {
 		php_phongo_bson_state state = PHONGO_BSON_STATE_INITIALIZER;
 		/* Use native arrays for debugging output */
 		state.map.root_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
 		state.map.document_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
 
-		phongo_bson_to_zval_ex(bson_get_data(&intern->read_preference->tags), intern->read_preference->tags.len, &state);
+		phongo_bson_to_zval_ex(bson_get_data(tags), tags->len, &state);
 #if PHP_VERSION_ID >= 70000
 		RETURN_ZVAL(&state.zchild, 0, 1);
 #else


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-609

This refactors existing code to take advantage of new functions in mongoc_uri_t's public API. There should be no functional changes.