### PR TITLE
Move php_phongo_new_datetime_from_utcdatetime() into UTCDateTime.c

### DIFF
--- a/php_phongo.c
+++ b/php_phongo.c
@@ -2068,25 +2068,6 @@ void php_phongo_new_utcdatetime_from_epoch(zval *object, int64_t msec_since_epoc
 	intern->milliseconds = msec_since_epoch;
 } /* }}} */
 
-void php_phongo_new_datetime_from_utcdatetime(zval *object, int64_t milliseconds TSRMLS_DC) /* {{{ */
-{
-	php_date_obj             *datetime_obj;
-	char                     *sec;
-	int                       sec_len;
-
-	object_init_ex(object, php_date_get_date_ce());
-
-#ifdef WIN32
-	sec_len = spprintf(&sec, 0, "@%I64d", (int64_t) milliseconds / 1000);
-#else
-	sec_len = spprintf(&sec, 0, "@%lld", (long long int) milliseconds / 1000);
-#endif
-
-	datetime_obj = Z_PHPDATE_P(object);
-	php_date_initialize(datetime_obj, sec, sec_len, NULL, NULL, 0 TSRMLS_CC);
-	efree(sec);
-	datetime_obj->time->f = (double) (milliseconds % 1000) / 1000;
-} /* }}} */
 void php_phongo_new_timestamp_from_increment_and_timestamp(zval *object, uint32_t increment, uint32_t timestamp TSRMLS_DC) /* {{{ */
 {
 	php_phongo_timestamp_t     *intern;

--- a/php_phongo.h
+++ b/php_phongo.h
@@ -140,7 +140,6 @@ bool phongo_manager_init(php_phongo_manager_t *manager, const char *uri_string, 
 void php_phongo_objectid_new_from_oid(zval *object, const bson_oid_t *oid TSRMLS_DC);
 void php_phongo_cursor_id_new_from_id(zval *object, int64_t cursorid TSRMLS_DC);
 void php_phongo_new_utcdatetime_from_epoch(zval *object, int64_t msec_since_epoch TSRMLS_DC);
-void php_phongo_new_datetime_from_utcdatetime(zval *object, int64_t milliseconds TSRMLS_DC);
 void php_phongo_new_timestamp_from_increment_and_timestamp(zval *object, uint32_t increment, uint32_t timestamp TSRMLS_DC);
 void php_phongo_new_javascript_from_javascript(int init, zval *object, const char *code, size_t code_len TSRMLS_DC);
 void php_phongo_new_javascript_from_javascript_and_scope(int init, zval *object, const char *code, size_t code_len, const bson_t *scope TSRMLS_DC);

--- a/src/BSON/UTCDateTime.c
+++ b/src/BSON/UTCDateTime.c
@@ -34,6 +34,7 @@
 #include <ext/standard/info.h>
 #include <Zend/zend_interfaces.h>
 #include <ext/spl/spl_iterators.h>
+#include <ext/date/php_date.h>
 /* Our Compatability header */
 #include "phongo_compat.h"
 
@@ -112,7 +113,10 @@ PHP_METHOD(UTCDateTime, __toString)
    Returns DateTime object representing this UTCDateTime */
 PHP_METHOD(UTCDateTime, toDateTime)
 {
-	php_phongo_utcdatetime_t    *intern;
+	php_phongo_utcdatetime_t *intern;
+	php_date_obj             *datetime_obj;
+	char                     *sec;
+	size_t                    sec_len;
 
 
 	intern = Z_UTCDATETIME_OBJ_P(getThis());
@@ -121,7 +125,14 @@ PHP_METHOD(UTCDateTime, toDateTime)
 		return;
 	}
 
-	php_phongo_new_datetime_from_utcdatetime(return_value, intern->milliseconds TSRMLS_CC);
+	object_init_ex(return_value, php_date_get_date_ce());
+	datetime_obj = Z_PHPDATE_P(return_value);
+
+	sec_len = spprintf(&sec, 0, "@%" PRId64, intern->milliseconds / 1000);
+	php_date_initialize(datetime_obj, sec, sec_len, NULL, NULL, 0 TSRMLS_CC);
+	efree(sec);
+
+	datetime_obj->time->f = (double) (intern->milliseconds % 1000) / 1000;
 }
 /* }}} */
 


### PR DESCRIPTION
This function was only used by UTCDateTime::toDateTime(), so it does not need to be in php_phongo.c. Additionally, this commit removes the platform-specific spprintf patterns in favor of the portable PRId64 pattern.

This PR depends on https://github.com/mongodb/mongo-php-driver/pull/338.