### PR TITLE
PHPC-726: Allow cross-platform serialization of Timestamp and UTCDateTime

### DIFF
--- a/tests/bson/bson-timestamp-002.phpt
+++ b/tests/bson/bson-timestamp-002.phpt
@@ -13,8 +13,8 @@ var_dump($timestamp);
 --EXPECTF--
 object(MongoDB\BSON\Timestamp)#%d (%d) {
   ["increment"]=>
-  int(1234)
+  string(4) "1234"
   ["timestamp"]=>
-  int(5678)
+  string(4) "5678"
 }
 ===DONE===

--- a/tests/bson/bson-timestamp-003.phpt
+++ b/tests/bson/bson-timestamp-003.phpt
@@ -21,17 +21,17 @@ foreach ($tests as $test) {
 Test [2147483647:0]
 object(MongoDB\BSON\Timestamp)#%d (%d) {
   ["increment"]=>
-  int(2147483647)
+  string(10) "2147483647"
   ["timestamp"]=>
-  int(0)
+  string(1) "0"
 }
 
 Test [0:2147483647]
 object(MongoDB\BSON\Timestamp)#%d (%d) {
   ["increment"]=>
-  int(0)
+  string(1) "0"
   ["timestamp"]=>
-  int(2147483647)
+  string(10) "2147483647"
 }
 
 ===DONE===

--- a/tests/bson/bson-timestamp-004.phpt
+++ b/tests/bson/bson-timestamp-004.phpt
@@ -23,17 +23,17 @@ foreach ($tests as $test) {
 Test [4294967295:0]
 object(MongoDB\BSON\Timestamp)#%d (%d) {
   ["increment"]=>
-  int(4294967295)
+  string(10) "4294967295"
   ["timestamp"]=>
-  int(0)
+  string(1) "0"
 }
 
 Test [0:4294967295]
 object(MongoDB\BSON\Timestamp)#%d (%d) {
   ["increment"]=>
-  int(0)
+  string(1) "0"
   ["timestamp"]=>
-  int(4294967295)
+  string(10) "4294967295"
 }
 
 ===DONE===

--- a/tests/bson/bson-timestamp-serialization-001.phpt
+++ b/tests/bson/bson-timestamp-serialization-001.phpt
@@ -24,44 +24,44 @@ foreach ($tests as $test) {
 --EXPECTF--
 object(MongoDB\BSON\Timestamp)#%d (%d) {
   ["increment"]=>
-  int(1234)
+  string(4) "1234"
   ["timestamp"]=>
-  int(5678)
+  string(4) "5678"
 }
-string(80) "O:22:"MongoDB\BSON\Timestamp":2:{s:9:"increment";i:1234;s:9:"timestamp";i:5678;}"
+string(88) "O:22:"MongoDB\BSON\Timestamp":2:{s:9:"increment";s:4:"1234";s:9:"timestamp";s:4:"5678";}"
 object(MongoDB\BSON\Timestamp)#%d (%d) {
   ["increment"]=>
-  int(1234)
+  string(4) "1234"
   ["timestamp"]=>
-  int(5678)
-}
-
-object(MongoDB\BSON\Timestamp)#%d (%d) {
-  ["increment"]=>
-  int(2147483647)
-  ["timestamp"]=>
-  int(0)
-}
-string(83) "O:22:"MongoDB\BSON\Timestamp":2:{s:9:"increment";i:2147483647;s:9:"timestamp";i:0;}"
-object(MongoDB\BSON\Timestamp)#%d (%d) {
-  ["increment"]=>
-  int(2147483647)
-  ["timestamp"]=>
-  int(0)
+  string(4) "5678"
 }
 
 object(MongoDB\BSON\Timestamp)#%d (%d) {
   ["increment"]=>
-  int(0)
+  string(10) "2147483647"
   ["timestamp"]=>
-  int(2147483647)
+  string(1) "0"
 }
-string(83) "O:22:"MongoDB\BSON\Timestamp":2:{s:9:"increment";i:0;s:9:"timestamp";i:2147483647;}"
+string(92) "O:22:"MongoDB\BSON\Timestamp":2:{s:9:"increment";s:10:"2147483647";s:9:"timestamp";s:1:"0";}"
 object(MongoDB\BSON\Timestamp)#%d (%d) {
   ["increment"]=>
