### PR TITLE
PHPC-829: BSON Regex flags must be alphabetically ordered

### DIFF
--- a/src/BSON/Regex.c
+++ b/src/BSON/Regex.c
@@ -53,6 +53,15 @@ PHONGO_API zend_class_entry *php_phongo_regex_ce;
 
 zend_object_handlers php_phongo_handler_regex;
 
+/* qsort() compare callback for alphabetizing regex flags upon initialization */
+static int php_phongo_regex_compare_flags(const void *f1, const void *f2) {
+	if (* (const char *) f1 == * (const char *) f2) {
+		return 0;
+	}
+
+	return (* (const char *) f1 > * (const char *) f2) ? 1 : -1;
+}
+
 /* Initialize the object and return whether it was successful. An exception will
  * be thrown on error. */
 static bool php_phongo_regex_init(php_phongo_regex_t *intern, const char *pattern, phongo_zpp_char_len pattern_len, const char *flags, phongo_zpp_char_len flags_len TSRMLS_DC)
@@ -71,6 +80,8 @@ static bool php_phongo_regex_init(php_phongo_regex_t *intern, const char *patter
 		}
 		intern->flags = estrndup(flags, flags_len);
 		intern->flags_len = flags_len;
+		/* Ensure flags are alphabetized upon initialization */
+		qsort((void *) intern->flags, flags_len, 1, php_phongo_regex_compare_flags);
 	} else {
 		intern->flags = estrdup("");
 		intern->flags_len = 0;

--- a/tests/bson/bson-regex-005.phpt
+++ b/tests/bson/bson-regex-005.phpt
@@ -1,0 +1,20 @@
+--TEST--
+MongoDB\BSON\Regex initialization will alphabetize flags
+--FILE--
+<?php
+
+$regex = new MongoDB\BSON\Regex('regexp', 'xusmli');
+
+var_dump($regex);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+object(MongoDB\BSON\Regex)#%d (%d) {
+  ["pattern"]=>
+  string(6) "regexp"
+  ["flags"]=>
+  string(6) "ilmsux"
+}
+===DONE===

--- a/tests/bson/bson-regex-serialization-003.phpt
+++ b/tests/bson/bson-regex-serialization-003.phpt
@@ -1,0 +1,18 @@
+--TEST--
+MongoDB\BSON\Regex unserialization will alphabetize flags
+--FILE--
+<?php
+
+var_dump(unserialize('C:18:"MongoDB\BSON\Regex":58:{a:2:{s:7:"pattern";s:6:"regexp";s:5:"flags";s:6:"xusmli";}}'));
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+object(MongoDB\BSON\Regex)#%d (%d) {
+  ["pattern"]=>
+  string(6) "regexp"
+  ["flags"]=>
+  string(6) "ilmsux"
+}
+===DONE===

--- a/tests/bson/bson-regex-set_state-002.phpt
+++ b/tests/bson/bson-regex-set_state-002.phpt
@@ -1,0 +1,20 @@
+--TEST--
+MongoDB\BSON\Regex::__set_state() will alphabetize flags
+--FILE--
+<?php
+
+var_export(MongoDB\BSON\Regex::__set_state([
+    'pattern' => 'regexp',
+    'flags' => 'xusmli',
+]));
+echo "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+MongoDB\BSON\Regex::__set_state(array(
+%w'pattern' => 'regexp',
+%w'flags' => 'ilmsux',
+))
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-829

We do not test that MongoDB\BSON\fromJSON() alphabetizes the flags, as that will be handled by CDRIVER-1883.