### PR TITLE
PHPC-631: Fix timelib_time.f assignment in UTCDateTime::toDateTime()

### DIFF
--- a/php_phongo.c
+++ b/php_phongo.c
@@ -2085,7 +2085,7 @@ void php_phongo_new_datetime_from_utcdatetime(zval *object, int64_t milliseconds
 	datetime_obj = Z_PHPDATE_P(object);
 	php_date_initialize(datetime_obj, sec, sec_len, NULL, NULL, 0 TSRMLS_CC);
 	efree(sec);
-	datetime_obj->time->f = milliseconds % 1000;
+	datetime_obj->time->f = (double) (milliseconds % 1000) / 1000;
 } /* }}} */
 void php_phongo_new_timestamp_from_increment_and_timestamp(zval *object, uint32_t increment, uint32_t timestamp TSRMLS_DC) /* {{{ */
 {

--- a/tests/bson/bson-utcdatetime-int-size.phpt
+++ b/tests/bson/bson-utcdatetime-int-size.phpt
@@ -26,7 +26,7 @@ object(MongoDB\BSON\UTCDateTime)#%d (1) {
 }
 object(DateTime)#%d (3) {
   ["date"]=>
-  string(29) "2014-11-20 01:03:31.987000000"
+  string(26) "2014-11-20 01:03:31.987000"
   ["timezone_type"]=>
   int(1)
   ["timezone"]=>
@@ -39,7 +39,7 @@ object(MongoDB\BSON\UTCDateTime)#%d (1) {
 }
 object(DateTime)#%d (3) {
   ["date"]=>
-  string(29) "2014-11-20 01:03:31.987000000"
+  string(26) "2014-11-20 01:03:31.987000"
   ["timezone_type"]=>
   int(1)
   ["timezone"]=>

--- a/tests/bson/bson-utcdatetime-todatetime-002.phpt
+++ b/tests/bson/bson-utcdatetime-todatetime-002.phpt
@@ -1,0 +1,20 @@
+--TEST--
+BSON BSON\UTCDateTime::toDateTime() dumping seconds and microseconds
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+--FILE--
+<?php
+use MongoDB\BSON as BSON;
+
+require_once __DIR__ . "/../utils/basic.inc";
+
+$utcdatetime = new BSON\UTCDateTime("1416445411987");
+$datetime = $utcdatetime->toDateTime();
+echo $datetime->format('U.u'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+1416445411.987000
+===DONE===

--- a/tests/bson/bug0631.phpt
+++ b/tests/bson/bug0631.phpt
@@ -1,0 +1,42 @@
+--TEST--
+PHPC-631: UTCDateTime::toDateTime() may return object that cannot be serialized
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$utcdatetime = new MongoDB\BSON\UTCDateTime(1466540755123);
+$datetime = $utcdatetime->toDateTime();
+$s = serialize($datetime);
+
+var_dump($datetime);
+
+echo "\n", $s, "\n\n";
+
+var_dump(unserialize($s));
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+object(DateTime)#%d (%d) {
+  ["date"]=>
+  string(26) "2016-06-21 20:25:55.123000"
+  ["timezone_type"]=>
+  int(1)
+  ["timezone"]=>
+  string(6) "+00:00"
+}
+
+O:8:"DateTime":3:{s:4:"date";s:26:"2016-06-21 20:25:55.123000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}
+
+object(DateTime)#%d (%d) {
+  ["date"]=>
+  string(26) "2016-06-21 20:25:55.123000"
+  ["timezone_type"]=>
+  int(1)
+  ["timezone"]=>
+  string(6) "+00:00"
+}
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-631

This includes the patch from #267 and adds additional tests.