### PR TITLE
PHPC-734: Test for BulkWrite::delete() collation option error

### DIFF
--- a/tests/bulk/bulkwrite-delete_error-001.phpt
+++ b/tests/bulk/bulkwrite-delete_error-001.phpt
@@ -1,0 +1,20 @@
+--TEST--
+MongoDB\Driver\BulkWrite::delete() with invalid options
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/tools.php';
+
+$bulk = new MongoDB\Driver\BulkWrite;
+
+echo throws(function() use ($bulk) {
+    $bulk->update([], [], ['collation' => 1]);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "collation" option to be array or object, integer given
+===DONE===


### PR DESCRIPTION
This should have been included with https://github.com/mongodb/mongo-php-driver/pull/419