### PR TITLE
Print a custom error message on platforms with ext/json as shared extension

### DIFF
--- a/php_phongo.c
+++ b/php_phongo.c
@@ -2016,6 +2016,18 @@ static void php_phongo_client_dtor(void *client)
 }
 #endif
 
+static void _phongo_check_json (void) __attribute__((constructor));
+static void _phongo_check_json (void)
+{
+	DL_HANDLE handle = DL_LOAD(NULL);
+	zend_class_entry *json = (zend_class_entry *)DL_FETCH_SYMBOL (handle, "php_json_serializable_ce");
+
+	if (json == NULL) {
+		fprintf (stderr, "Please make sure json.so is loaded before mongodb.so\n");
+		fflush (stderr);
+	}
+}
+
 /* {{{ PHP_MINIT_FUNCTION */
 PHP_MINIT_FUNCTION(mongodb)
 {

--- a/src/BSON/Binary.c
+++ b/src/BSON/Binary.c
@@ -452,6 +452,7 @@ HashTable *php_phongo_binary_get_properties(zval *object TSRMLS_DC) /* {{{ */
 PHP_MINIT_FUNCTION(Binary)
 {
 	zend_class_entry ce;
+	zend_string *zstr = zend_string_init("jsonserializable", sizeof("jsonserializable") - 1, 0);
 	(void)type;(void)module_number;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "Binary", php_phongo_binary_me);
@@ -459,7 +460,8 @@ PHP_MINIT_FUNCTION(Binary)
 	php_phongo_binary_ce->create_object = php_phongo_binary_create_object;
 	PHONGO_CE_FINAL(php_phongo_binary_ce);
 
-	zend_class_implements(php_phongo_binary_ce TSRMLS_CC, 1, php_json_serializable_ce);
+	zend_class_implements(php_phongo_binary_ce TSRMLS_CC, 1, zend_hash_find_ptr(CG(class_table), zstr));
+	zend_string_release(zstr);
 	zend_class_implements(php_phongo_binary_ce TSRMLS_CC, 1, php_phongo_type_ce);
 	zend_class_implements(php_phongo_binary_ce TSRMLS_CC, 1, zend_ce_serializable);
 

--- a/src/BSON/Decimal128.c
+++ b/src/BSON/Decimal128.c
@@ -367,6 +367,7 @@ HashTable *php_phongo_decimal128_get_properties(zval *object TSRMLS_DC) /* {{{ *
 PHP_MINIT_FUNCTION(Decimal128)
 {
 	zend_class_entry ce;
+	zend_string *zstr = zend_string_init("jsonserializable", sizeof("jsonserializable") - 1, 0);
 	(void)type;(void)module_number;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "Decimal128", php_phongo_decimal128_me);
@@ -374,7 +375,8 @@ PHP_MINIT_FUNCTION(Decimal128)
 	php_phongo_decimal128_ce->create_object = php_phongo_decimal128_create_object;
 	PHONGO_CE_FINAL(php_phongo_decimal128_ce);
 
-	zend_class_implements(php_phongo_decimal128_ce TSRMLS_CC, 1, php_json_serializable_ce);
+	zend_class_implements(php_phongo_decimal128_ce TSRMLS_CC, 1, zend_hash_find_ptr(CG(class_table), zstr));
+	zend_string_release(zstr);
 	zend_class_implements(php_phongo_decimal128_ce TSRMLS_CC, 1, php_phongo_type_ce);
 	zend_class_implements(php_phongo_decimal128_ce TSRMLS_CC, 1, zend_ce_serializable);
 

--- a/src/BSON/Javascript.c
+++ b/src/BSON/Javascript.c
@@ -531,6 +531,7 @@ HashTable *php_phongo_javascript_get_properties(zval *object TSRMLS_DC) /* {{{ *
 PHP_MINIT_FUNCTION(Javascript)
 {
 	zend_class_entry ce;
+	zend_string *zstr = zend_string_init("jsonserializable", sizeof("jsonserializable") - 1, 0);
 	(void)type;(void)module_number;
 
 
@@ -539,7 +540,8 @@ PHP_MINIT_FUNCTION(Javascript)
 	php_phongo_javascript_ce->create_object = php_phongo_javascript_create_object;
 	PHONGO_CE_FINAL(php_phongo_javascript_ce);
 
-	zend_class_implements(php_phongo_javascript_ce TSRMLS_CC, 1, php_json_serializable_ce);
+	zend_class_implements(php_phongo_javascript_ce TSRMLS_CC, 1, zend_hash_find_ptr(CG(class_table), zstr));
+	zend_string_release(zstr);
 	zend_class_implements(php_phongo_javascript_ce TSRMLS_CC, 1, php_phongo_type_ce);
 	zend_class_implements(php_phongo_javascript_ce TSRMLS_CC, 1, zend_ce_serializable);
 

--- a/src/BSON/MaxKey.c
+++ b/src/BSON/MaxKey.c
@@ -164,6 +164,7 @@ phongo_create_object_retval php_phongo_maxkey_create_object(zend_class_entry *cl
 PHP_MINIT_FUNCTION(MaxKey)
 {
 	zend_class_entry ce;
+	zend_string *zstr = zend_string_init("jsonserializable", sizeof("jsonserializable") - 1, 0);
 	(void)type;(void)module_number;
 
 
@@ -172,7 +173,8 @@ PHP_MINIT_FUNCTION(MaxKey)
 	php_phongo_maxkey_ce->create_object = php_phongo_maxkey_create_object;
 	PHONGO_CE_FINAL(php_phongo_maxkey_ce);
 
-	zend_class_implements(php_phongo_maxkey_ce TSRMLS_CC, 1, php_json_serializable_ce);
+	zend_class_implements(php_phongo_maxkey_ce TSRMLS_CC, 1, zend_hash_find_ptr(CG(class_table), zstr));
+	zend_string_release(zstr);
 	zend_class_implements(php_phongo_maxkey_ce TSRMLS_CC, 1, php_phongo_type_ce);
 	zend_class_implements(php_phongo_maxkey_ce TSRMLS_CC, 1, zend_ce_serializable);
 

--- a/src/BSON/MinKey.c
+++ b/src/BSON/MinKey.c
@@ -165,6 +165,7 @@ phongo_create_object_retval php_phongo_minkey_create_object(zend_class_entry *cl
 PHP_MINIT_FUNCTION(MinKey)
 {
 	zend_class_entry ce;
+	zend_string *zstr = zend_string_init("jsonserializable", sizeof("jsonserializable") - 1, 0);
 	(void)type;(void)module_number;
 
 
@@ -173,7 +174,8 @@ PHP_MINIT_FUNCTION(MinKey)
 	php_phongo_minkey_ce->create_object = php_phongo_minkey_create_object;
 	PHONGO_CE_FINAL(php_phongo_minkey_ce);
 
-	zend_class_implements(php_phongo_minkey_ce TSRMLS_CC, 1, php_json_serializable_ce);
+	zend_class_implements(php_phongo_minkey_ce TSRMLS_CC, 1, zend_hash_find_ptr(CG(class_table), zstr));
+	zend_string_release(zstr);
 	zend_class_implements(php_phongo_minkey_ce TSRMLS_CC, 1, php_phongo_type_ce);
 	zend_class_implements(php_phongo_minkey_ce TSRMLS_CC, 1, zend_ce_serializable);
 

--- a/src/BSON/ObjectID.c
+++ b/src/BSON/ObjectID.c
@@ -417,6 +417,7 @@ HashTable *php_phongo_objectid_get_properties(zval *object TSRMLS_DC) /* {{{ */
 PHP_MINIT_FUNCTION(ObjectID)
 {
 	zend_class_entry ce;
+	zend_string *zstr = zend_string_init("jsonserializable", sizeof("jsonserializable") - 1, 0);
 	(void)type;(void)module_number;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "ObjectID", php_phongo_objectid_me);
@@ -424,7 +425,8 @@ PHP_MINIT_FUNCTION(ObjectID)
 	php_phongo_objectid_ce->create_object = php_phongo_objectid_create_object;
 	PHONGO_CE_FINAL(php_phongo_objectid_ce);
 
-	zend_class_implements(php_phongo_objectid_ce TSRMLS_CC, 1, php_json_serializable_ce);
+	zend_class_implements(php_phongo_objectid_ce TSRMLS_CC, 1, zend_hash_find_ptr(CG(class_table), zstr));
+	zend_string_release(zstr);
 	zend_class_implements(php_phongo_objectid_ce TSRMLS_CC, 1, php_phongo_type_ce);
 	zend_class_implements(php_phongo_objectid_ce TSRMLS_CC, 1, zend_ce_serializable);
 

--- a/src/BSON/Regex.c
+++ b/src/BSON/Regex.c
@@ -464,6 +464,7 @@ HashTable *php_phongo_regex_get_properties(zval *object TSRMLS_DC) /* {{{ */
 PHP_MINIT_FUNCTION(Regex)
 {
 	zend_class_entry ce;
+	zend_string *zstr = zend_string_init("jsonserializable", sizeof("jsonserializable") - 1, 0);
 	(void)type;(void)module_number;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "Regex", php_phongo_regex_me);
@@ -471,9 +472,10 @@ PHP_MINIT_FUNCTION(Regex)
 	php_phongo_regex_ce->create_object = php_phongo_regex_create_object;
 	PHONGO_CE_FINAL(php_phongo_regex_ce);
 
+	zend_class_implements(php_phongo_regex_ce TSRMLS_CC, 1, zend_hash_find_ptr(CG(class_table), zstr));
+	zend_string_release(zstr);
 	zend_class_implements(php_phongo_regex_ce TSRMLS_CC, 1, php_phongo_type_ce);
 	zend_class_implements(php_phongo_regex_ce TSRMLS_CC, 1, zend_ce_serializable);
-	zend_class_implements(php_phongo_regex_ce TSRMLS_CC, 1, php_json_serializable_ce);
 
 	memcpy(&php_phongo_handler_regex, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 	php_phongo_handler_regex.compare_objects = php_phongo_regex_compare_objects;

--- a/src/BSON/Timestamp.c
+++ b/src/BSON/Timestamp.c
@@ -497,6 +497,7 @@ HashTable *php_phongo_timestamp_get_properties(zval *object TSRMLS_DC) /* {{{ */
 PHP_MINIT_FUNCTION(Timestamp)
 {
 	zend_class_entry ce;
+	zend_string *zstr = zend_string_init("jsonserializable", sizeof("jsonserializable") - 1, 0);
 	(void)type;(void)module_number;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "Timestamp", php_phongo_timestamp_me);
@@ -504,7 +505,8 @@ PHP_MINIT_FUNCTION(Timestamp)
 	php_phongo_timestamp_ce->create_object = php_phongo_timestamp_create_object;
 	PHONGO_CE_FINAL(php_phongo_timestamp_ce);
 
-	zend_class_implements(php_phongo_timestamp_ce TSRMLS_CC, 1, php_json_serializable_ce);
+	zend_class_implements(php_phongo_timestamp_ce TSRMLS_CC, 1, zend_hash_find_ptr(CG(class_table), zstr));
+	zend_string_release(zstr);
 	zend_class_implements(php_phongo_timestamp_ce TSRMLS_CC, 1, php_phongo_type_ce);
 	zend_class_implements(php_phongo_timestamp_ce TSRMLS_CC, 1, zend_ce_serializable);
 

--- a/src/BSON/UTCDateTime.c
+++ b/src/BSON/UTCDateTime.c
@@ -542,6 +542,7 @@ HashTable *php_phongo_utcdatetime_get_properties(zval *object TSRMLS_DC) /* {{{ 
 PHP_MINIT_FUNCTION(UTCDateTime)
 {
 	zend_class_entry ce;
+	zend_string *zstr = zend_string_init("jsonserializable", sizeof("jsonserializable") - 1, 0);
 	(void)type;(void)module_number;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "UTCDateTime", php_phongo_utcdatetime_me);
@@ -549,7 +550,8 @@ PHP_MINIT_FUNCTION(UTCDateTime)
 	php_phongo_utcdatetime_ce->create_object = php_phongo_utcdatetime_create_object;
 	PHONGO_CE_FINAL(php_phongo_utcdatetime_ce);
 
-	zend_class_implements(php_phongo_utcdatetime_ce TSRMLS_CC, 1, php_json_serializable_ce);
+	zend_class_implements(php_phongo_utcdatetime_ce TSRMLS_CC, 1, zend_hash_find_ptr(CG(class_table), zstr));
+	zend_string_release(zstr);
 	zend_class_implements(php_phongo_utcdatetime_ce TSRMLS_CC, 1, php_phongo_type_ce);
 	zend_class_implements(php_phongo_utcdatetime_ce TSRMLS_CC, 1, zend_ce_serializable);
 


### PR DESCRIPTION
Before:
```
$ php -n -dextension=modules/mongodb.so -r 'echo phpversion("mongodb"), "\n";'
PHP Warning:  PHP Startup: Unable to load dynamic library 'modules/mongodb.so' - modules/mongodb.so: undefined symbol: php_json_serializable_ce in Unknown on line 0
```
After:
```
$ php -n -dextension=modules/mongodb.so -r 'echo phpversion("mongodb"), "\n";'
Please make sure json.so is loaded before mongodb.so
PHP Warning:  Cannot load module 'mongodb' because required module 'json' is not loaded in Unknown on line 0
```
