### PR TITLE
PHPC-848: Consult ZEND_HASH_APPLY_PROTECTION() in PHP7

### DIFF
--- a/phongo_compat.h
+++ b/phongo_compat.h
@@ -167,7 +167,10 @@
 # define Z_ISUNDEF(x) !x
 # define phongo_free_object_arg void
 # define phongo_zpp_char_len int
-# define ZEND_HASH_APPLY_COUNT(ht) (ht)->nApplyCount
+# define ZEND_HASH_APPLY_PROTECTION(ht) true
+# define ZEND_HASH_GET_APPLY_COUNT(ht) ((ht)->nApplyCount)
+# define ZEND_HASH_DEC_APPLY_COUNT(ht) ((ht)->nApplyCount -= 1)
+# define ZEND_HASH_INC_APPLY_COUNT(ht) ((ht)->nApplyCount += 1)
 # define PHONGO_RETVAL_STRINGL(s, slen) RETVAL_STRINGL(s, slen, 1)
 # define PHONGO_RETURN_STRINGL(s, slen) RETURN_STRINGL(s, slen, 1)
 # define PHONGO_RETURN_STRING(s) RETURN_STRING(s, 1)

--- a/src/bson.c
+++ b/src/bson.c
@@ -862,8 +862,8 @@ void object_to_bson(zval *object, php_phongo_bson_flags_t flags, const char *key
 			tmp_ht = HASH_OF(obj_data);
 #endif
 
-			if (tmp_ht) {
-				ZEND_HASH_APPLY_COUNT(tmp_ht)++;
+			if (tmp_ht && ZEND_HASH_APPLY_PROTECTION(tmp_ht)) {
+				ZEND_HASH_INC_APPLY_COUNT(tmp_ht);
 			}
 
 			/* Persistable objects must always be serialized as BSON documents;
@@ -897,8 +897,8 @@ void object_to_bson(zval *object, php_phongo_bson_flags_t flags, const char *key
 				bson_append_array_end(bson, &child);
 			}
 
-			if (tmp_ht) {
-				ZEND_HASH_APPLY_COUNT(tmp_ht)--;
+			if (tmp_ht && ZEND_HASH_APPLY_PROTECTION(tmp_ht)) {
+				ZEND_HASH_DEC_APPLY_COUNT(tmp_ht);
 			}
 			zval_ptr_dtor(&obj_data);
 			return;
@@ -970,12 +970,22 @@ void object_to_bson(zval *object, php_phongo_bson_flags_t flags, const char *key
 		phongo_throw_exception(PHONGO_ERROR_UNEXPECTED_VALUE TSRMLS_CC, "Unexpected %s instance: %s", php_phongo_type_ce->name, Z_OBJCE_P(object)->name);
 #endif
 		return;
-	}
+	} else {
+		HashTable *tmp_ht = HASH_OF(object);
 
-	mongoc_log(MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, "encoding document");
-	bson_append_document_begin(bson, key, key_len, &child);
-	phongo_zval_to_bson(object, flags, &child, NULL TSRMLS_CC);
-	bson_append_document_end(bson, &child);
+		if (tmp_ht && ZEND_HASH_APPLY_PROTECTION(tmp_ht)) {
+			ZEND_HASH_INC_APPLY_COUNT(tmp_ht);
+		}
+
+		mongoc_log(MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, "encoding document");
+		bson_append_document_begin(bson, key, key_len, &child);
+		phongo_zval_to_bson(object, flags, &child, NULL TSRMLS_CC);
+		bson_append_document_end(bson, &child);
+
+		if (tmp_ht && ZEND_HASH_APPLY_PROTECTION(tmp_ht)) {
+			ZEND_HASH_DEC_APPLY_COUNT(tmp_ht);
+		}
+	}
 }
 
 static void phongo_bson_append(bson_t *bson, php_phongo_bson_flags_t flags, const char *key, long key_len, zval *entry TSRMLS_DC)
@@ -1023,16 +1033,16 @@ try_again:
 				bson_t     child;
 				HashTable *tmp_ht = HASH_OF(entry);
 
-				if (tmp_ht) {
-					ZEND_HASH_APPLY_COUNT(tmp_ht)++;
+				if (tmp_ht && ZEND_HASH_APPLY_PROTECTION(tmp_ht)) {
+					ZEND_HASH_INC_APPLY_COUNT(tmp_ht);
 				}
 
 				bson_append_array_begin(bson, key, key_len, &child);
 				phongo_zval_to_bson(entry, flags, &child, NULL TSRMLS_CC);
 				bson_append_array_end(bson, &child);
 
-				if (tmp_ht) {
-					ZEND_HASH_APPLY_COUNT(tmp_ht)--;
+				if (tmp_ht && ZEND_HASH_APPLY_PROTECTION(tmp_ht)) {
+					ZEND_HASH_DEC_APPLY_COUNT(tmp_ht);
 				}
 				break;
 			}
@@ -1191,7 +1201,7 @@ PHONGO_API void phongo_zval_to_bson(zval *data, php_phongo_bson_flags_t flags, b
 			return;
 	}
 
-	if (!ht_data || ZEND_HASH_APPLY_COUNT(ht_data) > 1) {
+	if (!ht_data || ZEND_HASH_GET_APPLY_COUNT(ht_data) > 1) {
 #if PHP_VERSION_ID >= 70000
 		if (Z_TYPE_P(data) == IS_OBJECT && instanceof_function(Z_OBJCE_P(data), php_phongo_serializable_ce TSRMLS_CC)) {
 #endif

--- a/tests/bson/bson-fromPHP-004.phpt
+++ b/tests/bson/bson-fromPHP-004.phpt
@@ -1,0 +1,38 @@
+--TEST--
+BSON\fromPHP(): PHP documents with circular references
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/tools.php';
+
+echo "\nTesting packed array with circular reference\n";
+
+$document = ['x' => 1, 'y' => []];
+$document['y'][] = &$document['y'];
+echo toJson(fromPHP($document)), "\n";
+
+echo "\nTesting associative array with circular reference\n";
+
+$document = ['x' => 1, 'y' => []];
+$document['y']['z'] = &$document['y'];
+echo toJson(fromPHP($document)), "\n";
+
+echo "\nTesting object with circular reference\n";
+
+$document = (object) ['x' => 1, 'y' => (object) []];
+$document->y->z = &$document->y;
+echo toJson(fromPHP($document)), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+Testing packed array with circular reference
+{ "x" : 1, "y" : [ [  ] ] }
+
+Testing associative array with circular reference
+{ "x" : 1, "y" : { "z" : {  } } }
+
+Testing object with circular reference
+{ "x" : 1, "y" : { "z" : {  } } }
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-848

When a numeric array was encoded to BSON, the hash's apply counter was incremented and decremented irrespective of whether apply protection was enabled. This was not compatible with immutable arrays, which may be created by OPcache. We now consult ZEND_HASH_APPLY_PROTECTION() whenever an apply counter might be modified.

Previously, object_to_bson() incremented the apply counter when converting a MongoDB\BSON\Type instance. Associative arrays and other objects were not protected. This patch adds recursion checking for those types.

Since PHP7 already has macros for working with the apply counter, this patch adds equivalent macros for PHP 5.x.

Related issues:
 * https://github.com/mongodb/mongo-php-library/issues/216
 * https://github.com/jbboehr/php-mustache/pull/29
