### PR TITLE
Only fetch TSRMLS for 32-bit platforms in int64 visitor

### DIFF
--- a/src/bson.c
+++ b/src/bson.c
@@ -530,7 +530,9 @@ bool php_phongo_bson_visit_int64(const bson_iter_t *iter ARG_UNUSED, const char 
 #else
 	zval *retval = ((php_phongo_bson_state *)data)->zchild;
 #endif
+#if SIZEOF_PHONGO_LONG == 4
 	TSRMLS_FETCH();
+#endif
 
 	ADD_ASSOC_INT64(retval, key, v_int64);
 


### PR DESCRIPTION
This fixes a build error introduced in be58940cd9c1373dad97d0e4364e4b61881022b2.