### PR TITLE
Ensure php_phongo_bson_visit_int64() has TSRMLS vars if needed

### DIFF
--- a/src/bson.c
+++ b/src/bson.c
@@ -530,7 +530,7 @@ bool php_phongo_bson_visit_int64(const bson_iter_t *iter ARG_UNUSED, const char 
 #else
 	zval *retval = ((php_phongo_bson_state *)data)->zchild;
 #endif
-
+	TSRMLS_FETCH();
 
 	ADD_ASSOC_INT64(retval, key, v_int64);
 


### PR DESCRIPTION
Fixes a 32-bit build error introduced in 22a39d68f3661438be6d6820faf508a5bc98d084 for PHPC-313