### PR TITLE
PHPC-688: Change Cursor debug handler to use libmongoc public API

### DIFF
--- a/php_phongo.h
+++ b/php_phongo.h
@@ -144,14 +144,13 @@ void                     phongo_writeconcern_init    (zval *return_value, const 
 bool                     phongo_query_init           (php_phongo_query_t *query, bson_t *filter, bson_t *options TSRMLS_DC);
 mongoc_bulk_operation_t* phongo_bulkwrite_init       (zend_bool ordered);
 bool                     phongo_execute_write        (mongoc_client_t *client, const char *namespace, php_phongo_bulkwrite_t  *bulk_write, const mongoc_write_concern_t *write_concern, int server_id, zval *return_value, int return_value_used TSRMLS_DC);
-int                      phongo_execute_command      (mongoc_client_t *client, const char *db,        const bson_t *command,           const mongoc_read_prefs_t *read_preference, int server_id, zval *return_value, int return_value_used TSRMLS_DC);
-int                      phongo_execute_query        (mongoc_client_t *client, const char *namespace, const php_phongo_query_t *query, const mongoc_read_prefs_t *read_preference, int server_id, zval *return_value, int return_value_used TSRMLS_DC);
+int                      phongo_execute_command      (mongoc_client_t *client, const char *db, zval *zcommand, zval *zreadPreference, int server_id, zval *return_value, int return_value_used TSRMLS_DC);
+int                      phongo_execute_query        (mongoc_client_t *client, const char *namespace, zval *zquery, zval *zreadPreference, int server_id, zval *return_value, int return_value_used TSRMLS_DC);
 
 mongoc_stream_t*         phongo_stream_initiator     (const mongoc_uri_t *uri, const mongoc_host_list_t *host, void *user_data, bson_error_t *error);
 const mongoc_read_concern_t*  phongo_read_concern_from_zval   (zval *zread_concern TSRMLS_DC);
 const mongoc_read_prefs_t*    phongo_read_preference_from_zval(zval *zread_preference TSRMLS_DC);
 const mongoc_write_concern_t* phongo_write_concern_from_zval  (zval *zwrite_concern TSRMLS_DC);
-const php_phongo_query_t*     phongo_query_from_zval          (zval *zquery TSRMLS_DC);
 
 php_phongo_server_description_type_t php_phongo_server_description_type(mongoc_server_description_t *sd);
 

--- a/php_phongo_classes.h
+++ b/php_phongo_classes.h
@@ -130,7 +130,6 @@
 typedef struct {
 	zend_object_iterator   intern;
 	php_phongo_cursor_t   *cursor;
-	long                   current;
 } php_phongo_cursor_iterator;
 
 

--- a/php_phongo_structs-5.h
+++ b/php_phongo_structs-5.h
@@ -38,12 +38,18 @@ typedef struct {
 } php_phongo_command_t;
 
 typedef struct {
-	zend_object              std;
-	mongoc_cursor_t         *cursor;
-	mongoc_client_t         *client;
-	int                      server_id;
-	php_phongo_bson_state    visitor_data;
-	int                      got_iterator;
+	zend_object                 std;
+	mongoc_cursor_t            *cursor;
+	mongoc_client_t            *client;
+	int                         server_id;
+	php_phongo_bson_state       visitor_data;
+	int                         got_iterator;
+	long                        current;
+	char                       *database;
+	char                       *collection;
+	zval                       *query;
+	zval                       *command;
+	zval                       *read_preference;
 } php_phongo_cursor_t;
 
 typedef struct {

--- a/php_phongo_structs-7.h
+++ b/php_phongo_structs-7.h
@@ -38,12 +38,18 @@ typedef struct {
 } php_phongo_command_t;
 
 typedef struct {
-	mongoc_cursor_t         *cursor;
-	mongoc_client_t         *client;
-	int                      server_id;
-	php_phongo_bson_state    visitor_data;
-	int                      got_iterator;
-	zend_object              std;
+	mongoc_cursor_t            *cursor;
+	mongoc_client_t            *client;
+	int                         server_id;
+	php_phongo_bson_state       visitor_data;
+	int                         got_iterator;
+	long                        current;
+	char                       *database;
+	char                       *collection;
+	zval                        query;
+	zval                        command;
+	zval                        read_preference;
+	zend_object                 std;
 } php_phongo_cursor_t;
 
 typedef struct {

--- a/src/MongoDB/Manager.c
+++ b/src/MongoDB/Manager.c
@@ -88,10 +88,9 @@ PHP_METHOD(Manager, executeCommand)
 {
 	php_phongo_manager_t     *intern;
 	char                     *db;
-	phongo_zpp_char_len      db_len;
+	phongo_zpp_char_len       db_len;
 	zval                     *command;
 	zval                     *readPreference = NULL;
-	php_phongo_command_t     *cmd;
 	DECLARE_RETURN_VALUE_USED
 	SUPPRESS_UNUSED_WARNING(return_value_ptr)
 
@@ -102,19 +101,17 @@ PHP_METHOD(Manager, executeCommand)
 		return;
 	}
 
-
-	cmd = Z_COMMAND_OBJ_P(command);
-	phongo_execute_command(intern->client, db, cmd->bson, phongo_read_preference_from_zval(readPreference TSRMLS_CC), -1, return_value, return_value_used TSRMLS_CC);
+	phongo_execute_command(intern->client, db, command, readPreference, -1, return_value, return_value_used TSRMLS_CC);
 }
 /* }}} */
-/* {{{ proto MongoDB\Driver\Cursor Manager::executeQuery(string $namespace, MongoDB\Driver\Query $zquery[, MongoDB\Driver\ReadPreference $readPreference = null])
+/* {{{ proto MongoDB\Driver\Cursor Manager::executeQuery(string $namespace, MongoDB\Driver\Query $query[, MongoDB\Driver\ReadPreference $readPreference = null])
    Execute a Query */
 PHP_METHOD(Manager, executeQuery)
 {
 	php_phongo_manager_t     *intern;
 	char                     *namespace;
 	phongo_zpp_char_len       namespace_len;
-	zval                     *zquery;
+	zval                     *query;
 	zval                     *readPreference = NULL;
 	DECLARE_RETURN_VALUE_USED
 	SUPPRESS_UNUSED_WARNING(return_value_ptr)
@@ -122,12 +119,11 @@ PHP_METHOD(Manager, executeQuery)
 
 	intern = Z_MANAGER_OBJ_P(getThis());
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sO|O!", &namespace, &namespace_len, &zquery, php_phongo_query_ce, &readPreference, php_phongo_readpreference_ce) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sO|O!", &namespace, &namespace_len, &query, php_phongo_query_ce, &readPreference, php_phongo_readpreference_ce) == FAILURE) {
 		return;
 	}
 
-
-	phongo_execute_query(intern->client, namespace, phongo_query_from_zval(zquery TSRMLS_CC), phongo_read_preference_from_zval(readPreference TSRMLS_CC), -1, return_value, return_value_used TSRMLS_CC);
+	phongo_execute_query(intern->client, namespace, query, readPreference, -1, return_value, return_value_used TSRMLS_CC);
 }
 /* }}} */
 /* {{{ proto MongoDB\Driver\WriteResult Manager::executeBulkWrite(string $namespace, MongoDB\Driver\BulkWrite $zbulk[, MongoDB\Driver\WriteConcern $writeConcern = null])

--- a/src/MongoDB/Server.c
+++ b/src/MongoDB/Server.c
@@ -67,7 +67,6 @@ PHP_METHOD(Server, executeCommand)
 	phongo_zpp_char_len       db_len;
 	zval                     *command;
 	zval                     *readPreference = NULL;
-	php_phongo_command_t     *cmd;
 	DECLARE_RETURN_VALUE_USED
 	SUPPRESS_UNUSED_WARNING(return_value_ptr)
 
@@ -78,19 +77,17 @@ PHP_METHOD(Server, executeCommand)
 		return;
 	}
 
-
-	cmd = Z_COMMAND_OBJ_P(command);
-	phongo_execute_command(intern->client, db, cmd->bson, phongo_read_preference_from_zval(readPreference TSRMLS_CC), intern->server_id, return_value, return_value_used TSRMLS_CC);
+	phongo_execute_command(intern->client, db, command, readPreference, intern->server_id, return_value, return_value_used TSRMLS_CC);
 }
 /* }}} */
