### PR TITLE
PHPC-731: Parse Timestamp argument as strings to accept large integers

### DIFF
--- a/src/BSON/Timestamp.c
+++ b/src/BSON/Timestamp.c
@@ -141,27 +141,28 @@ static bool php_phongo_timestamp_init_from_hash(php_phongo_timestamp_t *intern, 
 	return false;
 }
 
-/* {{{ proto void Timestamp::__construct(integer $increment, integer $timestamp)
+/* {{{ proto void Timestamp::__construct(string $increment, string $timestamp)
    Construct a new BSON timestamp type, which consists of a 4-byte increment and
    4-byte timestamp. */
 PHP_METHOD(Timestamp, __construct)
 {
 	php_phongo_timestamp_t    *intern;
 	zend_error_handling       error_handling;
-	phongo_long               increment;
-	phongo_long               timestamp;
-
+	char                      *s_increment;
+	phongo_zpp_char_len       s_increment_len;
+	char                      *s_timestamp;
+	phongo_zpp_char_len       s_timestamp_len;
 
 	zend_replace_error_handling(EH_THROW, phongo_exception_from_phongo_domain(PHONGO_ERROR_INVALID_ARGUMENT), &error_handling TSRMLS_CC);
 	intern = Z_TIMESTAMP_OBJ_P(getThis());
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ll", &increment, &timestamp) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss", &s_increment, &s_increment_len, &s_timestamp, &s_timestamp_len) == FAILURE) {
 		zend_restore_error_handling(&error_handling TSRMLS_CC);
 		return;
 	}
 	zend_restore_error_handling(&error_handling TSRMLS_CC);
 
-	php_phongo_timestamp_init(intern, increment, timestamp TSRMLS_CC);
+	php_phongo_timestamp_init_from_string(intern, s_increment, s_increment_len, s_timestamp, s_timestamp_len TSRMLS_CC);
 }
 /* }}} */
 

--- a/tests/bson/bson-timestamp-005.phpt
+++ b/tests/bson/bson-timestamp-005.phpt
@@ -1,0 +1,55 @@
+--TEST--
+MongoDB\BSON\Timestamp constructor requires positive unsigned 32-bit integers (as string)
+--FILE--
+<?php
+
+$tests = [
+    new MongoDB\BSON\Timestamp("2147483647", "0"),
+    new MongoDB\BSON\Timestamp(0, "2147483647"),
+    new MongoDB\BSON\Timestamp("4294967295", "0"),
+    new MongoDB\BSON\Timestamp("0", "4294967295"),
+];
+
+foreach ($tests as $test) {
+    printf("Test %s\n", $test);
+    var_dump($test);
+    echo "\n";
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+Test [2147483647:0]
+object(MongoDB\BSON\Timestamp)#%d (%d) {
+  ["increment"]=>
+  string(10) "2147483647"
+  ["timestamp"]=>
+  string(1) "0"
+}
+
+Test [0:2147483647]
+object(MongoDB\BSON\Timestamp)#%d (%d) {
+  ["increment"]=>
+  string(1) "0"
+  ["timestamp"]=>
+  string(10) "2147483647"
+}
+
+Test [4294967295:0]
+object(MongoDB\BSON\Timestamp)#%d (%d) {
+  ["increment"]=>
+  string(10) "4294967295"
+  ["timestamp"]=>
+  string(1) "0"
+}
+
+Test [0:4294967295]
+object(MongoDB\BSON\Timestamp)#%d (%d) {
+  ["increment"]=>
+  string(1) "0"
+  ["timestamp"]=>
+  string(10) "4294967295"
+}
+
+===DONE===


### PR DESCRIPTION
Depends on PHPC-726/PR #386 