### PR TITLE
PHPC-698: Check HAVE_OPENSSL_EXT before calling php-ssl.c functions

### DIFF
--- a/php_phongo.c
+++ b/php_phongo.c
@@ -983,13 +983,13 @@ ssize_t phongo_stream_poll (mongoc_stream_poll_t *streams, size_t nstreams, int3
 } /* }}} */
 
 #if PHP_VERSION_ID < 50600
-int php_mongo_verify_hostname(const char *hostname, X509 *cert TSRMLS_DC)
+static int php_phongo_verify_hostname(const char *hostname, X509 *cert TSRMLS_DC)
 {
-	if (php_mongo_matches_san_list(cert, hostname) == SUCCESS) {
+	if (php_mongodb_matches_san_list(cert, hostname) == SUCCESS) {
 		return SUCCESS;
 	}
 
-	if (php_mongo_matches_common_name(cert, hostname TSRMLS_CC) == SUCCESS) {
+	if (php_mongodb_matches_common_name(cert, hostname TSRMLS_CC) == SUCCESS) {
 		return SUCCESS;
 	}
 
@@ -1012,7 +1012,7 @@ int php_phongo_peer_verify(php_stream *stream, X509 *cert, const char *hostname,
 			peer = hostname;
 		}
 
-		if (php_mongo_verify_hostname(peer, cert TSRMLS_CC) == FAILURE) {
+		if (php_phongo_verify_hostname(peer, cert TSRMLS_CC) == FAILURE) {
 			bson_set_error(error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_CONNECT, "Remote certificate SubjectAltName or CN does not match '%s'", hostname);
 			return false;
 		}
@@ -1068,8 +1068,8 @@ bool php_phongo_ssl_verify(php_stream *stream, const char *hostname, bson_error_
 	if (php_stream_context_get_option(PHP_STREAM_CONTEXT(stream), "ssl", "verify_expiry", &verify_expiry) == SUCCESS && zend_is_true(*verify_expiry)) {
 #endif
 		time_t current     = time(NULL);
-		time_t valid_from  = php_mongo_asn1_time_to_time_t(X509_get_notBefore(cert) TSRMLS_CC);
-		time_t valid_until = php_mongo_asn1_time_to_time_t(X509_get_notAfter(cert) TSRMLS_CC);
+		time_t valid_from  = php_mongodb_asn1_time_to_time_t(X509_get_notBefore(cert) TSRMLS_CC);
+		time_t valid_until = php_mongodb_asn1_time_to_time_t(X509_get_notAfter(cert) TSRMLS_CC);
 
 		if (valid_from > current) {
 			bson_set_error(error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_CONNECT, "Certificate is not valid yet on %s", hostname);

--- a/src/contrib/php-ssl.c
+++ b/src/contrib/php-ssl.c
@@ -34,7 +34,7 @@
 #define timezone _timezone  /* timezone is called _timezone in LibC */
 #endif
 
-int php_mongo_matches_wildcard_name(const char *subjectname, const char *certname) /* {{{ */
+int php_mongodb_matches_wildcard_name(const char *subjectname, const char *certname) /* {{{ */
 {
     char *wildcard = NULL;
     int prefix_len, suffix_len, subject_len;
@@ -70,7 +70,7 @@ int php_mongo_matches_wildcard_name(const char *subjectname, const char *certnam
 }
 /* }}} */
 
-int php_mongo_matches_san_list(X509 *peer, const char *subject_name) /* {{{ */
+int php_mongodb_matches_san_list(X509 *peer, const char *subject_name) /* {{{ */
 {
 	int i, len;
 	unsigned char *cert_name = NULL;
@@ -96,7 +96,7 @@ int php_mongo_matches_san_list(X509 *peer, const char *subject_name) /* {{{ */
 				cert_name[len-1] = '\0';
 			}
 
-			if (php_mongo_matches_wildcard_name(subject_name, (const char *)cert_name) == SUCCESS) {
+			if (php_mongodb_matches_wildcard_name(subject_name, (const char *)cert_name) == SUCCESS) {
 				OPENSSL_free(cert_name);
 				return SUCCESS;
 			}
@@ -124,7 +124,7 @@ int php_mongo_matches_san_list(X509 *peer, const char *subject_name) /* {{{ */
 }
 /* }}} */
 
-int php_mongo_matches_common_name(X509 *peer, const char *subject_name TSRMLS_DC) /* {{{ */
+int php_mongodb_matches_common_name(X509 *peer, const char *subject_name TSRMLS_DC) /* {{{ */
 {
 	char buf[1024];
 	X509_NAME *cert_name;
@@ -137,7 +137,7 @@ int php_mongo_matches_common_name(X509 *peer, const char *subject_name TSRMLS_DC
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to locate peer certificate CN");
 	} else if ((size_t) cert_name_len != strlen(buf)) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Peer certificate CN=`%.*s' is malformed", cert_name_len, buf);
-	} else if (php_mongo_matches_wildcard_name(subject_name, buf) == SUCCESS) {
+	} else if (php_mongodb_matches_wildcard_name(subject_name, buf) == SUCCESS) {
 		return SUCCESS;
 	} else {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Peer certificate CN=`%.*s' did not match expected CN=`%s'", cert_name_len, buf, subject_name);
@@ -147,7 +147,7 @@ int php_mongo_matches_common_name(X509 *peer, const char *subject_name TSRMLS_DC
 }
 /* }}} */
 
-time_t php_mongo_asn1_time_to_time_t(ASN1_UTCTIME * timestr TSRMLS_DC) /* {{{ */
+time_t php_mongodb_asn1_time_to_time_t(ASN1_UTCTIME * timestr TSRMLS_DC) /* {{{ */
 {
 /*
 	This is how the time string is formatted:

--- a/src/contrib/php-ssl.h
+++ b/src/contrib/php-ssl.h
@@ -34,10 +34,10 @@
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 
-int php_mongo_matches_wildcard_name(const char *subjectname, const char *certname);
-int php_mongo_matches_san_list(X509 *peer, const char *subject_name);
-int php_mongo_matches_common_name(X509 *peer, const char *subject_name TSRMLS_DC);
-time_t php_mongo_asn1_time_to_time_t(ASN1_UTCTIME * timestr TSRMLS_DC);
+int php_mongodb_matches_wildcard_name(const char *subjectname, const char *certname);
+int php_mongodb_matches_san_list(X509 *peer, const char *subject_name);
+int php_mongodb_matches_common_name(X509 *peer, const char *subject_name TSRMLS_DC);
+time_t php_mongodb_asn1_time_to_time_t(ASN1_UTCTIME * timestr TSRMLS_DC);
 
 #endif /* HAVE_OPENSSL_EXT */
 #endif 


### PR DESCRIPTION
 * https://jira.mongodb.org/browse/PHPC-698
 * https://jira.mongodb.org/browse/PHPC-699