-/* {{{ proto MongoDB\Driver\Cursor Server::executeQuery(string $namespace, MongoDB\Driver\Query $zquery[, MongoDB\Driver\ReadPreference $readPreference = null]))
+/* {{{ proto MongoDB\Driver\Cursor Server::executeQuery(string $namespace, MongoDB\Driver\Query $query[, MongoDB\Driver\ReadPreference $readPreference = null]))
    Executes a Query */
 PHP_METHOD(Server, executeQuery)
 {
 	php_phongo_server_t      *intern;
 	char                     *namespace;
 	phongo_zpp_char_len       namespace_len;
-	zval                     *zquery;
+	zval                     *query;
 	zval                     *readPreference = NULL;
 	DECLARE_RETURN_VALUE_USED
 	SUPPRESS_UNUSED_WARNING(return_value_ptr)
@@ -98,12 +95,11 @@ PHP_METHOD(Server, executeQuery)
 
 	intern = Z_SERVER_OBJ_P(getThis());
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sO|O!", &namespace, &namespace_len, &zquery, php_phongo_query_ce, &readPreference, php_phongo_readpreference_ce) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sO|O!", &namespace, &namespace_len, &query, php_phongo_query_ce, &readPreference, php_phongo_readpreference_ce) == FAILURE) {
 		return;
 	}
 