-  int(0)
+  string(10) "2147483647"
   ["timestamp"]=>
-  int(2147483647)
+  string(1) "0"
+}
+
+object(MongoDB\BSON\Timestamp)#%d (%d) {
+  ["increment"]=>
+  string(1) "0"
+  ["timestamp"]=>
+  string(10) "2147483647"
+}
+string(92) "O:22:"MongoDB\BSON\Timestamp":2:{s:9:"increment";s:1:"0";s:9:"timestamp";s:10:"2147483647";}"
+object(MongoDB\BSON\Timestamp)#%d (%d) {
+  ["increment"]=>
+  string(1) "0"
+  ["timestamp"]=>
+  string(10) "2147483647"
 }
 
 ===DONE===

--- a/tests/bson/bson-timestamp-serialization-002.phpt
+++ b/tests/bson/bson-timestamp-serialization-002.phpt
@@ -25,30 +25,30 @@ foreach ($tests as $test) {
 --EXPECTF--
 object(MongoDB\BSON\Timestamp)#%d (%d) {
   ["increment"]=>
-  int(4294967295)
+  string(10) "4294967295"
   ["timestamp"]=>
-  int(0)
+  string(1) "0"
 }
-string(83) "O:22:"MongoDB\BSON\Timestamp":2:{s:9:"increment";i:4294967295;s:9:"timestamp";i:0;}"
+string(92) "O:22:"MongoDB\BSON\Timestamp":2:{s:9:"increment";s:10:"4294967295";s:9:"timestamp";s:1:"0";}"
 object(MongoDB\BSON\Timestamp)#%d (%d) {
   ["increment"]=>
-  int(4294967295)
+  string(10) "4294967295"
   ["timestamp"]=>
-  int(0)
+  string(1) "0"
 }
 
 object(MongoDB\BSON\Timestamp)#%d (%d) {
   ["increment"]=>
-  int(0)
+  string(1) "0"
   ["timestamp"]=>
-  int(4294967295)
+  string(10) "4294967295"
 }
-string(83) "O:22:"MongoDB\BSON\Timestamp":2:{s:9:"increment";i:0;s:9:"timestamp";i:4294967295;}"
+string(92) "O:22:"MongoDB\BSON\Timestamp":2:{s:9:"increment";s:1:"0";s:9:"timestamp";s:10:"4294967295";}"
 object(MongoDB\BSON\Timestamp)#%d (%d) {
   ["increment"]=>
-  int(0)
+  string(1) "0"
   ["timestamp"]=>
-  int(4294967295)
+  string(10) "4294967295"
 }
 
 ===DONE===

