### PR TITLE
PHPC-606: Use mongoc_server_description_t public API in Server methods

### DIFF
--- a/phongo_compat.h
+++ b/phongo_compat.h
@@ -154,6 +154,7 @@
 # define ZEND_HASH_APPLY_COUNT(ht) (ht)->u.v.nApplyCount
 # define PHONGO_RETVAL_STRINGL(s, slen) RETVAL_STRINGL(s, slen)
 # define PHONGO_RETURN_STRINGL(s, slen) RETURN_STRINGL(s, slen)
+# define PHONGO_RETVAL_STRING(s) RETVAL_STRING(s)
 # define PHONGO_RETURN_STRING(s) RETURN_STRING(s)
 #else
 # define phongo_char char
@@ -186,6 +187,7 @@
 # define ZEND_HASH_APPLY_COUNT(ht) (ht)->nApplyCount
 # define PHONGO_RETVAL_STRINGL(s, slen) RETVAL_STRINGL(s, slen, 1)
 # define PHONGO_RETURN_STRINGL(s, slen) RETURN_STRINGL(s, slen, 1)
+# define PHONGO_RETVAL_STRING(s) RETVAL_STRING(s, 1)
 # define PHONGO_RETURN_STRING(s) RETURN_STRING(s, 1)
 # define PHP_STREAM_CONTEXT(stream) ((php_stream_context*) (stream)->context)
 #endif

