### PR TITLE
Use string literal php_array macros where possible

### DIFF
--- a/src/MongoDB/BulkWrite.c
+++ b/src/MongoDB/BulkWrite.c
@@ -69,8 +69,8 @@ PHP_METHOD(BulkWrite, __construct)
 	}
 	zend_restore_error_handling(&error_handling TSRMLS_CC);
 
-	if (options && php_array_exists(options, "ordered")) {
-		ordered = php_array_fetch_bool(options, "ordered");
+	if (options && php_array_existsc(options, "ordered")) {
+		ordered = php_array_fetchc_bool(options, "ordered");
 	}
 
 	intern->bulk = phongo_bulkwrite_init(ordered);
@@ -78,8 +78,8 @@ PHP_METHOD(BulkWrite, __construct)
 	intern->bypass = BYPASS_UNSET;
 	intern->num_ops = 0;
 
-	if (options && php_array_exists(options, "bypassDocumentValidation")) {
-		zend_bool bypass = php_array_fetch_bool(options, "bypassDocumentValidation");
+	if (options && php_array_existsc(options, "bypassDocumentValidation")) {
+		zend_bool bypass = php_array_fetchc_bool(options, "bypassDocumentValidation");
 		mongoc_bulk_operation_set_bypass_document_validation(intern->bulk, bypass);
 		intern->bypass = bypass;
 	}
@@ -159,8 +159,8 @@ PHP_METHOD(BulkWrite, update)
 	phongo_zval_to_bson(newObj, PHONGO_BSON_NONE, bupdate, NULL TSRMLS_CC);
 
 	if (updateOptions) {
-		flags |= php_array_fetch_bool(updateOptions, "multi") ?  MONGOC_UPDATE_MULTI_UPDATE : 0;
-		flags |= php_array_fetch_bool(updateOptions, "upsert") ? MONGOC_UPDATE_UPSERT : 0;
+		flags |= php_array_fetchc_bool(updateOptions, "multi") ?  MONGOC_UPDATE_MULTI_UPDATE : 0;
+		flags |= php_array_fetchc_bool(updateOptions, "upsert") ? MONGOC_UPDATE_UPSERT : 0;
 	}
 
 	if (flags & MONGOC_UPDATE_MULTI_UPDATE) {
@@ -212,7 +212,7 @@ PHP_METHOD(BulkWrite, delete)
 	bson = bson_new();
 	phongo_zval_to_bson(query, PHONGO_BSON_NONE, bson, NULL TSRMLS_CC);
 
-	if (deleteOptions && php_array_fetch_bool(deleteOptions, "limit")) {
+	if (deleteOptions && php_array_fetchc_bool(deleteOptions, "limit")) {
 		mongoc_bulk_operation_remove_one(intern->bulk, bson);
 	} else {
 		mongoc_bulk_operation_remove(intern->bulk, bson);

--- a/src/bson.c
+++ b/src/bson.c
@@ -1559,7 +1559,7 @@ PHONGO_API void phongo_bson_typemap_to_state(zval *typemap, php_phongo_bson_type
 		int        classname_len;
 		zend_bool  classname_free = 0;
 
-		classname = php_array_fetchl_string(typemap, "array", sizeof("array")-1, &classname_len, &classname_free);
+		classname = php_array_fetchc_string(typemap, "array", &classname_len, &classname_free);
 		if (classname_len) {
 			apply_classname_to_state(classname, classname_len, &map->array_type, &map->array TSRMLS_CC);
 		}
@@ -1567,7 +1567,7 @@ PHONGO_API void phongo_bson_typemap_to_state(zval *typemap, php_phongo_bson_type
 			str_efree(classname);
 		}
 
-		classname = php_array_fetchl_string(typemap, "document", sizeof("document")-1, &classname_len, &classname_free);
+		classname = php_array_fetchc_string(typemap, "document", &classname_len, &classname_free);
 		if (classname_len) {
 			apply_classname_to_state(classname, classname_len, &map->document_type, &map->document TSRMLS_CC);
 		}
@@ -1575,7 +1575,7 @@ PHONGO_API void phongo_bson_typemap_to_state(zval *typemap, php_phongo_bson_type
 			str_efree(classname);
 		}
 
-		classname = php_array_fetchl_string(typemap, "root", sizeof("root")-1, &classname_len, &classname_free);
+		classname = php_array_fetchc_string(typemap, "root", &classname_len, &classname_free);
 		if (classname_len) {
 			apply_classname_to_state(classname, classname_len, &map->root_type, &map->root TSRMLS_CC);
 		}


### PR DESCRIPTION
This updates a few cases where we were already passing string literals to the php_array macros. The "c" variant expands to `lit, sizeof(lit) - 1` instead of `lit, strlen(lit)`.