-
-	phongo_execute_query(intern->client, namespace, phongo_query_from_zval(zquery TSRMLS_CC), phongo_read_preference_from_zval(readPreference TSRMLS_CC), intern->server_id, return_value, return_value_used TSRMLS_CC);
+	phongo_execute_query(intern->client, namespace, query, readPreference, intern->server_id, return_value, return_value_used TSRMLS_CC);
 }
 /* }}} */
 /* {{{ proto MongoDB\Driver\WriteResult Server::executeBulkWrite(string $namespace, MongoDB\Driver\BulkWrite $zbulk[, MongoDB\Driver\WriteConcern $writeConcern = null])

--- a/tests/manager/manager-executeCommand-001.phpt
+++ b/tests/manager/manager-executeCommand-001.phpt
@@ -28,7 +28,7 @@ var_dump($server->getPort());
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-object(MongoDB\Driver\Command)#%d (1) {
+object(MongoDB\Driver\Command)#%d (%d) {
   ["command"]=>
   object(stdClass)#%d (1) {
     ["ping"]=>
@@ -37,62 +37,36 @@ object(MongoDB\Driver\Command)#%d (1) {
 }
 bool(true)
 object(MongoDB\Driver\Cursor)#%d (%d) {
-  ["cursor"]=>
-  array(%d) {
-    ["stamp"]=>
-    int(0)
-    ["is_command"]=>
-    bool(true)
-    ["sent"]=>
-    bool(true)
-    ["done"]=>
-    bool(false)
-    ["end_of_event"]=>
-    bool(false)
-    ["in_exhaust"]=>
-    bool(false)
-    ["has_fields"]=>
-    bool(false)
-    ["query"]=>
-    object(stdClass)#%d (1) {
+  ["database"]=>
+  string(6) "phongo"
+  ["collection"]=>
+  NULL
+  ["query"]=>
+  NULL
+  ["command"]=>
+  object(MongoDB\Driver\Command)#%d (%d) {
+    ["command"]=>
+    object(stdClass)#%d (%d) {
       ["ping"]=>
       int(1)
     }
-    ["fields"]=>
-    object(stdClass)#%d (0) {
-    }
-    ["read_preference"]=>
-    array(2) {
-      ["mode"]=>
-      int(1)
-      ["tags"]=>
-      array(0) {
-      }
-    }
-    ["flags"]=>
-    int(0)
-    ["skip"]=>
-    int(0)
-    ["limit"]=>
-    int(1)
-    ["count"]=>
-    int(1)
-    ["batch_size"]=>
-    int(0)
-    ["ns"]=>
-    string(11) "phongo.$cmd"
-    ["current_doc"]=>
-    object(stdClass)#%d (1) {
-      ["ok"]=>
-      float(1)
-    }
   }
-  ["server_id"]=>
-  int(1)
+  ["readPreference"]=>
+  NULL
+  ["isDead"]=>
+  bool(true)
+  ["currentIndex"]=>
+  int(0)
+  ["currentDocument"]=>
+  NULL
+  ["server"]=>
+  object(MongoDB\Driver\Server)#%d (%d) {
+    %a
+  }
 }
 
 Dumping response document:
-object(stdClass)#%d (1) {
+object(stdClass)#%d (%d) {
   ["ok"]=>
   float(1)
 }

--- a/tests/manager/manager-executeQuery-001.phpt
+++ b/tests/manager/manager-executeQuery-001.phpt
@@ -36,22 +36,12 @@ var_dump(iterator_to_array($qr));
 --EXPECTF--
 bool(true)
 object(MongoDB\Driver\Cursor)#%d (%d) {
-  ["cursor"]=>
-  array(%d) {
-    ["stamp"]=>
-    int(0)
-    ["is_command"]=>
-    bool(false)
-    ["sent"]=>
-    bool(true)
-    ["done"]=>
-    bool(false)
-    ["end_of_event"]=>
-    bool(false)
-    ["in_exhaust"]=>
-    bool(false)
-    ["has_fields"]=>
-    bool(true)
+  ["database"]=>
+  string(6) "phongo"
+  ["collection"]=>
+  string(32) "manager_manager_executeQuery_001"
+  ["query"]=>
+  object(MongoDB\Driver\Query)#%d (%d) {
     ["query"]=>
     object(stdClass)#%d (%d) {
       ["$query"]=>
@@ -60,18 +50,10 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
         int(3)
       }
     }
-    ["fields"]=>
+    ["selector"]=>
     object(stdClass)#%d (%d) {
       ["y"]=>
       int(1)
-    }
-    ["read_preference"]=>
-    array(2) {
-      ["mode"]=>
-      int(1)
-      ["tags"]=>
-      array(0) {
-      }
     }
     ["flags"]=>
     int(0)
@@ -79,22 +61,25 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     int(0)
     ["limit"]=>
     int(0)
-    ["count"]=>
-    int(1)
     ["batch_size"]=>
     int(0)
-    ["ns"]=>
-    string(39) "phongo.manager_manager_executeQuery_001"
-    ["current_doc"]=>
-    object(stdClass)#%d (2) {
-      ["_id"]=>
-      int(2)
-      ["y"]=>
-      int(4)
-    }
+    ["readConcern"]=>
+    NULL
   }
-  ["server_id"]=>
-  int(1)
+  ["command"]=>
+  NULL
+  ["readPreference"]=>
+  NULL
+  ["isDead"]=>
+  bool(true)
+  ["currentIndex"]=>
+  int(0)
+  ["currentDocument"]=>
+  NULL
+  ["server"]=>
+  object(MongoDB\Driver\Server)#%d (%d) {
+    %a
+  }
 }
 bool(true)
 string(%d) "%s"

--- a/tests/manager/manager-executeQuery-002.phpt
+++ b/tests/manager/manager-executeQuery-002.phpt
@@ -35,49 +35,24 @@ var_dump(iterator_to_array($qr));
 --EXPECTF--
 bool(true)
 object(MongoDB\Driver\Cursor)#%d (%d) {
-  ["cursor"]=>
-  array(%d) {
-    ["stamp"]=>
-    int(0)
-    ["is_command"]=>
-    bool(false)
-    ["sent"]=>
-    bool(true)
-    ["done"]=>
-    bool(false)
-    ["end_of_event"]=>
-    bool(false)
-    ["in_exhaust"]=>
-    bool(false)
-    ["has_fields"]=>
-    bool(true)
+  ["database"]=>
+  string(6) "phongo"
+  ["collection"]=>
+  string(32) "manager_manager_executeQuery_002"
+  ["query"]=>
+  object(MongoDB\Driver\Query)#%d (%d) {
     ["query"]=>
     object(stdClass)#%d (%d) {
-      ["find"]=>
-      string(%d) "%s"
-      ["filter"]=>
+      ["$query"]=>
       object(stdClass)#%d (%d) {
         ["x"]=>
         int(3)
       }
-      ["projection"]=>
-      object(stdClass)#%d (%d) {
-        ["y"]=>
-        int(1)
-      }
     }
-    ["fields"]=>
+    ["selector"]=>
     object(stdClass)#%d (%d) {
       ["y"]=>
       int(1)
-    }
-    ["read_preference"]=>
-    array(2) {
-      ["mode"]=>
-      int(1)
-      ["tags"]=>
-      array(0) {
-      }
     }
     ["flags"]=>
     int(0)
@@ -85,22 +60,25 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     int(0)
     ["limit"]=>
     int(0)
-    ["count"]=>
-    int(1)
     ["batch_size"]=>
     int(0)
-    ["ns"]=>
-    string(39) "phongo.manager_manager_executeQuery_002"
-    ["current_doc"]=>
-    object(stdClass)#%d (2) {
-      ["_id"]=>
-      int(2)
-      ["y"]=>
-      int(4)
-    }
+    ["readConcern"]=>
+    NULL
   }
-  ["server_id"]=>
-  int(1)
+  ["command"]=>
+  NULL
+  ["readPreference"]=>
+  NULL
+  ["isDead"]=>
+  bool(true)
+  ["currentIndex"]=>
+  int(0)
+  ["currentDocument"]=>
+  NULL
+  ["server"]=>
+  object(MongoDB\Driver\Server)#%d (%d) {
+    %a
+  }
 }
 bool(true)
 string(%d) "%s"

--- a/tests/readPreference/bug0146-001.phpt
+++ b/tests/readPreference/bug0146-001.phpt
@@ -31,22 +31,12 @@ foreach($rps as $r) {
 <?php exit(0); ?>
 --EXPECTF--
 object(MongoDB\Driver\Cursor)#%d (%d) {
-  ["cursor"]=>
-  array(%d) {
-    ["stamp"]=>
-    int(0)
-    ["is_command"]=>
-    bool(false)
-    ["sent"]=>
-    bool(true)
-    ["done"]=>
-    bool(true)
-    ["end_of_event"]=>
-    bool(true)
-    ["in_exhaust"]=>
-    bool(false)
-    ["has_fields"]=>
-    bool(false)
+  ["database"]=>
+  string(6) "phongo"
+  ["collection"]=>
+  string(26) "readPreference_bug0146_001"
+  ["query"]=>
+  object(MongoDB\Driver\Query)#%d (%d) {
     ["query"]=>
     object(stdClass)#%d (%d) {
       ["$query"]=>
@@ -55,50 +45,47 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
         string(5) "query"
       }
     }
-    ["fields"]=>
-    object(stdClass)#%d (0) {
-    }
-    ["read_preference"]=>
-    array(2) {
-      ["mode"]=>
-      int(1)
-      ["tags"]=>
-      array(0) {
-      }
-    }
+    ["selector"]=>
+    NULL
     ["flags"]=>
     int(0)
     ["skip"]=>
     int(0)
     ["limit"]=>
     int(0)
-    ["count"]=>
-    int(1)
     ["batch_size"]=>
     int(0)
-    ["ns"]=>
-    string(%d) "%s"
+    ["readConcern"]=>
+    NULL
   }
-  ["server_id"]=>
-  int(1)
+  ["command"]=>
+  NULL
+  ["readPreference"]=>
+  object(MongoDB\Driver\ReadPreference)#%d (%d) {
+    ["mode"]=>
+    int(1)
+    ["tags"]=>
+    array(0) {
+    }
+  }
+  ["isDead"]=>
+  bool(true)
+  ["currentIndex"]=>
+  int(0)
+  ["currentDocument"]=>
+  NULL
+  ["server"]=>
+  object(MongoDB\Driver\Server)#%d (%d) {
+    %a
+  }
 }
 object(MongoDB\Driver\Cursor)#%d (%d) {
-  ["cursor"]=>
-  array(%d) {
-    ["stamp"]=>
-    int(0)
-    ["is_command"]=>
-    bool(false)
-    ["sent"]=>
-    bool(true)
-    ["done"]=>
-    bool(true)
-    ["end_of_event"]=>
-    bool(true)
-    ["in_exhaust"]=>
-    bool(false)
-    ["has_fields"]=>
-    bool(false)
+  ["database"]=>
+  string(6) "phongo"
+  ["collection"]=>
+  string(26) "readPreference_bug0146_001"
+  ["query"]=>
+  object(MongoDB\Driver\Query)#%d (%d) {
     ["query"]=>
     object(stdClass)#%d (%d) {
       ["$query"]=>
@@ -107,50 +94,47 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
         string(5) "query"
       }
     }
-    ["fields"]=>
-    object(stdClass)#%d (0) {
-    }
-    ["read_preference"]=>
-    array(2) {
-      ["mode"]=>
-      int(5)
-      ["tags"]=>
-      array(0) {
-      }
-    }
+    ["selector"]=>
+    NULL
     ["flags"]=>
     int(0)
     ["skip"]=>
     int(0)
     ["limit"]=>
     int(0)
-    ["count"]=>
-    int(1)
     ["batch_size"]=>
     int(0)
-    ["ns"]=>
-    string(%d) "%s"
+    ["readConcern"]=>
+    NULL
   }
-  ["server_id"]=>
-  int(1)
+  ["command"]=>
+  NULL
+  ["readPreference"]=>
+  object(MongoDB\Driver\ReadPreference)#%d (%d) {
+    ["mode"]=>
+    int(5)
+    ["tags"]=>
+    array(0) {
+    }
+  }
+  ["isDead"]=>
+  bool(true)
+  ["currentIndex"]=>
+  int(0)
+  ["currentDocument"]=>
+  NULL
+  ["server"]=>
+  object(MongoDB\Driver\Server)#%d (%d) {
+    %a
+  }
 }
 object(MongoDB\Driver\Cursor)#%d (%d) {
-  ["cursor"]=>
-  array(%d) {
-    ["stamp"]=>
-    int(0)
-    ["is_command"]=>
-    bool(false)
-    ["sent"]=>
-    bool(true)
-    ["done"]=>
-    bool(true)
-    ["end_of_event"]=>
-    bool(true)
-    ["in_exhaust"]=>
-    bool(false)
-    ["has_fields"]=>
-    bool(false)
+  ["database"]=>
+  string(6) "phongo"
+  ["collection"]=>
+  string(26) "readPreference_bug0146_001"
+  ["query"]=>
+  object(MongoDB\Driver\Query)#%d (%d) {
     ["query"]=>
     object(stdClass)#%d (%d) {
       ["$query"]=>
@@ -159,50 +143,47 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
         string(5) "query"
       }
     }
-    ["fields"]=>
-    object(stdClass)#%d (0) {
-    }
-    ["read_preference"]=>
-    array(2) {
-      ["mode"]=>
-      int(2)
-      ["tags"]=>
-      array(0) {
-      }
-    }
+    ["selector"]=>
+    NULL
     ["flags"]=>
     int(0)
     ["skip"]=>
     int(0)
     ["limit"]=>
     int(0)
-    ["count"]=>
-    int(1)
     ["batch_size"]=>
     int(0)
-    ["ns"]=>
-    string(%d) "%s"
+    ["readConcern"]=>
+    NULL
   }
-  ["server_id"]=>
-  int(1)
+  ["command"]=>
+  NULL
+  ["readPreference"]=>
+  object(MongoDB\Driver\ReadPreference)#%d (%d) {
+    ["mode"]=>
+    int(2)
+    ["tags"]=>
+    array(0) {
+    }
+  }
+  ["isDead"]=>
+  bool(true)
+  ["currentIndex"]=>
+  int(0)
+  ["currentDocument"]=>
+  NULL
+  ["server"]=>
+  object(MongoDB\Driver\Server)#%d (%d) {
+    %a
+  }
 }
 object(MongoDB\Driver\Cursor)#%d (%d) {
-  ["cursor"]=>
-  array(%d) {
-    ["stamp"]=>
-    int(0)
-    ["is_command"]=>
-    bool(false)
-    ["sent"]=>
-    bool(true)
-    ["done"]=>
-    bool(true)
-    ["end_of_event"]=>
-    bool(true)
-    ["in_exhaust"]=>
-    bool(false)
-    ["has_fields"]=>
-    bool(false)
+  ["database"]=>
+  string(6) "phongo"
+  ["collection"]=>
+  string(26) "readPreference_bug0146_001"
+  ["query"]=>
+  object(MongoDB\Driver\Query)#%d (%d) {
     ["query"]=>
     object(stdClass)#%d (%d) {
       ["$query"]=>
@@ -211,50 +192,47 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
         string(5) "query"
       }
     }
-    ["fields"]=>
-    object(stdClass)#%d (0) {
-    }
-    ["read_preference"]=>
-    array(2) {
-      ["mode"]=>
-      int(6)
-      ["tags"]=>
-      array(0) {
-      }
-    }
+    ["selector"]=>
+    NULL
     ["flags"]=>
     int(0)
     ["skip"]=>
     int(0)
     ["limit"]=>
     int(0)
-    ["count"]=>
-    int(1)
     ["batch_size"]=>
     int(0)
-    ["ns"]=>
-    string(%d) "%s"
+    ["readConcern"]=>
+    NULL
   }
-  ["server_id"]=>
-  int(1)
+  ["command"]=>
+  NULL
+  ["readPreference"]=>
+  object(MongoDB\Driver\ReadPreference)#%d (%d) {
+    ["mode"]=>
+    int(6)
+    ["tags"]=>
+    array(0) {
+    }
+  }
+  ["isDead"]=>
+  bool(true)
+  ["currentIndex"]=>
+  int(0)
+  ["currentDocument"]=>
+  NULL
+  ["server"]=>
+  object(MongoDB\Driver\Server)#%d (%d) {
+    %a
+  }
 }
 object(MongoDB\Driver\Cursor)#%d (%d) {
-  ["cursor"]=>
-  array(%d) {
-    ["stamp"]=>
-    int(0)
-    ["is_command"]=>
-    bool(false)
-    ["sent"]=>
-    bool(true)
-    ["done"]=>
-    bool(true)
-    ["end_of_event"]=>
-    bool(true)
-    ["in_exhaust"]=>
-    bool(false)
-    ["has_fields"]=>
-    bool(false)
+  ["database"]=>
+  string(6) "phongo"
+  ["collection"]=>
+  string(26) "readPreference_bug0146_001"
+  ["query"]=>
+  object(MongoDB\Driver\Query)#%d (%d) {
     ["query"]=>
     object(stdClass)#%d (%d) {
       ["$query"]=>
@@ -263,31 +241,38 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
         string(5) "query"
       }
     }
-    ["fields"]=>
-    object(stdClass)#%d (0) {
-    }
-    ["read_preference"]=>
-    array(2) {
-      ["mode"]=>
-      int(10)
-      ["tags"]=>
-      array(0) {
-      }
-    }
+    ["selector"]=>
+    NULL
     ["flags"]=>
     int(0)
     ["skip"]=>
     int(0)
     ["limit"]=>
     int(0)
-    ["count"]=>
-    int(1)
     ["batch_size"]=>
     int(0)
-    ["ns"]=>
-    string(%d) "%s"
+    ["readConcern"]=>
+    NULL
   }
-  ["server_id"]=>
-  int(1)
+  ["command"]=>
+  NULL
+  ["readPreference"]=>
+  object(MongoDB\Driver\ReadPreference)#%d (%d) {
+    ["mode"]=>
+    int(10)
+    ["tags"]=>
+    array(0) {
+    }
+  }
+  ["isDead"]=>
+  bool(true)
+  ["currentIndex"]=>
+  int(0)
+  ["currentDocument"]=>
+  NULL
+  ["server"]=>
+  object(MongoDB\Driver\Server)#%d (%d) {
+    %a
+  }
 }
 ===DONE===

--- a/tests/readPreference/bug0146-002.phpt
+++ b/tests/readPreference/bug0146-002.phpt
@@ -31,273 +31,248 @@ foreach($rps as $r) {
 <?php exit(0); ?>
 --EXPECTF--
 object(MongoDB\Driver\Cursor)#%d (%d) {
-  ["cursor"]=>
-  array(%d) {
-    ["stamp"]=>
-    int(0)
-    ["is_command"]=>
-    bool(false)
-    ["sent"]=>
-    bool(true)
-    ["done"]=>
-    bool(false)
-    ["end_of_event"]=>
-    bool(false)
-    ["in_exhaust"]=>
-    bool(false)
-    ["has_fields"]=>
-    bool(false)
+  ["database"]=>
+  string(6) "phongo"
+  ["collection"]=>
+  string(26) "readPreference_bug0146_002"
+  ["query"]=>
+  object(MongoDB\Driver\Query)#%d (%d) {
     ["query"]=>
     object(stdClass)#%d (%d) {
-      ["find"]=>
-      string(%d) "%s"
-      ["filter"]=>
+      ["$query"]=>
       object(stdClass)#%d (%d) {
         ["my"]=>
         string(5) "query"
       }
     }
-    ["fields"]=>
-    object(stdClass)#%d (0) {
-    }
-    ["read_preference"]=>
-    array(2) {
-      ["mode"]=>
-      int(1)
-      ["tags"]=>
-      array(0) {
-      }
-    }
+    ["selector"]=>
+    NULL
     ["flags"]=>
     int(0)
     ["skip"]=>
     int(0)
     ["limit"]=>
     int(0)
-    ["count"]=>
-    int(1)
     ["batch_size"]=>
     int(0)
-    ["ns"]=>
-    string(%d) "%s"
+    ["readConcern"]=>
+    NULL
   }
-  ["server_id"]=>
-  int(1)
+  ["command"]=>
+  NULL
+  ["readPreference"]=>
+  object(MongoDB\Driver\ReadPreference)#%d (%d) {
+    ["mode"]=>
+    int(1)
+    ["tags"]=>
+    array(0) {
+    }
+  }
+  ["isDead"]=>
+  bool(true)
+  ["currentIndex"]=>
+  int(0)
+  ["currentDocument"]=>
+  NULL
+  ["server"]=>
+  object(MongoDB\Driver\Server)#%d (%d) {
+    %a
+  }
 }
 object(MongoDB\Driver\Cursor)#%d (%d) {
-  ["cursor"]=>
-  array(%d) {
-    ["stamp"]=>
-    int(0)
-    ["is_command"]=>
-    bool(false)
-    ["sent"]=>
-    bool(true)
-    ["done"]=>
-    bool(false)
-    ["end_of_event"]=>
-    bool(false)
-    ["in_exhaust"]=>
-    bool(false)
-    ["has_fields"]=>
-    bool(false)
+  ["database"]=>
+  string(6) "phongo"
+  ["collection"]=>
+  string(26) "readPreference_bug0146_002"
+  ["query"]=>
+  object(MongoDB\Driver\Query)#%d (%d) {
     ["query"]=>
     object(stdClass)#%d (%d) {
-      ["find"]=>
-      string(%d) "%s"
-      ["filter"]=>
+      ["$query"]=>
       object(stdClass)#%d (%d) {
         ["my"]=>
         string(5) "query"
       }
     }
-    ["fields"]=>
-    object(stdClass)#%d (0) {
-    }
-    ["read_preference"]=>
-    array(2) {
-      ["mode"]=>
-      int(5)
-      ["tags"]=>
-      array(0) {
-      }
-    }
+    ["selector"]=>
+    NULL
     ["flags"]=>
     int(0)
     ["skip"]=>
     int(0)
     ["limit"]=>
     int(0)
-    ["count"]=>
-    int(1)
     ["batch_size"]=>
     int(0)
-    ["ns"]=>
-    string(%d) "%s"
+    ["readConcern"]=>
+    NULL
   }
-  ["server_id"]=>
-  int(1)
+  ["command"]=>
+  NULL
+  ["readPreference"]=>
+  object(MongoDB\Driver\ReadPreference)#%d (%d) {
+    ["mode"]=>
+    int(5)
+    ["tags"]=>
+    array(0) {
+    }
+  }
+  ["isDead"]=>
+  bool(true)
+  ["currentIndex"]=>
+  int(0)
+  ["currentDocument"]=>
+  NULL
+  ["server"]=>
+  object(MongoDB\Driver\Server)#%d (%d) {
+    %a
+  }
 }
 object(MongoDB\Driver\Cursor)#%d (%d) {
-  ["cursor"]=>
-  array(%d) {
-    ["stamp"]=>
-    int(0)
-    ["is_command"]=>
-    bool(false)
-    ["sent"]=>
-    bool(true)
-    ["done"]=>
-    bool(false)
-    ["end_of_event"]=>
-    bool(false)
-    ["in_exhaust"]=>
-    bool(false)
-    ["has_fields"]=>
-    bool(false)
+  ["database"]=>
+  string(6) "phongo"
+  ["collection"]=>
+  string(26) "readPreference_bug0146_002"
+  ["query"]=>
+  object(MongoDB\Driver\Query)#%d (%d) {
     ["query"]=>
     object(stdClass)#%d (%d) {
-      ["find"]=>
-      string(%d) "%s"
-      ["filter"]=>
+      ["$query"]=>
       object(stdClass)#%d (%d) {
         ["my"]=>
         string(5) "query"
       }
     }
-    ["fields"]=>
-    object(stdClass)#%d (0) {
-    }
-    ["read_preference"]=>
-    array(2) {
-      ["mode"]=>
-      int(2)
-      ["tags"]=>
-      array(0) {
-      }
-    }
+    ["selector"]=>
+    NULL
     ["flags"]=>
     int(0)
     ["skip"]=>
     int(0)
     ["limit"]=>
     int(0)
-    ["count"]=>
-    int(1)
     ["batch_size"]=>
     int(0)
-    ["ns"]=>
-    string(%d) "%s"
+    ["readConcern"]=>
+    NULL
   }
-  ["server_id"]=>
-  int(1)
+  ["command"]=>
+  NULL
+  ["readPreference"]=>
+  object(MongoDB\Driver\ReadPreference)#%d (%d) {
+    ["mode"]=>
+    int(2)
+    ["tags"]=>
+    array(0) {
+    }
+  }
+  ["isDead"]=>
+  bool(true)
+  ["currentIndex"]=>
+  int(0)
+  ["currentDocument"]=>
+  NULL
+  ["server"]=>
+  object(MongoDB\Driver\Server)#%d (%d) {
+    %a
+  }
 }
 object(MongoDB\Driver\Cursor)#%d (%d) {
-  ["cursor"]=>
-  array(%d) {
-    ["stamp"]=>
-    int(0)
-    ["is_command"]=>
-    bool(false)
-    ["sent"]=>
-    bool(true)
-    ["done"]=>
-    bool(false)
-    ["end_of_event"]=>
-    bool(false)
-    ["in_exhaust"]=>
-    bool(false)
-    ["has_fields"]=>
-    bool(false)
+  ["database"]=>
+  string(6) "phongo"
+  ["collection"]=>
+  string(26) "readPreference_bug0146_002"
+  ["query"]=>
+  object(MongoDB\Driver\Query)#%d (%d) {
     ["query"]=>
     object(stdClass)#%d (%d) {
-      ["find"]=>
-      string(%d) "%s"
-      ["filter"]=>
+      ["$query"]=>
       object(stdClass)#%d (%d) {
         ["my"]=>
         string(5) "query"
       }
     }
-    ["fields"]=>
-    object(stdClass)#%d (0) {
-    }
-    ["read_preference"]=>
-    array(2) {
-      ["mode"]=>
-      int(6)
-      ["tags"]=>
-      array(0) {
-      }
-    }
+    ["selector"]=>
+    NULL
     ["flags"]=>
     int(0)
     ["skip"]=>
     int(0)
     ["limit"]=>
     int(0)
-    ["count"]=>
-    int(1)
     ["batch_size"]=>
     int(0)
-    ["ns"]=>
-    string(%d) "%s"
+    ["readConcern"]=>
+    NULL
   }
-  ["server_id"]=>
-  int(1)
+  ["command"]=>
+  NULL
+  ["readPreference"]=>
+  object(MongoDB\Driver\ReadPreference)#%d (%d) {
+    ["mode"]=>
+    int(6)
+    ["tags"]=>
+    array(0) {
+    }
+  }
+  ["isDead"]=>
+  bool(true)
+  ["currentIndex"]=>
+  int(0)
+  ["currentDocument"]=>
+  NULL
+  ["server"]=>
+  object(MongoDB\Driver\Server)#%d (%d) {
+    %a
+  }
 }
 object(MongoDB\Driver\Cursor)#%d (%d) {
-  ["cursor"]=>
-  array(%d) {
-    ["stamp"]=>
-    int(0)
-    ["is_command"]=>
-    bool(false)
-    ["sent"]=>
-    bool(true)
-    ["done"]=>
-    bool(false)
-    ["end_of_event"]=>
-    bool(false)
-    ["in_exhaust"]=>
-    bool(false)
-    ["has_fields"]=>
-    bool(false)
+  ["database"]=>
+  string(6) "phongo"
+  ["collection"]=>
+  string(26) "readPreference_bug0146_002"
+  ["query"]=>
+  object(MongoDB\Driver\Query)#%d (%d) {
     ["query"]=>
     object(stdClass)#%d (%d) {
-      ["find"]=>
-      string(%d) "%s"
-      ["filter"]=>
+      ["$query"]=>
       object(stdClass)#%d (%d) {
         ["my"]=>
         string(5) "query"
       }
     }
-    ["fields"]=>
-    object(stdClass)#%d (0) {
-    }
-    ["read_preference"]=>
-    array(2) {
-      ["mode"]=>
-      int(10)
-      ["tags"]=>
-      array(0) {
-      }
-    }
+    ["selector"]=>
+    NULL
     ["flags"]=>
     int(0)
     ["skip"]=>
     int(0)
     ["limit"]=>
     int(0)
-    ["count"]=>
-    int(1)
     ["batch_size"]=>
     int(0)
-    ["ns"]=>
-    string(%d) "%s"
+    ["readConcern"]=>
+    NULL
   }
-  ["server_id"]=>
-  int(1)
+  ["command"]=>
+  NULL
+  ["readPreference"]=>
+  object(MongoDB\Driver\ReadPreference)#%d (%d) {
+    ["mode"]=>
+    int(10)
+    ["tags"]=>
+    array(0) {
+    }
+  }
+  ["isDead"]=>
+  bool(true)
+  ["currentIndex"]=>
+  int(0)
+  ["currentDocument"]=>
+  NULL
+  ["server"]=>
+  object(MongoDB\Driver\Server)#%d (%d) {
+    %a
+  }
 }
 ===DONE===

--- a/tests/server/server-executeCommand-001.phpt
+++ b/tests/server/server-executeCommand-001.phpt
@@ -26,58 +26,32 @@ var_dump($server == $result->getServer());
 --EXPECTF--
 bool(true)
 object(MongoDB\Driver\Cursor)#%d (%d) {
-  ["cursor"]=>
-  array(%d) {
-    ["stamp"]=>
-    int(0)
-    ["is_command"]=>
-    bool(true)
-    ["sent"]=>
-    bool(true)
-    ["done"]=>
-    bool(false)
-    ["end_of_event"]=>
-    bool(false)
-    ["in_exhaust"]=>
-    bool(false)
-    ["has_fields"]=>
-    bool(false)
-    ["query"]=>
-    object(stdClass)#%d (1) {
+  ["database"]=>
+  string(6) "phongo"
+  ["collection"]=>
+  NULL
+  ["query"]=>
+  NULL
+  ["command"]=>
+  object(MongoDB\Driver\Command)#%d (%d) {
+    ["command"]=>
+    object(stdClass)#%d (%d) {
       ["ping"]=>
       int(1)
     }
-    ["fields"]=>
-    object(stdClass)#%d (0) {
-    }
-    ["read_preference"]=>
-    array(2) {
-      ["mode"]=>
-      int(1)
-      ["tags"]=>
-      array(0) {
-      }
-    }
-    ["flags"]=>
-    int(4)
-    ["skip"]=>
-    int(0)
-    ["limit"]=>
-    int(1)
-    ["count"]=>
-    int(1)
-    ["batch_size"]=>
-    int(0)
-    ["ns"]=>
-    string(11) "phongo.$cmd"
-    ["current_doc"]=>
-    object(stdClass)#%d (1) {
-      ["ok"]=>
-      float(1)
-    }
   }
-  ["server_id"]=>
-  int(1)
+  ["readPreference"]=>
+  NULL
+  ["isDead"]=>
+  bool(true)
+  ["currentIndex"]=>
+  int(0)
+  ["currentDocument"]=>
+  NULL
+  ["server"]=>
+  object(MongoDB\Driver\Server)#%d (%d) {
+    %a
+  }
 }
 
 Dumping response document:


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-688

This significantly alters the structure of the Cursor's debug output, since we not longer have access to private fields within mongoc_cursor_t.