### PR TITLE
PHPC-682, PHPC-684: BulkWrite debug handler improvements

### DIFF
--- a/php_phongo.h
+++ b/php_phongo.h
@@ -143,7 +143,7 @@ void                     phongo_readpreference_init  (zval *return_value, const 
 void                     phongo_writeconcern_init    (zval *return_value, const mongoc_write_concern_t *write_concern TSRMLS_DC);
 bool                     phongo_query_init           (php_phongo_query_t *query, bson_t *filter, bson_t *options TSRMLS_DC);
 mongoc_bulk_operation_t* phongo_bulkwrite_init       (zend_bool ordered);
-bool                     phongo_execute_write        (mongoc_client_t *client, const char *namespace, mongoc_bulk_operation_t *bulk, const mongoc_write_concern_t *write_concern, int server_id, zval *return_value, int return_value_used TSRMLS_DC);
+bool                     phongo_execute_write        (mongoc_client_t *client, const char *namespace, php_phongo_bulkwrite_t  *bulk_write, const mongoc_write_concern_t *write_concern, int server_id, zval *return_value, int return_value_used TSRMLS_DC);
 int                      phongo_execute_command      (mongoc_client_t *client, const char *db,        const bson_t *command,           const mongoc_read_prefs_t *read_preference, int server_id, zval *return_value, int return_value_used TSRMLS_DC);
 int                      phongo_execute_query        (mongoc_client_t *client, const char *namespace, const php_phongo_query_t *query, const mongoc_read_prefs_t *read_preference, int server_id, zval *return_value, int return_value_used TSRMLS_DC);
 

--- a/php_phongo_structs-5.h
+++ b/php_phongo_structs-5.h
@@ -89,6 +89,7 @@ typedef struct {
 	mongoc_bulk_operation_t *bulk;
 	size_t                   num_ops;
 	bool                     ordered;
+	int                      bypass;
 	char                    *database;
 	char                    *collection;
 	bool                     executed;

--- a/php_phongo_structs-5.h
+++ b/php_phongo_structs-5.h
@@ -88,6 +88,10 @@ typedef struct {
 	zend_object              std;
 	mongoc_bulk_operation_t *bulk;
 	size_t                   num_ops;
+	bool                     ordered;
+	char                    *database;
+	char                    *collection;
+	bool                     executed;
 } php_phongo_bulkwrite_t;
 
 typedef struct {

--- a/php_phongo_structs-7.h
+++ b/php_phongo_structs-7.h
@@ -87,6 +87,10 @@ typedef struct {
 typedef struct {
 	mongoc_bulk_operation_t *bulk;
 	size_t                   num_ops;
+	bool                     ordered;
+	char                    *database;
+	char                    *collection;
+	bool                     executed;
 	zend_object              std;
 } php_phongo_bulkwrite_t;
 

--- a/php_phongo_structs-7.h
+++ b/php_phongo_structs-7.h
@@ -88,6 +88,7 @@ typedef struct {
 	mongoc_bulk_operation_t *bulk;
 	size_t                   num_ops;
 	bool                     ordered;
+	int                      bypass;
 	char                    *database;
 	char                    *collection;
 	bool                     executed;

--- a/src/MongoDB/Manager.c
+++ b/src/MongoDB/Manager.c
@@ -152,7 +152,7 @@ PHP_METHOD(Manager, executeBulkWrite)
 
 
 	bulk = Z_BULKWRITE_OBJ_P(zbulk);
-	phongo_execute_write(intern->client, namespace, bulk->bulk, phongo_write_concern_from_zval(zwrite_concern TSRMLS_CC), -1, return_value, return_value_used TSRMLS_CC);
+	phongo_execute_write(intern->client, namespace, bulk, phongo_write_concern_from_zval(zwrite_concern TSRMLS_CC), -1, return_value, return_value_used TSRMLS_CC);
 }
 /* }}} */
 

--- a/src/MongoDB/Server.c
+++ b/src/MongoDB/Server.c
@@ -128,7 +128,7 @@ PHP_METHOD(Server, executeBulkWrite)
 
 
 	bulk = Z_BULKWRITE_OBJ_P(zbulk);
-	phongo_execute_write(intern->client, namespace, bulk->bulk, phongo_write_concern_from_zval(zwrite_concern TSRMLS_CC), intern->server_id, return_value, return_value_used TSRMLS_CC);
+	phongo_execute_write(intern->client, namespace, bulk, phongo_write_concern_from_zval(zwrite_concern TSRMLS_CC), intern->server_id, return_value, return_value_used TSRMLS_CC);
 }
 /* }}} */
 /* {{{ proto string Server::getHost()

--- a/tests/bulk/bulkwrite-debug-001.phpt
+++ b/tests/bulk/bulkwrite-debug-001.phpt
@@ -1,39 +1,23 @@
 --TEST--
-MongoDB\Driver\BulkWrite: #001 Variety Bulk
+MongoDB\Driver\BulkWrite debug output before execution
 --SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"; CLEANUP(STANDALONE); ?>
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";
 
-$manager = new MongoDB\Driver\Manager(STANDALONE);
+$tests = [
+    [],
+    ['ordered' => true],
+    ['ordered' => false],
+    ['bypassDocumentValidation' => true],
+    ['bypassDocumentValidation' => false],
+];
 
-$bulk = new MongoDB\Driver\BulkWrite;
-var_dump($bulk);
-
-$bulk->insert(array("my" => "value"));
-$bulk->insert(array("my" => "value", "foo" => "bar"));
-$bulk->insert(array("my" => "value", "foo" => "bar"));
-var_dump($bulk);
-
-$bulk->delete(array("my" => "value", "foo" => "bar"), array("limit" => 1));
-var_dump($bulk);
-
-$bulk->update(array("foo" => "bar"), array('$set' => array("foo" => "baz")), array("limit" => 1, "upsert" => 0));
-
-var_dump($bulk);
-
-$retval = $manager->executeBulkWrite(NS, $bulk);
-
-var_dump($bulk);
-
-printf("Inserted: %d\n", getInsertCount($retval));
-printf("Deleted: %d\n", getDeletedCount($retval));
-printf("Updated: %d\n", getModifiedCount($retval));
-printf("Upserted: %d\n", getUpsertedCount($retval));
-foreach(getWriteErrors($retval) as $error) {
-    printf("WriteErrors: %", $error);
+foreach ($tests as $options) {
+    var_dump(new MongoDB\Driver\BulkWrite($options));
 }
+
 ?>
 ===DONE===
 <?php exit(0); ?>
@@ -76,7 +60,7 @@ object(MongoDB\Driver\BulkWrite)#%d (%d) {
   ["collection"]=>
   NULL
   ["ordered"]=>
-  bool(true)
+  bool(false)
   ["bypassDocumentValidation"]=>
   NULL
   ["executed"]=>
@@ -94,7 +78,7 @@ object(MongoDB\Driver\BulkWrite)#%d (%d) {
   ["ordered"]=>
   bool(true)
   ["bypassDocumentValidation"]=>
-  NULL
+  bool(true)
   ["executed"]=>
   bool(false)
   ["server_id"]=>
@@ -104,22 +88,18 @@ object(MongoDB\Driver\BulkWrite)#%d (%d) {
 }
 object(MongoDB\Driver\BulkWrite)#%d (%d) {
   ["database"]=>
-  string(6) "phongo"
+  NULL
   ["collection"]=>
-  string(15) "bulk_write_0001"
+  NULL
   ["ordered"]=>
   bool(true)
   ["bypassDocumentValidation"]=>
-  NULL
+  bool(false)
   ["executed"]=>
-  bool(true)
+  bool(false)
   ["server_id"]=>
-  int(1)
+  int(0)
   ["write_concern"]=>
   NULL
 }
-Inserted: 3
-Deleted: 1
-Updated: 1
-Upserted: 0
 ===DONE===

--- a/tests/bulk/write-0002.phpt
+++ b/tests/bulk/write-0002.phpt
@@ -41,6 +41,8 @@ object(MongoDB\Driver\BulkWrite)#%d (%d) {
   NULL
   ["ordered"]=>
   bool(true)
+  ["bypassDocumentValidation"]=>
+  NULL
   ["executed"]=>
   bool(false)
   ["server_id"]=>
@@ -55,6 +57,8 @@ object(MongoDB\Driver\BulkWrite)#%d (%d) {
   string(15) "bulk_write_0002"
   ["ordered"]=>
   bool(true)
+  ["bypassDocumentValidation"]=>
+  NULL
   ["executed"]=>
   bool(true)
   ["server_id"]=>


### PR DESCRIPTION
 * https://jira.mongodb.org/browse/PHPC-682
 * https://jira.mongodb.org/browse/PHPC-684

I've grouped these issues into the same PR since PHPC-684 depends on PHPC-682's changes and the combined diff is still concise.

Combined with https://github.com/mongodb/mongo-php-driver/pull/311, this should resolve issues with depending on libmongoc's private API in BulkWrite.