### PR TITLE
PHPC-673: Fix Cursor::isDead() tests for mongoc_cursor_is_alive()

### DIFF
--- a/tests/cursor/cursor-isDead-002.phpt
+++ b/tests/cursor/cursor-isDead-002.phpt
@@ -1,5 +1,5 @@
 --TEST--
-MongoDB\Driver\Cursor::isDead() with basic iteration (find command)
+MongoDB\Driver\Cursor::isDead() with IteratorIterator (find command)
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; CLEANUP(STANDALONE) ?>
 --FILE--
@@ -16,8 +16,12 @@ $manager->executeBulkWrite(NS, $bulk);
 
 $cursor = $manager->executeQuery(NS, new MongoDB\Driver\Query([], ['batchSize' => 2]));
 
-foreach ($cursor as $_) {
+$iterator = new IteratorIterator($cursor);
+$iterator->rewind();
+
+for ($i = 0; $i < 3; $i++) {
     var_dump($cursor->isDead());
+    $iterator->next();
 }
 
 var_dump($cursor->isDead());

--- a/tests/cursor/cursor-isDead-003.phpt
+++ b/tests/cursor/cursor-isDead-003.phpt
@@ -1,12 +1,12 @@
 --TEST--
-MongoDB\Driver\Cursor::isDead() with basic iteration (find command)
+MongoDB\Driver\Cursor::isDead() with basic iteration (OP_QUERY)
 --SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"; CLEANUP(STANDALONE) ?>
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; CLEANUP(STANDALONE_30) ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";
 
-$manager = new MongoDB\Driver\Manager(STANDALONE);
+$manager = new MongoDB\Driver\Manager(STANDALONE_30);
 
 $bulk = new MongoDB\Driver\BulkWrite();
 $bulk->insert(['_id' => 1]);

--- a/tests/cursor/cursor-isDead-004.phpt
+++ b/tests/cursor/cursor-isDead-004.phpt
@@ -1,12 +1,12 @@
 --TEST--
-MongoDB\Driver\Cursor::isDead() with basic iteration (find command)
+MongoDB\Driver\Cursor::isDead() with IteratorIterator (OP_QUERY)
 --SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"; CLEANUP(STANDALONE) ?>
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; CLEANUP(STANDALONE_30) ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";
 
-$manager = new MongoDB\Driver\Manager(STANDALONE);
+$manager = new MongoDB\Driver\Manager(STANDALONE_30);
 
 $bulk = new MongoDB\Driver\BulkWrite();
 $bulk->insert(['_id' => 1]);
@@ -16,8 +16,12 @@ $manager->executeBulkWrite(NS, $bulk);
 
 $cursor = $manager->executeQuery(NS, new MongoDB\Driver\Query([], ['batchSize' => 2]));
 
-foreach ($cursor as $_) {
+$iterator = new IteratorIterator($cursor);
+$iterator->rewind();
+
+for ($i = 0; $i < 3; $i++) {
     var_dump($cursor->isDead());
+    $iterator->next();
 }
 
 var_dump($cursor->isDead());

--- a/tests/manager/manager-executeCommand-001.phpt
+++ b/tests/manager/manager-executeCommand-001.phpt
@@ -54,7 +54,7 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
   ["readPreference"]=>
   NULL
   ["isDead"]=>
-  bool(true)
+  bool(false)
   ["currentIndex"]=>
   int(0)
   ["currentDocument"]=>

--- a/tests/manager/manager-executeQuery-001.phpt
+++ b/tests/manager/manager-executeQuery-001.phpt
@@ -71,7 +71,7 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
   ["readPreference"]=>
   NULL
   ["isDead"]=>
-  bool(true)
+  bool(false)
   ["currentIndex"]=>
   int(0)
   ["currentDocument"]=>

--- a/tests/manager/manager-executeQuery-002.phpt
+++ b/tests/manager/manager-executeQuery-002.phpt
@@ -70,7 +70,7 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
   ["readPreference"]=>
   NULL
   ["isDead"]=>
-  bool(true)
+  bool(false)
   ["currentIndex"]=>
   int(0)
   ["currentDocument"]=>

--- a/tests/readPreference/bug0146-002.phpt
+++ b/tests/readPreference/bug0146-002.phpt
@@ -69,7 +69,7 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     }
   }
   ["isDead"]=>
-  bool(true)
+  bool(false)
   ["currentIndex"]=>
   int(0)
   ["currentDocument"]=>
@@ -118,7 +118,7 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     }
   }
   ["isDead"]=>
-  bool(true)
+  bool(false)
   ["currentIndex"]=>
   int(0)
   ["currentDocument"]=>
@@ -167,7 +167,7 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     }
   }
   ["isDead"]=>
-  bool(true)
+  bool(false)
   ["currentIndex"]=>
   int(0)
   ["currentDocument"]=>
@@ -216,7 +216,7 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     }
   }
   ["isDead"]=>
-  bool(true)
+  bool(false)
   ["currentIndex"]=>
   int(0)
   ["currentDocument"]=>
@@ -265,7 +265,7 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     }
   }
   ["isDead"]=>
-  bool(true)
+  bool(false)
   ["currentIndex"]=>
   int(0)
   ["currentDocument"]=>

--- a/tests/server/server-executeCommand-001.phpt
+++ b/tests/server/server-executeCommand-001.phpt
@@ -43,7 +43,7 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
   ["readPreference"]=>
   NULL
   ["isDead"]=>
-  bool(true)
+  bool(false)
   ["currentIndex"]=>
   int(0)
   ["currentDocument"]=>


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-673

This bump includes the fix [CDRIVER-1221](https://jira.mongodb.org/browse/CDRIVER-1221), which entails changes to our `Cursor::isDead()` tests (among others where we dump cursors).