### PR TITLE
PHPC-796, PHPC-794, and PHPC-734: Flexible opts API and collation option for BulkWrite

### DIFF
--- a/src/MongoDB/BulkWrite.c
+++ b/src/MongoDB/BulkWrite.c
@@ -242,6 +242,16 @@ PHP_METHOD(BulkWrite, update)
 			goto cleanup;
 		}
 	} else {
+		if (!bson_validate(bupdate, BSON_VALIDATE_DOT_KEYS|BSON_VALIDATE_DOLLAR_KEYS, NULL)) {
+			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Replacement document may not contain \"$\" or \".\" in keys");
+			goto cleanup;
+		}
+
+		if (zoptions && php_array_existsc(zoptions, "multi") && php_array_fetchc_bool(zoptions, "multi")) {
+			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Replacement document conflicts with true \"multi\" option");
+			goto cleanup;
+		}
+
 		if (!mongoc_bulk_operation_replace_one_with_opts(intern->bulk, bquery, bupdate, boptions, &error)) {
 			phongo_throw_exception_from_bson_error_t(&error TSRMLS_CC);
 			goto cleanup;

--- a/tests/bulk/bulkwrite-update_error-001.phpt
+++ b/tests/bulk/bulkwrite-update_error-001.phpt
@@ -13,8 +13,11 @@ echo throws(function() use ($bulk) {
 
 echo throws(function() use ($bulk) {
     $bulk->update(['x' => 1], ['y' => 1], ['multi' => true]);
-}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n\n";
 
+echo throws(function() use ($bulk) {
+    $bulk->update([], [], ['collation' => 1]);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 ?>
 ===DONE===
 <?php exit(0); ?>
@@ -24,4 +27,7 @@ Replacement document may not contain "$" or "." in keys
 
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Replacement document conflicts with true "multi" option
+
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "collation" option to be array or object, integer given
 ===DONE===

--- a/tests/bulk/bulkwrite-update_error-001.phpt
+++ b/tests/bulk/bulkwrite-update_error-001.phpt
@@ -1,0 +1,27 @@
+--TEST--
+MongoDB\Driver\BulkWrite::update() with invalid options
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/tools.php';
+
+$bulk = new MongoDB\Driver\BulkWrite;
+
+echo throws(function() use ($bulk) {
+    $bulk->update(['x' => 1], ['x.y' => 1]);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n\n";
+
+echo throws(function() use ($bulk) {
+    $bulk->update(['x' => 1], ['y' => 1], ['multi' => true]);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Replacement document may not contain "$" or "." in keys
+
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Replacement document conflicts with true "multi" option
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-734
https://jira.mongodb.org/browse/PHPC-794
https://jira.mongodb.org/browse/PHPC-796

This migrates the `BulkWrite::update()` and `delete()` methods to use libmongoc's flexible options API ([CDRIVER-1525](https://jira.mongodb.org/browse/CDRIVER-1525)) and adds support for a collation option. Additionally, we now check for invalid arguments for a replace operation.