### PR TITLE
PHPC-872: Do not use system crypto policy for OpenSSL on Windows

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -149,7 +149,6 @@ if (PHP_MONGODB != "no") {
     mongoc_opts.MONGOC_ENABLE_CRYPTO_LIBCRYPTO = 1;
     mongoc_opts.MONGOC_ENABLE_SSL = 1;
     mongoc_opts.MONGOC_ENABLE_CRYPTO = 1;
-    mongoc_opts.MONGOC_ENABLE_CRYPTO_SYSTEM_PROFILE = 1;
   } else {
     WARNING("mongodb libopenssl support not enabled, libs not found");
   }


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-872

This flag is primarily intended for Linux distributions with custom profiles (e.g. Fedora). d227207f970e590c3149979a675b17a0362145fa for PHPC-703 incorrectly assumed that libmongoc was enabling it by default on Windows.