### PR TITLE
PHPC-424: Validate that RP tag set is an array of documents

### DIFF
--- a/php_phongo.h
+++ b/php_phongo.h
@@ -129,6 +129,8 @@ const mongoc_write_concern_t* phongo_write_concern_from_zval  (zval *zwrite_conc
 
 php_phongo_server_description_type_t php_phongo_server_description_type(mongoc_server_description_t *sd);
 
+bool php_phongo_read_preference_tags_are_valid(const bson_t *tags);
+
 void php_phongo_server_to_zval(zval *retval, mongoc_server_description_t *sd);
 void php_phongo_read_concern_to_zval(zval *retval, const mongoc_read_concern_t *read_concern);
 void php_phongo_read_preference_to_zval(zval *retval, const mongoc_read_prefs_t *read_prefs);

--- a/src/MongoDB/ReadPreference.c
+++ b/src/MongoDB/ReadPreference.c
@@ -74,22 +74,39 @@ PHP_METHOD(ReadPreference, __construct)
 		case MONGOC_READ_SECONDARY_PREFERRED:
 		case MONGOC_READ_NEAREST:
 			intern->read_preference = mongoc_read_prefs_new(mode);
-
-			if (tagSets) {
-				bson_t *tags = bson_new();
-
-				phongo_zval_to_bson(tagSets, PHONGO_BSON_NONE, (bson_t *)tags, NULL TSRMLS_CC);
-				mongoc_read_prefs_set_tags(intern->read_preference, tags);
-				bson_destroy(tags);
-				if (!mongoc_read_prefs_is_valid(intern->read_preference)) {
-					phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Invalid tagSets");
-					return;
-				}
-			}
 			break;
 		default:
 			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Invalid mode: %" PHONGO_LONG_FORMAT, mode);
 			return;
+	}
+
+	switch(ZEND_NUM_ARGS()) {
+		case 2:
+			if (tagSets) {
+				bson_t *tags = bson_new();
+
+				phongo_zval_to_bson(tagSets, PHONGO_BSON_NONE, (bson_t *)tags, NULL TSRMLS_CC);
+
+				if (!php_phongo_read_preference_tags_are_valid(tags)) {
+					phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "tagSets must be an array of zero or more documents");
+					bson_destroy(tags);
+					return;
+				}
+
+				if (!bson_empty(tags) && mode == MONGOC_READ_PRIMARY) {
+					phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "tagSets may not be used with primary mode");
+					bson_destroy(tags);
+					return;
+				}
+
+				mongoc_read_prefs_set_tags(intern->read_preference, tags);
+				bson_destroy(tags);
+			}
+	}
+
+	if (!mongoc_read_prefs_is_valid(intern->read_preference)) {
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Read preference is not valid");
+		return;
 	}
 }
 /* }}} */

--- a/src/MongoDB/ReadPreference.c
+++ b/src/MongoDB/ReadPreference.c
@@ -52,7 +52,7 @@ PHP_METHOD(ReadPreference, __construct)
 {
 	php_phongo_readpreference_t *intern;
 	zend_error_handling       error_handling;
-	long                      mode;
+	phongo_long               mode;
 	zval                     *tagSets = NULL;
 	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value) SUPPRESS_UNUSED_WARNING(return_value_used)
 
@@ -88,7 +88,7 @@ PHP_METHOD(ReadPreference, __construct)
 			}
 			break;
 		default:
-			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Invalid mode: %ld", mode);
+			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Invalid mode: %" PHONGO_LONG_FORMAT, mode);
 			return;
 	}
 }

--- a/tests/manager/manager-ctor_error-003.phpt
+++ b/tests/manager/manager-ctor_error-003.phpt
@@ -11,11 +11,15 @@ echo throws(function() {
 }, "MongoDB\Driver\Exception\InvalidArgumentException"), "\n";
 
 echo throws(function() {
-    $manager = new MongoDB\Driver\Manager(STANDALONE, array('readPreference' => 'nothing'));
+    $manager = new MongoDB\Driver\Manager(STANDALONE, ['readPreference' => 'nothing']);
 }, "MongoDB\Driver\Exception\InvalidArgumentException"), "\n";
 
 echo throws(function() {
-    $manager = new MongoDB\Driver\Manager(STANDALONE . '/?readPreference=primary', array('readPreferenceTags' => array(array())));
+    $manager = new MongoDB\Driver\Manager(STANDALONE . '/?readPreference=primary', ['readPreferenceTags' => [[]]]);
+}, "MongoDB\Driver\Exception\InvalidArgumentException"), "\n";
+
+echo throws(function() {
+    $manager = new MongoDB\Driver\Manager(STANDALONE . '/?readPreference=primary', ['readPreferenceTags' => ['invalid']]);
 }, "MongoDB\Driver\Exception\InvalidArgumentException"), "\n";
 
 ?>
@@ -28,4 +32,6 @@ OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Unsupported readPreference value: 'nothing'
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Primary read preference mode conflicts with tags
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Read preference tags must be an array of zero or more documents
 ===DONE===

--- a/tests/readPreference/readpreference-ctor_error-001.phpt
+++ b/tests/readPreference/readpreference-ctor_error-001.phpt
@@ -1,14 +1,10 @@
 --TEST--
-MongoDB\Driver\ReadPreference construction (invalid arguments)
+MongoDB\Driver\ReadPreference construction (invalid mode)
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";
-
-echo throws(function() {
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY, array(array("tag" => "one")));
-}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
 echo throws(function() {
     new MongoDB\Driver\ReadPreference(42);
@@ -17,9 +13,7 @@ echo throws(function() {
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECTF--
-OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Invalid tagSets
+--EXPECT--
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Invalid mode: 42
 ===DONE===

--- a/tests/readPreference/readpreference-ctor_error-002.phpt
+++ b/tests/readPreference/readpreference-ctor_error-002.phpt
@@ -1,0 +1,31 @@
+--TEST--
+MongoDB\Driver\ReadPreference construction (invalid tagSets)
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+echo throws(function() {
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY, [['tag' => 'one']]);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() {
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY, ['invalid']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() {
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, ['invalid']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+tagSets may not be used with primary mode
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+tagSets must be an array of zero or more documents
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+tagSets must be an array of zero or more documents
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-424

This adds common validation for read preference tag sets when specified through either the Manager constructor's URI options array or ReadPreference constructor.

An additional test case for a malformed tag set has been added to the Manager::__construct() error test for read preference options. Additionally, the ReadPreference::__construct() error test has been split up to test for mode and tagSet errors separately.

Note: we cannot test for the exceptions for bson_init_static() and mongoc_read_prefs_is_valid(), since those points will never be hit in normal operation.