--- a/tests/bson/bson-timestamp-serialization_error-001.phpt
+++ b/tests/bson/bson-timestamp-serialization_error-001.phpt
@@ -14,7 +14,11 @@ echo throws(function() {
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
 echo throws(function() {
-    unserialize('O:22:"MongoDB\BSON\Timestamp":2:{s:9:"increment";s:4:"1234";s:9:"timestamp";s:4:"5678";}');
+    unserialize('O:22:"MongoDB\BSON\Timestamp":2:{s:9:"increment";i:1234;s:9:"timestamp";s:4:"5678";}');
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() {
+    unserialize('O:22:"MongoDB\BSON\Timestamp":2:{s:9:"increment";s:4:"1234";s:9:"timestamp";i:5678;}');
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
 ?>
@@ -22,9 +26,11 @@ echo throws(function() {
 <?php exit(0); ?>
 --EXPECT--
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-MongoDB\BSON\Timestamp initialization requires "increment" and "timestamp" integer fields
+MongoDB\BSON\Timestamp initialization requires "increment" and "timestamp" integer or numeric string fields
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-MongoDB\BSON\Timestamp initialization requires "increment" and "timestamp" integer fields
+MongoDB\BSON\Timestamp initialization requires "increment" and "timestamp" integer or numeric string fields
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-MongoDB\BSON\Timestamp initialization requires "increment" and "timestamp" integer fields
+MongoDB\BSON\Timestamp initialization requires "increment" and "timestamp" integer or numeric string fields
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+MongoDB\BSON\Timestamp initialization requires "increment" and "timestamp" integer or numeric string fields
 ===DONE===

--- a/tests/bson/bson-timestamp-set_state-001.phpt
+++ b/tests/bson/bson-timestamp-set_state-001.phpt
@@ -24,18 +24,18 @@ foreach ($tests as $test) {
 <?php exit(0); ?>
 --EXPECT--
 MongoDB\BSON\Timestamp::__set_state(array(
-   'increment' => 1234,
-   'timestamp' => 5678,
+   'increment' => '1234',
+   'timestamp' => '5678',
 ))
 
 MongoDB\BSON\Timestamp::__set_state(array(
-   'increment' => 2147483647,
-   'timestamp' => 0,
+   'increment' => '2147483647',
+   'timestamp' => '0',
 ))
 
 MongoDB\BSON\Timestamp::__set_state(array(
-   'increment' => 0,
-   'timestamp' => 2147483647,
+   'increment' => '0',
+   'timestamp' => '2147483647',
 ))
 
 ===DONE===

--- a/tests/bson/bson-timestamp-set_state-002.phpt
+++ b/tests/bson/bson-timestamp-set_state-002.phpt
@@ -25,13 +25,13 @@ foreach ($tests as $test) {
 <?php exit(0); ?>
 --EXPECT--
 MongoDB\BSON\Timestamp::__set_state(array(
-   'increment' => 4294967295,
-   'timestamp' => 0,
+   'increment' => '4294967295',
+   'timestamp' => '0',
 ))
 
 MongoDB\BSON\Timestamp::__set_state(array(
-   'increment' => 0,
-   'timestamp' => 4294967295,
+   'increment' => '0',
+   'timestamp' => '4294967295',
 ))
 
 ===DONE===

--- a/tests/bson/bson-timestamp-set_state_error-001.phpt
+++ b/tests/bson/bson-timestamp-set_state_error-001.phpt
@@ -14,7 +14,11 @@ echo throws(function() {
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
 echo throws(function() {
-    MongoDB\BSON\Timestamp::__set_state(['increment' => '1234', 'timestamp' => '5678']);
+    MongoDB\BSON\Timestamp::__set_state(['increment' => '1234', 'timestamp' => 5678]);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() {
+    MongoDB\BSON\Timestamp::__set_state(['increment' => 1234, 'timestamp' => '5678']);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
 ?>
@@ -22,9 +26,11 @@ echo throws(function() {
 <?php exit(0); ?>
 --EXPECT--
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-MongoDB\BSON\Timestamp initialization requires "increment" and "timestamp" integer fields
+MongoDB\BSON\Timestamp initialization requires "increment" and "timestamp" integer or numeric string fields
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-MongoDB\BSON\Timestamp initialization requires "increment" and "timestamp" integer fields
+MongoDB\BSON\Timestamp initialization requires "increment" and "timestamp" integer or numeric string fields
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-MongoDB\BSON\Timestamp initialization requires "increment" and "timestamp" integer fields
+MongoDB\BSON\Timestamp initialization requires "increment" and "timestamp" integer or numeric string fields
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+MongoDB\BSON\Timestamp initialization requires "increment" and "timestamp" integer or numeric string fields
 ===DONE===

--- a/tests/bson/bson-timestamp-set_state_error-004.phpt
+++ b/tests/bson/bson-timestamp-set_state_error-004.phpt
@@ -1,0 +1,26 @@
+--TEST--
+MongoDB\BSON\Timestamp::__set_state() with broken numeric strings
+--SKIPIF--
+<?php if (8 !== PHP_INT_SIZE) { die('skip Only for 64-bit platform'); } ?>
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/tools.php';
+
+echo throws(function() {
+    MongoDB\BSON\Timestamp::__set_state(['increment' => 'broken', 'timestamp' => '5678']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() {
+    MongoDB\BSON\Timestamp::__set_state(['increment' => '1234', 'timestamp' => 'broken']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Error parsing "broken" as 64-bit integer increment for MongoDB\BSON\Timestamp initialization
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Error parsing "broken" as 64-bit integer timestamp for MongoDB\BSON\Timestamp initialization
+===DONE===

--- a/tests/bson/bson-utcdatetime-003.phpt
+++ b/tests/bson/bson-utcdatetime-003.phpt
@@ -17,6 +17,6 @@ var_dump($utcdatetime);
 --EXPECTF--
 object(MongoDB\BSON\UTCDateTime)#%d (%d) {
   ["milliseconds"]=>
-  int(1416445411987)
+  string(13) "1416445411987"
 }
 ===DONE===

--- a/tests/bson/bson-utcdatetime-004.phpt
+++ b/tests/bson/bson-utcdatetime-004.phpt
@@ -18,10 +18,10 @@ foreach ($tests as $test) {
 --EXPECTF--
 object(MongoDB\BSON\UTCDateTime)#%d (%d) {
   ["milliseconds"]=>
-  int(%d)
+  string(13) "%d"
 }
 object(MongoDB\BSON\UTCDateTime)#%d (%d) {
   ["milliseconds"]=>
-  int(%d)
+  string(13) "%d"
 }
 ===DONE===

--- a/tests/bson/bson-utcdatetime-005.phpt
+++ b/tests/bson/bson-utcdatetime-005.phpt
@@ -20,18 +20,18 @@ foreach ($tests as $test) {
 --EXPECTF--
 object(MongoDB\BSON\UTCDateTime)#%d (%d) {
   ["milliseconds"]=>
-  int(%d000)
+  string(13) "%d000"
 }
 object(MongoDB\BSON\UTCDateTime)#%d (%d) {
   ["milliseconds"]=>
-  int(1215282385000)
+  string(13) "1215282385000"
 }
 object(MongoDB\BSON\UTCDateTime)#%d (%d) {
   ["milliseconds"]=>
-  int(1293894181012)
+  string(13) "1293894181012"
 }
 object(MongoDB\BSON\UTCDateTime)#%d (%d) {
   ["milliseconds"]=>
-  int(2551871655999)
+  string(13) "2551871655999"
 }
 ===DONE===

--- a/tests/bson/bson-utcdatetime-006.phpt
+++ b/tests/bson/bson-utcdatetime-006.phpt
@@ -22,18 +22,18 @@ foreach ($tests as $test) {
 --EXPECTF--
 object(MongoDB\BSON\UTCDateTime)#%d (%d) {
   ["milliseconds"]=>
-  int(%d000)
+  string(13) "%d000"
 }
 object(MongoDB\BSON\UTCDateTime)#%d (%d) {
   ["milliseconds"]=>
-  int(1215282385000)
+  string(13) "1215282385000"
 }
 object(MongoDB\BSON\UTCDateTime)#%d (%d) {
   ["milliseconds"]=>
-  int(1293894181012)
+  string(13) "1293894181012"
 }
 object(MongoDB\BSON\UTCDateTime)#%d (%d) {
   ["milliseconds"]=>
-  int(2551871655999)
+  string(13) "2551871655999"
 }
 ===DONE===

--- a/tests/bson/bson-utcdatetime-serialization-001.phpt
+++ b/tests/bson/bson-utcdatetime-serialization-001.phpt
@@ -22,32 +22,32 @@ foreach ($tests as $milliseconds) {
 --EXPECTF--
 object(MongoDB\BSON\UTCDateTime)#%d (%d) {
   ["milliseconds"]=>
-  %rint\(|string\(1\) "|%r0%r"|\)%r
+  string(1) "0"
 }
-string(60) "O:24:"MongoDB\BSON\UTCDateTime":1:{s:12:"milliseconds";%ri:|s:1:"%r0%r"?%r;}"
+string(64) "O:24:"MongoDB\BSON\UTCDateTime":1:{s:12:"milliseconds";s:1:"0";}"
 object(MongoDB\BSON\UTCDateTime)#%d (%d) {
   ["milliseconds"]=>
-  %rint\(|string\(1\) "|%r0%r"|\)%r
-}
-
-object(MongoDB\BSON\UTCDateTime)#%d (%d) {
-  ["milliseconds"]=>
-  %rint\(|string\(14\) "|%r-1416445411987%r"|\)%r
-}
-string(73) "O:24:"MongoDB\BSON\UTCDateTime":1:{s:12:"milliseconds";%ri:|s:14:"%r-1416445411987%r"?%r;}"
-object(MongoDB\BSON\UTCDateTime)#%d (%d) {
-  ["milliseconds"]=>
-  %rint\(|string\(14\) "|%r-1416445411987%r"|\)%r
+  string(1) "0"
 }
 
 object(MongoDB\BSON\UTCDateTime)#%d (%d) {
   ["milliseconds"]=>
-  %rint\(|string\(13\) "|%r1416445411987%r"|\)%r
+  string(14) "-1416445411987"
 }
-string(72) "O:24:"MongoDB\BSON\UTCDateTime":1:{s:12:"milliseconds";%ri:|s:13:"%r1416445411987%r"?%r;}"
+string(78) "O:24:"MongoDB\BSON\UTCDateTime":1:{s:12:"milliseconds";s:14:"-1416445411987";}"
 object(MongoDB\BSON\UTCDateTime)#%d (%d) {
   ["milliseconds"]=>
-  %rint\(|string\(13\) "|%r1416445411987%r"|\)%r
+  string(14) "-1416445411987"
+}
+
+object(MongoDB\BSON\UTCDateTime)#%d (%d) {
+  ["milliseconds"]=>
+  string(13) "1416445411987"
+}
+string(77) "O:24:"MongoDB\BSON\UTCDateTime":1:{s:12:"milliseconds";s:13:"1416445411987";}"
+object(MongoDB\BSON\UTCDateTime)#%d (%d) {
+  ["milliseconds"]=>
+  string(13) "1416445411987"
 }
 
 ===DONE===

--- a/tests/bson/bson-utcdatetime-serialization-002.phpt
+++ b/tests/bson/bson-utcdatetime-serialization-002.phpt
@@ -26,19 +26,19 @@ foreach ($tests as $milliseconds) {
 string(64) "O:24:"MongoDB\BSON\UTCDateTime":1:{s:12:"milliseconds";s:1:"0";}"
 object(MongoDB\BSON\UTCDateTime)#%d (%d) {
   ["milliseconds"]=>
-  int(0)
+  string(1) "0"
 }
 
 string(78) "O:24:"MongoDB\BSON\UTCDateTime":1:{s:12:"milliseconds";s:14:"-1416445411987";}"
 object(MongoDB\BSON\UTCDateTime)#%d (%d) {
   ["milliseconds"]=>
-  int(-1416445411987)
+  string(14) "-1416445411987"
 }
 
 string(77) "O:24:"MongoDB\BSON\UTCDateTime":1:{s:12:"milliseconds";s:13:"1416445411987";}"
 object(MongoDB\BSON\UTCDateTime)#%d (%d) {
   ["milliseconds"]=>
-  int(1416445411987)
+  string(13) "1416445411987"
 }
 
 ===DONE===

--- a/tests/bson/bson-utcdatetime-set_state-001.phpt
+++ b/tests/bson/bson-utcdatetime-set_state-001.phpt
@@ -21,15 +21,15 @@ foreach ($tests as $milliseconds) {
 <?php exit(0); ?>
 --EXPECTF--
 MongoDB\BSON\UTCDateTime::__set_state(array(
-   'milliseconds' => %r'?%r0%r'?%r,
+   'milliseconds' => '0',
 ))
 
 MongoDB\BSON\UTCDateTime::__set_state(array(
-   'milliseconds' => %r'?%r-1416445411987%r'?%r,
+   'milliseconds' => '-1416445411987',
 ))
 
 MongoDB\BSON\UTCDateTime::__set_state(array(
-   'milliseconds' => %r'?%r1416445411987%r'?%r,
+   'milliseconds' => '1416445411987',
 ))
 
 ===DONE===

--- a/tests/bson/bson-utcdatetime-set_state-002.phpt
+++ b/tests/bson/bson-utcdatetime-set_state-002.phpt
@@ -23,15 +23,15 @@ foreach ($tests as $milliseconds) {
 <?php exit(0); ?>
 --EXPECT--
 MongoDB\BSON\UTCDateTime::__set_state(array(
-   'milliseconds' => 0,
+   'milliseconds' => '0',
 ))
 
 MongoDB\BSON\UTCDateTime::__set_state(array(
-   'milliseconds' => -1416445411987,
+   'milliseconds' => '-1416445411987',
 ))
 
 MongoDB\BSON\UTCDateTime::__set_state(array(
-   'milliseconds' => 1416445411987,
+   'milliseconds' => '1416445411987',
 ))
 
 ===DONE===


### PR DESCRIPTION
I've opted to make Timestamp either accept strings for both increment and timestamp, or an integer for both. You can not mix a string increment and an integer timestamp, or v.v.