### PR TITLE
Use both mongodb and openssl extension paths for CHECK_LIB

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -126,9 +126,15 @@ if (PHP_MONGODB != "no") {
     MONGOC_USER_SET_LDFLAGS: ""
   };
 
-  if (CHECK_LIB("ssleay32.lib", "mongodb", PHP_MONGODB) &&
-      CHECK_LIB("libeay32.lib", "mongodb", PHP_MONGODB) &&
-      CHECK_LIB("crypt32.lib", "mongodb", PHP_MONGODB) &&
+  var mongoc_ssl_path_to_check = PHP_MONGODB;
+
+  if (typeof PHP_OPENSSL === 'string') {
+    mongoc_ssl_path_to_check += ";" + PHP_OPENSSL;
+  }
+
+  if (CHECK_LIB("ssleay32.lib", "mongodb", mongoc_ssl_path_to_check) &&
+      CHECK_LIB("libeay32.lib", "mongodb", mongoc_ssl_path_to_check) &&
+      CHECK_LIB("crypt32.lib", "mongodb") &&
       CHECK_HEADER_ADD_INCLUDE("openssl/ssl.h", "CFLAGS_MONGODB")) {
     mongoc_opts.MONGOC_ENABLE_SSL_OPENSSL = 1;
     mongoc_opts.MONGOC_ENABLE_CRYPTO_LIBCRYPTO = 1;


### PR DESCRIPTION
The ldap extensions' [config.w32](https://github.com/php/php-src/blob/php-7.0.10/ext/ldap/config.w32) uses `PHP_LDAP` as its search path, so we'll continue to start with `PHP_MONGODB` as a rule of thumb. Since we currently declare a dependency on the OpenSSL extension, it makes sense to also include it in our search path in case it was customized at build time.

Based on the openssl extension's [config.w32](https://github.com/php/php-src/blob/php-7.0.10/ext/openssl/config.w32), crypt32.lib is a system library and needs no extra search path.