--- a/php_phongo.c
+++ b/php_phongo.c
@@ -1277,13 +1277,14 @@ void php_phongo_objectid_new_from_oid(zval *object, const bson_oid_t *oid TSRMLS
 
 void php_phongo_server_to_zval(zval *retval, mongoc_server_description_t *sd) /* {{{ */
 {
-	const bson_t *is_master = mongoc_server_description_ismaster(sd);
-	bson_iter_t   iter;
+	mongoc_host_list_t *host = mongoc_server_description_host(sd);
+	const bson_t       *is_master = mongoc_server_description_ismaster(sd);
+	bson_iter_t         iter;
 
 	array_init(retval);
 
-	ADD_ASSOC_STRING(retval, "host", (char *)sd->host.host);
-	ADD_ASSOC_LONG_EX(retval, "port", sd->host.port);
+	ADD_ASSOC_STRING(retval, "host", host->host);
+	ADD_ASSOC_LONG_EX(retval, "port", host->port);
 	ADD_ASSOC_LONG_EX(retval, "type", sd->type);
 	ADD_ASSOC_BOOL_EX(retval, "is_primary", sd->type == MONGOC_SERVER_RS_PRIMARY);
 	ADD_ASSOC_BOOL_EX(retval, "is_secondary", sd->type == MONGOC_SERVER_RS_SECONDARY);

--- a/php_phongo.c
+++ b/php_phongo.c
@@ -1325,7 +1325,7 @@ void php_phongo_server_to_zval(zval *retval, mongoc_server_description_t *sd) /*
 		ADD_ASSOC_ZVAL_EX(retval, "last_is_master", state.zchild);
 #endif
 	}
-	ADD_ASSOC_LONG_EX(retval, "round_trip_time", sd->round_trip_time);
+	ADD_ASSOC_LONG_EX(retval, "round_trip_time", (phongo_long) mongoc_server_description_round_trip_time(sd));
 
 } /* }}} */
 

--- a/php_phongo.h
+++ b/php_phongo.h
@@ -130,7 +130,7 @@ const mongoc_read_prefs_t*    phongo_read_preference_from_zval(zval *zread_prefe
 const mongoc_write_concern_t* phongo_write_concern_from_zval  (zval *zwrite_concern TSRMLS_DC);
 const php_phongo_query_t*     phongo_query_from_zval          (zval *zquery TSRMLS_DC);
 
-void php_phongo_server_to_zval(zval *retval, const mongoc_server_description_t *sd);
+void php_phongo_server_to_zval(zval *retval, mongoc_server_description_t *sd);
 void php_phongo_read_concern_to_zval(zval *retval, const mongoc_read_concern_t *read_concern);
 void php_phongo_read_preference_to_zval(zval *retval, const mongoc_read_prefs_t *read_prefs);
 void php_phongo_write_concern_to_zval(zval *retval, const mongoc_write_concern_t *write_concern);

--- a/php_phongo.h
+++ b/php_phongo.h
@@ -70,6 +70,29 @@ ZEND_END_MODULE_GLOBALS(mongodb)
 
 #include "php_phongo_classes.h"
 
+/* This enum is necessary since mongoc_server_description_type_t is private and
+ * we need to translate strings returned by mongoc_server_description_type() to
+ * Server integer constants. */
+typedef enum {
+	PHONGO_SERVER_UNKNOWN           = 0,
+	PHONGO_SERVER_STANDALONE        = 1,
+	PHONGO_SERVER_MONGOS            = 2,
+	PHONGO_SERVER_POSSIBLE_PRIMARY  = 3,
+	PHONGO_SERVER_RS_PRIMARY        = 4,
+	PHONGO_SERVER_RS_SECONDARY      = 5,
+	PHONGO_SERVER_RS_ARBITER        = 6,
+	PHONGO_SERVER_RS_OTHER          = 7,
+	PHONGO_SERVER_RS_GHOST          = 8,
+	PHONGO_SERVER_DESCRIPTION_TYPES = 9,
+} php_phongo_server_description_type_t;
+
+typedef struct {
+	php_phongo_server_description_type_t  type;
+	const char                           *name;
+} php_phongo_server_description_type_map_t;
+
+extern php_phongo_server_description_type_map_t php_phongo_server_description_type_map[];
+
 typedef enum {
 	PHONGO_ERROR_INVALID_ARGUMENT    = 1,
 	PHONGO_ERROR_RUNTIME             = 2,
@@ -129,6 +152,8 @@ const mongoc_read_concern_t*  phongo_read_concern_from_zval   (zval *zread_conce
 const mongoc_read_prefs_t*    phongo_read_preference_from_zval(zval *zread_preference TSRMLS_DC);
 const mongoc_write_concern_t* phongo_write_concern_from_zval  (zval *zwrite_concern TSRMLS_DC);
 const php_phongo_query_t*     phongo_query_from_zval          (zval *zquery TSRMLS_DC);
+
+php_phongo_server_description_type_t php_phongo_server_description_type(mongoc_server_description_t *sd);
 
 void php_phongo_server_to_zval(zval *retval, mongoc_server_description_t *sd);
 void php_phongo_read_concern_to_zval(zval *retval, const mongoc_read_concern_t *read_concern);

--- a/src/MongoDB/Server.c
+++ b/src/MongoDB/Server.c
@@ -135,9 +135,8 @@ PHP_METHOD(Server, executeBulkWrite)
    Returns the hostname used to connect to this Server */
 PHP_METHOD(Server, getHost)
 {
-	php_phongo_server_t      *intern;
+	php_phongo_server_t         *intern;
 	mongoc_server_description_t *sd;
-	bson_error_t                 error;
 	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 	intern = Z_SERVER_OBJ_P(getThis());
@@ -146,20 +145,21 @@ PHP_METHOD(Server, getHost)
 		return;
 	}
 
-	if ((sd = mongoc_topology_description_server_by_id(&intern->client->topology->description, intern->server_id, &error))) {
-		PHONGO_RETURN_STRING(sd->host.host);
+	if ((sd = mongoc_client_get_server_description(intern->client, intern->server_id))) {
+		PHONGO_RETVAL_STRING(sd->host.host);
+		mongoc_server_description_destroy(sd);
+		return;
 	}
 
-	phongo_throw_exception(PHONGO_ERROR_RUNTIME TSRMLS_CC, "Failed to get server description: %s", error.message);
+	phongo_throw_exception(PHONGO_ERROR_RUNTIME TSRMLS_CC, "Failed to get server description");
 }
 /* }}} */
 /* {{{ proto array Server::getTags()
    Returns the currently configured tags for this node */
 PHP_METHOD(Server, getTags)
 {
-	php_phongo_server_t      *intern;
+	php_phongo_server_t         *intern;
 	mongoc_server_description_t *sd;
-	bson_error_t                 error;
 	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
@@ -170,12 +170,14 @@ PHP_METHOD(Server, getTags)
 	}
 
 
-	if ((sd = mongoc_topology_description_server_by_id(&intern->client->topology->description, intern->server_id, &error))) {
+	if ((sd = mongoc_client_get_server_description(intern->client, intern->server_id))) {
 		php_phongo_bson_state  state = PHONGO_BSON_STATE_INITIALIZER;
 		state.map.root_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
 		state.map.document_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
 
 		phongo_bson_to_zval_ex(bson_get_data(&sd->tags), sd->tags.len, &state);
+		mongoc_server_description_destroy(sd);
+
 #if PHP_VERSION_ID >= 70000
 		RETURN_ZVAL(&state.zchild, 0, 1);
 #else
@@ -183,16 +185,15 @@ PHP_METHOD(Server, getTags)
 #endif
 	}
 
-	phongo_throw_exception(PHONGO_ERROR_RUNTIME TSRMLS_CC, "Failed to get server description: %s", error.message);
+	phongo_throw_exception(PHONGO_ERROR_RUNTIME TSRMLS_CC, "Failed to get server description");
 }
 /* }}} */
 /* {{{ proto array Server::getInfo()
    Returns the last isMaster() result document */
 PHP_METHOD(Server, getInfo)
 {
-	php_phongo_server_t      *intern;
+	php_phongo_server_t         *intern;
 	mongoc_server_description_t *sd;
-	bson_error_t                 error;
 	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
@@ -203,12 +204,13 @@ PHP_METHOD(Server, getInfo)
 	}
 
 
-	if ((sd = mongoc_topology_description_server_by_id(&intern->client->topology->description, intern->server_id, &error))) {
+	if ((sd = mongoc_client_get_server_description(intern->client, intern->server_id))) {
 		php_phongo_bson_state  state = PHONGO_BSON_STATE_INITIALIZER;
 		state.map.root_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
 		state.map.document_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
 
 		phongo_bson_to_zval_ex(bson_get_data(&sd->last_is_master), sd->last_is_master.len, &state);
+		mongoc_server_description_destroy(sd);
 
 #if PHP_VERSION_ID >= 70000
 		RETURN_ZVAL(&state.zchild, 0, 1);
@@ -217,16 +219,15 @@ PHP_METHOD(Server, getInfo)
 #endif
 	}
 
-	phongo_throw_exception(PHONGO_ERROR_RUNTIME TSRMLS_CC, "Failed to get server description: %s", error.message);
+	phongo_throw_exception(PHONGO_ERROR_RUNTIME TSRMLS_CC, "Failed to get server description");
 }
 /* }}} */
 /* {{{ proto integer Server::getLatency()
    Returns the last messured latency */
 PHP_METHOD(Server, getLatency)
 {
-	php_phongo_server_t      *intern;
+	php_phongo_server_t         *intern;
 	mongoc_server_description_t *sd;
-	bson_error_t                 error;
 	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
@@ -236,11 +237,13 @@ PHP_METHOD(Server, getLatency)
 		return;
 	}
 
-	if ((sd = mongoc_topology_description_server_by_id(&intern->client->topology->description, intern->server_id, &error))) {
-		RETURN_LONG(sd->round_trip_time);
+	if ((sd = mongoc_client_get_server_description(intern->client, intern->server_id))) {
+		RETVAL_LONG(sd->round_trip_time);
+		mongoc_server_description_destroy(sd);
+		return;
 	}
 
-	phongo_throw_exception(PHONGO_ERROR_RUNTIME TSRMLS_CC, "Failed to get server description: %s", error.message);
+	phongo_throw_exception(PHONGO_ERROR_RUNTIME TSRMLS_CC, "Failed to get server description");
 }
 /* }}} */
 /* {{{ proto integer Server::getPort()
@@ -249,7 +252,6 @@ PHP_METHOD(Server, getPort)
 {
 	php_phongo_server_t         *intern;
 	mongoc_server_description_t *sd;
-	bson_error_t                 error;
 	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
@@ -259,20 +261,21 @@ PHP_METHOD(Server, getPort)
 		return;
 	}
 
-	if ((sd = mongoc_topology_description_server_by_id(&intern->client->topology->description, intern->server_id, &error))) {
-		RETURN_LONG(sd->host.port);
+	if ((sd = mongoc_client_get_server_description(intern->client, intern->server_id))) {
+		RETVAL_LONG(sd->host.port);
+		mongoc_server_description_destroy(sd);
+		return;
 	}
 
-	phongo_throw_exception(PHONGO_ERROR_RUNTIME TSRMLS_CC, "Failed to get server description: %s", error.message);
+	phongo_throw_exception(PHONGO_ERROR_RUNTIME TSRMLS_CC, "Failed to get server description");
 }
 /* }}} */
 /* {{{ proto integer Server::getType()
    Returns the node type of this Server */
 PHP_METHOD(Server, getType)
 {
-	php_phongo_server_t      *intern;
+	php_phongo_server_t         *intern;
 	mongoc_server_description_t *sd;
-	bson_error_t                 error;
 	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
@@ -282,20 +285,21 @@ PHP_METHOD(Server, getType)
 		return;
 	}
 
-	if ((sd = mongoc_topology_description_server_by_id(&intern->client->topology->description, intern->server_id, &error))) {
-		RETURN_LONG(sd->type);
+	if ((sd = mongoc_client_get_server_description(intern->client, intern->server_id))) {
+		RETVAL_LONG(sd->type);
+		mongoc_server_description_destroy(sd);
+		return;
 	}
 
-	phongo_throw_exception(PHONGO_ERROR_RUNTIME TSRMLS_CC, "Failed to get server description: %s", error.message);
+	phongo_throw_exception(PHONGO_ERROR_RUNTIME TSRMLS_CC, "Failed to get server description");
 }
 /* }}} */
 /* {{{ proto bool Server::isPrimary()
    Checks if this is a special "Primary" member of a RepilcaSet */
 PHP_METHOD(Server, isPrimary)
 {
-	php_phongo_server_t      *intern;
+	php_phongo_server_t         *intern;
 	mongoc_server_description_t *sd;
-	bson_error_t                 error;
 	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
@@ -305,20 +309,21 @@ PHP_METHOD(Server, isPrimary)
 		return;
 	}
 
-	if ((sd = mongoc_topology_description_server_by_id(&intern->client->topology->description, intern->server_id, &error))) {
-		RETURN_BOOL(sd->type == MONGOC_SERVER_RS_PRIMARY);
+	if ((sd = mongoc_client_get_server_description(intern->client, intern->server_id))) {
+		RETVAL_BOOL(sd->type == MONGOC_SERVER_RS_PRIMARY);
+		mongoc_server_description_destroy(sd);
+		return;
 	}
 
-	phongo_throw_exception(PHONGO_ERROR_RUNTIME TSRMLS_CC, "Failed to get server description: %s", error.message);
+	phongo_throw_exception(PHONGO_ERROR_RUNTIME TSRMLS_CC, "Failed to get server description");
 }
 /* }}} */
 /* {{{ proto bool Server::isSecondary()
    Checks if this is a special "Secondary" member of a RepilcaSet */
 PHP_METHOD(Server, isSecondary)
 {
-	php_phongo_server_t      *intern;
+	php_phongo_server_t         *intern;
 	mongoc_server_description_t *sd;
-	bson_error_t                 error;
 	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
@@ -328,20 +333,21 @@ PHP_METHOD(Server, isSecondary)
 		return;
 	}
 
-	if ((sd = mongoc_topology_description_server_by_id(&intern->client->topology->description, intern->server_id, &error))) {
-		RETURN_BOOL(sd->type == MONGOC_SERVER_RS_SECONDARY);
+	if ((sd = mongoc_client_get_server_description(intern->client, intern->server_id))) {
+		RETVAL_BOOL(sd->type == MONGOC_SERVER_RS_SECONDARY);
+		mongoc_server_description_destroy(sd);
+		return;
 	}
 
-	phongo_throw_exception(PHONGO_ERROR_RUNTIME TSRMLS_CC, "Failed to get server description: %s", error.message);
+	phongo_throw_exception(PHONGO_ERROR_RUNTIME TSRMLS_CC, "Failed to get server description");
 }
 /* }}} */
 /* {{{ proto bool Server::isArbiter()
    Checks if this is a special "Arbiter" member of a RepilcaSet */
 PHP_METHOD(Server, isArbiter)
 {
-	php_phongo_server_t      *intern;
+	php_phongo_server_t         *intern;
 	mongoc_server_description_t *sd;
-	bson_error_t                 error;
 	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
@@ -351,20 +357,21 @@ PHP_METHOD(Server, isArbiter)
 		return;
 	}
 
-	if ((sd = mongoc_topology_description_server_by_id(&intern->client->topology->description, intern->server_id, &error))) {
-		RETURN_BOOL(sd->type == MONGOC_SERVER_RS_ARBITER);
+	if ((sd = mongoc_client_get_server_description(intern->client, intern->server_id))) {
+		RETVAL_BOOL(sd->type == MONGOC_SERVER_RS_ARBITER);
+		mongoc_server_description_destroy(sd);
+		return;
 	}
 
-	phongo_throw_exception(PHONGO_ERROR_RUNTIME TSRMLS_CC, "Failed to get server description: %s", error.message);
+	phongo_throw_exception(PHONGO_ERROR_RUNTIME TSRMLS_CC, "Failed to get server description");
 }
 /* }}} */
 /* {{{ proto bool Server::isHidden()
    Checks if this is a special "hidden" member of a RepilcaSet */
 PHP_METHOD(Server, isHidden)
 {
-	php_phongo_server_t      *intern;
+	php_phongo_server_t         *intern;
 	mongoc_server_description_t *sd;
-	bson_error_t                 error;
 	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
@@ -374,13 +381,15 @@ PHP_METHOD(Server, isHidden)
 		return;
 	}
 
-	if ((sd = mongoc_topology_description_server_by_id(&intern->client->topology->description, intern->server_id, &error))) {
+	if ((sd = mongoc_client_get_server_description(intern->client, intern->server_id))) {
 		bson_iter_t iter;
 
-		RETURN_BOOL(bson_iter_init_find_case(&iter, &sd->last_is_master, "hidden") && bson_iter_as_bool(&iter));
+		RETVAL_BOOL(bson_iter_init_find_case(&iter, &sd->last_is_master, "hidden") && bson_iter_as_bool(&iter));
+		mongoc_server_description_destroy(sd);
+		return;
 	}
 
-	phongo_throw_exception(PHONGO_ERROR_RUNTIME TSRMLS_CC, "Failed to get server description: %s", error.message);
+	phongo_throw_exception(PHONGO_ERROR_RUNTIME TSRMLS_CC, "Failed to get server description");
 }
 /* }}} */
 /* {{{ proto bool Server::isPassive()
@@ -389,7 +398,6 @@ PHP_METHOD(Server, isPassive)
 {
 	php_phongo_server_t         *intern;
 	mongoc_server_description_t *sd;
-	bson_error_t                 error;
 	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
@@ -399,13 +407,15 @@ PHP_METHOD(Server, isPassive)
 		return;
 	}
 
-	if ((sd = mongoc_topology_description_server_by_id(&intern->client->topology->description, intern->server_id, &error))) {
+	if ((sd = mongoc_client_get_server_description(intern->client, intern->server_id))) {
 		bson_iter_t iter;
 
-		RETURN_BOOL(bson_iter_init_find_case(&iter, &sd->last_is_master, "passive") && bson_iter_as_bool(&iter));
+		RETVAL_BOOL(bson_iter_init_find_case(&iter, &sd->last_is_master, "passive") && bson_iter_as_bool(&iter));
+		mongoc_server_description_destroy(sd);
+		return;
 	}
 
-	phongo_throw_exception(PHONGO_ERROR_RUNTIME TSRMLS_CC, "Failed to get server description: %s", error.message);
+	phongo_throw_exception(PHONGO_ERROR_RUNTIME TSRMLS_CC, "Failed to get server description");
 }
 /* }}} */
 
@@ -489,30 +499,31 @@ static zend_function_entry php_phongo_server_me[] = {
 /* {{{ Other functions */
 static int php_phongo_server_compare_objects(zval *o1, zval *o2 TSRMLS_DC) /* {{{ */
 {
-    php_phongo_server_t *intern1;
-    php_phongo_server_t *intern2;
-	bson_error_t error1;
-	bson_error_t error2;
+	php_phongo_server_t         *intern1, *intern2;
 	mongoc_server_description_t *sd1, *sd2;
+	int                          retval = 0;
 
-    intern1 = Z_SERVER_OBJ_P(o1);
-    intern2 = Z_SERVER_OBJ_P(o2);
+	intern1 = Z_SERVER_OBJ_P(o1);
+	intern2 = Z_SERVER_OBJ_P(o2);
 
-	sd1 = mongoc_topology_description_server_by_id(&intern1->client->topology->description, intern1->server_id, &error1);
-	sd2 = mongoc_topology_description_server_by_id(&intern2->client->topology->description, intern2->server_id, &error2);
+	sd1 = mongoc_client_get_server_description(intern1->client, intern1->server_id);
+	sd2 = mongoc_client_get_server_description(intern2->client, intern2->server_id);
 
-	if (!sd1 || !sd2) {
-		if (!sd1 && !sd2) {
-			phongo_throw_exception(PHONGO_ERROR_RUNTIME TSRMLS_CC, "Failed to get server descriptions: %s and %s", error1.message, error2.message);
-		} else if (!sd1) {
-			phongo_throw_exception(PHONGO_ERROR_RUNTIME TSRMLS_CC, "Failed to get server description: %s", error1.message);
-		} else {
-			phongo_throw_exception(PHONGO_ERROR_RUNTIME TSRMLS_CC, "Failed to get server description: %s", error2.message);
-		}
-		return 0;
+	if (sd1 && sd2) {
+		retval = strcasecmp(sd1->host.host_and_port, sd2->host.host_and_port);
+	} else {
+		phongo_throw_exception(PHONGO_ERROR_RUNTIME TSRMLS_CC, "Failed to get server description(s)");
 	}
 
-	return strcasecmp(sd1->host.host_and_port, sd2->host.host_and_port);
+	if (sd1) {
+		mongoc_server_description_destroy(sd1);
+	}
+
+	if (sd2) {
+		mongoc_server_description_destroy(sd2);
+	}
+
+	return retval;
 } /* }}} */
 /* }}} */
 /* {{{ php_phongo_server_t object handlers */
@@ -560,18 +571,18 @@ HashTable *php_phongo_server_get_debug_info(zval *object, int *is_temp TSRMLS_DC
 	zval                         retval = zval_used_for_init;
 #endif
 	mongoc_server_description_t *sd;
-	bson_error_t                 error;
 
 	*is_temp = 1;
 	intern = Z_SERVER_OBJ_P(object);
 
 
-	if (!(sd = mongoc_topology_description_server_by_id(&intern->client->topology->description, intern->server_id, &error))) {
-		phongo_throw_exception(PHONGO_ERROR_RUNTIME TSRMLS_CC, "Failed to get server description: %s", error.message);
+	if (!(sd = mongoc_client_get_server_description(intern->client, intern->server_id))) {
+		phongo_throw_exception(PHONGO_ERROR_RUNTIME TSRMLS_CC, "Failed to get server description");
 		return NULL;
 	}
 
 	php_phongo_server_to_zval(&retval, sd);
+	mongoc_server_description_destroy(sd);
 
 	return Z_ARRVAL(retval);
 } /* }}} */

--- a/src/MongoDB/Server.c
+++ b/src/MongoDB/Server.c
@@ -146,7 +146,7 @@ PHP_METHOD(Server, getHost)
 	}
 
 	if ((sd = mongoc_client_get_server_description(intern->client, intern->server_id))) {
-		PHONGO_RETVAL_STRING(sd->host.host);
+		PHONGO_RETVAL_STRING(mongoc_server_description_host(sd)->host);
 		mongoc_server_description_destroy(sd);
 		return;
 	}
@@ -277,7 +277,7 @@ PHP_METHOD(Server, getPort)
 	}
 
 	if ((sd = mongoc_client_get_server_description(intern->client, intern->server_id))) {
-		RETVAL_LONG(sd->host.port);
+		RETVAL_LONG(mongoc_server_description_host(sd)->port);
 		mongoc_server_description_destroy(sd);
 		return;
 	}
@@ -525,7 +525,7 @@ static int php_phongo_server_compare_objects(zval *o1, zval *o2 TSRMLS_DC) /* {{
 	sd2 = mongoc_client_get_server_description(intern2->client, intern2->server_id);
 
 	if (sd1 && sd2) {
-		retval = strcasecmp(sd1->host.host_and_port, sd2->host.host_and_port);
+		retval = strcasecmp(mongoc_server_description_host(sd1)->host_and_port, mongoc_server_description_host(sd2)->host_and_port);
 	} else {
 		phongo_throw_exception(PHONGO_ERROR_RUNTIME TSRMLS_CC, "Failed to get server description(s)");
 	}

--- a/src/MongoDB/Server.c
+++ b/src/MongoDB/Server.c
@@ -301,7 +301,7 @@ PHP_METHOD(Server, getType)
 	}
 
 	if ((sd = mongoc_client_get_server_description(intern->client, intern->server_id))) {
-		RETVAL_LONG(sd->type);
+		RETVAL_LONG(php_phongo_server_description_type(sd));
 		mongoc_server_description_destroy(sd);
 		return;
 	}
@@ -325,7 +325,7 @@ PHP_METHOD(Server, isPrimary)
 	}
 
 	if ((sd = mongoc_client_get_server_description(intern->client, intern->server_id))) {
-		RETVAL_BOOL(sd->type == MONGOC_SERVER_RS_PRIMARY);
+		RETVAL_BOOL(!strcmp(mongoc_server_description_type(sd), php_phongo_server_description_type_map[PHONGO_SERVER_RS_PRIMARY].name));
 		mongoc_server_description_destroy(sd);
 		return;
 	}
@@ -349,7 +349,7 @@ PHP_METHOD(Server, isSecondary)
 	}
 
 	if ((sd = mongoc_client_get_server_description(intern->client, intern->server_id))) {
-		RETVAL_BOOL(sd->type == MONGOC_SERVER_RS_SECONDARY);
+		RETVAL_BOOL(!strcmp(mongoc_server_description_type(sd), php_phongo_server_description_type_map[PHONGO_SERVER_RS_SECONDARY].name));
 		mongoc_server_description_destroy(sd);
 		return;
 	}
@@ -373,7 +373,7 @@ PHP_METHOD(Server, isArbiter)
 	}
 
 	if ((sd = mongoc_client_get_server_description(intern->client, intern->server_id))) {
-		RETVAL_BOOL(sd->type == MONGOC_SERVER_RS_ARBITER);
+		RETVAL_BOOL(!strcmp(mongoc_server_description_type(sd), php_phongo_server_description_type_map[PHONGO_SERVER_RS_ARBITER].name));
 		mongoc_server_description_destroy(sd);
 		return;
 	}
@@ -622,15 +622,15 @@ PHP_MINIT_FUNCTION(Server)
 	php_phongo_handler_server.offset = XtOffsetOf(php_phongo_server_t, std);
 #endif
 
-	zend_declare_class_constant_long(php_phongo_server_ce, ZEND_STRL("TYPE_UNKNOWN"), MONGOC_SERVER_UNKNOWN TSRMLS_CC);
-	zend_declare_class_constant_long(php_phongo_server_ce, ZEND_STRL("TYPE_STANDALONE"), MONGOC_SERVER_STANDALONE TSRMLS_CC);
-	zend_declare_class_constant_long(php_phongo_server_ce, ZEND_STRL("TYPE_MONGOS"), MONGOC_SERVER_MONGOS TSRMLS_CC);
-	zend_declare_class_constant_long(php_phongo_server_ce, ZEND_STRL("TYPE_POSSIBLE_PRIMARY"), MONGOC_SERVER_POSSIBLE_PRIMARY TSRMLS_CC);
-	zend_declare_class_constant_long(php_phongo_server_ce, ZEND_STRL("TYPE_RS_PRIMARY"), MONGOC_SERVER_RS_PRIMARY TSRMLS_CC);
-	zend_declare_class_constant_long(php_phongo_server_ce, ZEND_STRL("TYPE_RS_SECONDARY"), MONGOC_SERVER_RS_SECONDARY TSRMLS_CC);
-	zend_declare_class_constant_long(php_phongo_server_ce, ZEND_STRL("TYPE_RS_ARBITER"), MONGOC_SERVER_RS_ARBITER TSRMLS_CC);
-	zend_declare_class_constant_long(php_phongo_server_ce, ZEND_STRL("TYPE_RS_OTHER"), MONGOC_SERVER_RS_OTHER TSRMLS_CC);
-	zend_declare_class_constant_long(php_phongo_server_ce, ZEND_STRL("TYPE_RS_GHOST"), MONGOC_SERVER_RS_GHOST TSRMLS_CC);
+	zend_declare_class_constant_long(php_phongo_server_ce, ZEND_STRL("TYPE_UNKNOWN"), PHONGO_SERVER_UNKNOWN TSRMLS_CC);
+	zend_declare_class_constant_long(php_phongo_server_ce, ZEND_STRL("TYPE_STANDALONE"), PHONGO_SERVER_STANDALONE TSRMLS_CC);
+	zend_declare_class_constant_long(php_phongo_server_ce, ZEND_STRL("TYPE_MONGOS"), PHONGO_SERVER_MONGOS TSRMLS_CC);
+	zend_declare_class_constant_long(php_phongo_server_ce, ZEND_STRL("TYPE_POSSIBLE_PRIMARY"), PHONGO_SERVER_POSSIBLE_PRIMARY TSRMLS_CC);
+	zend_declare_class_constant_long(php_phongo_server_ce, ZEND_STRL("TYPE_RS_PRIMARY"), PHONGO_SERVER_RS_PRIMARY TSRMLS_CC);
+	zend_declare_class_constant_long(php_phongo_server_ce, ZEND_STRL("TYPE_RS_SECONDARY"), PHONGO_SERVER_RS_SECONDARY TSRMLS_CC);
+	zend_declare_class_constant_long(php_phongo_server_ce, ZEND_STRL("TYPE_RS_ARBITER"), PHONGO_SERVER_RS_ARBITER TSRMLS_CC);
+	zend_declare_class_constant_long(php_phongo_server_ce, ZEND_STRL("TYPE_RS_OTHER"), PHONGO_SERVER_RS_OTHER TSRMLS_CC);
+	zend_declare_class_constant_long(php_phongo_server_ce, ZEND_STRL("TYPE_RS_GHOST"), PHONGO_SERVER_RS_GHOST TSRMLS_CC);
 
 
 	return SUCCESS;

--- a/src/MongoDB/Server.c
+++ b/src/MongoDB/Server.c
@@ -253,7 +253,7 @@ PHP_METHOD(Server, getLatency)
 	}
 
 	if ((sd = mongoc_client_get_server_description(intern->client, intern->server_id))) {
-		RETVAL_LONG(sd->round_trip_time);
+		RETVAL_LONG((phongo_long) mongoc_server_description_round_trip_time(sd));
 		mongoc_server_description_destroy(sd);
 		return;
 	}


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-606

Possible refactoring in the debug handler: serialize "last_is_master" first, and then copy the already-serialized "tags" field. Alternatively, we can decide to remove the duplicate, top-level "tags" field.