### PR TITLE
PHPC-884: Do not skip public property with empty string name during BSON encoding

### DIFF
--- a/src/bson.c
+++ b/src/bson.c
@@ -1271,44 +1271,6 @@ try_again:
 	}
 }
 
-#if PHP_VERSION_ID >= 70000
-static bool is_public_property(zend_class_entry *ce, zend_string *name, zend_string **member TSRMLS_DC) /* {{{ */
-#else
-static bool is_public_property(zend_class_entry *ce, const char *prop_name, int prop_name_len TSRMLS_DC) /* {{{ */
-#endif
-{
-	zend_property_info *property_info = NULL;
-
-#if PHP_VERSION_ID >= 70000
-	if (ZSTR_VAL(name)[0] == 0) {
-		const char *prop_name,
-			 *class_name;
-		size_t prop_name_len;
-
-		zend_unmangle_property_name_ex(name,
-			&class_name, &prop_name, &prop_name_len);
-		(*member) = zend_string_init(prop_name, prop_name_len, 0);
-	} else (*member) = zend_string_copy(name);
-	property_info = zend_get_property_info(ce, (*member), 1 TSRMLS_CC);
-
-	if (!property_info) /* undefined property */
-		return true;
-
-	if (property_info == ZEND_WRONG_PROPERTY_INFO) {
-		return false;
-	}
-	
-	return (property_info->flags & ZEND_ACC_PUBLIC);
-#else
-	zval member;
-	ZVAL_STRINGL(&member, prop_name, prop_name_len, 0);
-	property_info = zend_get_property_info(ce, &member, 1 TSRMLS_CC);
-
-	return (property_info && (property_info->flags & ZEND_ACC_PUBLIC));
-#endif
-}
-/* }}} */
-
 void phongo_zval_to_bson(zval *data, php_phongo_bson_flags_t flags, bson_t *bson, bson_t **bson_out TSRMLS_DC) /* {{{ */
 {
 	HashTable   *ht_data = NULL;
@@ -1422,6 +1384,22 @@ void phongo_zval_to_bson(zval *data, php_phongo_bson_flags_t flags, bson_t *bson
 		zval        *value;
 
 		ZEND_HASH_FOREACH_KEY_VAL(ht_data, num_key, string_key, value) {
+			if (string_key) {
+				if (ht_data_from_properties) {
+					/* Skip protected and private properties */
+					if (ZSTR_VAL(string_key)[0] == '\0' && ZSTR_LEN(string_key) > 0) {
+						zend_string_release(string_key);
+						continue;
+					}
+				}
+
+				if (flags & PHONGO_BSON_ADD_ID) {
+					if (!strcmp(ZSTR_VAL(string_key), "_id")) {
+						flags &= ~PHONGO_BSON_ADD_ID;
+					}
+				}
+			}
+
 			/* Ensure we're working with a string key */
 			if (!string_key) {
 				string_key = zend_long_to_str(num_key);
@@ -1429,41 +1407,7 @@ void phongo_zval_to_bson(zval *data, php_phongo_bson_flags_t flags, bson_t *bson
 				zend_string_addref(string_key);
 			}
 
-			if (Z_TYPE_P(data) == IS_OBJECT) {
-				zend_string *member = NULL;
-
-				/* Ignore non-public properties */
-				if (!instanceof_function(Z_OBJCE_P(data), php_phongo_serializable_ce) &&
-					!is_public_property(Z_OBJCE_P(data), string_key, &member TSRMLS_CC)) {
-					if (member) {
-						zend_string_release(member);
-					}
-					zend_string_release(string_key);
-					continue;
-				}
-
-				if (flags & PHONGO_BSON_ADD_ID) {
-					if (!strcmp(member ? ZSTR_VAL(member) : ZSTR_VAL(string_key), "_id")) {
-						flags &= ~PHONGO_BSON_ADD_ID;
-					}
-				}
-
-				phongo_bson_append(bson, flags & ~PHONGO_BSON_ADD_ID,
-					member ? ZSTR_VAL(member) : ZSTR_VAL(string_key),
-					member ? ZSTR_LEN(member) : ZSTR_LEN(string_key),
-					value TSRMLS_CC);
-
-				if (member) {
-					zend_string_release(member);
-				}
-			} else {
-				if (flags & PHONGO_BSON_ADD_ID) {
-					if (!strcmp(ZSTR_VAL(string_key), "_id")) {
-						flags &= ~PHONGO_BSON_ADD_ID;
-					}
-				}
-				phongo_bson_append(bson, flags & ~PHONGO_BSON_ADD_ID, ZSTR_VAL(string_key), ZSTR_LEN(string_key), value TSRMLS_CC);
-			}
+			phongo_bson_append(bson, flags & ~PHONGO_BSON_ADD_ID, ZSTR_VAL(string_key), strlen(ZSTR_VAL(string_key)), value TSRMLS_CC);
 
 			zend_string_release(string_key);
 		} ZEND_HASH_FOREACH_END();
@@ -1489,17 +1433,10 @@ void phongo_zval_to_bson(zval *data, php_phongo_bson_flags_t flags, bson_t *bson
 
 		if (hash_type == HASH_KEY_IS_STRING) {
 			if (ht_data_from_properties) {
-				const char *class_name;
-				zend_unmangle_property_name(string_key, string_key_len-1, &class_name, (const char **)&string_key);
-				string_key_len = strlen(string_key);
-
-				/* Ignore non-public properties */
-				if (!is_public_property(Z_OBJCE_P(data), string_key, string_key_len TSRMLS_CC)) {
+				/* Skip protected and private properties */
+				if (string_key[0] == '\0' && string_key_len > 1) {
 					continue;
 				}
-			} else {
-				/* Chop off the \0 from string lengths */
-				string_key_len -= 1;
 			}
 
 			if (flags & PHONGO_BSON_ADD_ID) {
@@ -1507,6 +1444,10 @@ void phongo_zval_to_bson(zval *data, php_phongo_bson_flags_t flags, bson_t *bson
 					flags &= ~PHONGO_BSON_ADD_ID;
 				}
 			}
+
+			/* PHP's HashTable API includes the terminating NULL byte in key's
+			 * string length, so subtract to track the equivalent strlen(). */
+			string_key_len -= 1;
 		}
 
 		/* Ensure we're working with a string key */

--- a/src/bson.c
+++ b/src/bson.c
@@ -1444,19 +1444,14 @@ void phongo_zval_to_bson(zval *data, php_phongo_bson_flags_t flags, bson_t *bson
 					flags &= ~PHONGO_BSON_ADD_ID;
 				}
 			}
-
-			/* PHP's HashTable API includes the terminating NULL byte in key's
-			 * string length, so subtract to track the equivalent strlen(). */
-			string_key_len -= 1;
 		}
 
 		/* Ensure we're working with a string key */
 		if (hash_type == HASH_KEY_IS_LONG) {
 			spprintf(&string_key, 0, "%ld", num_key);
-			string_key_len = strlen(string_key);
 		}
 
-		phongo_bson_append(bson, flags & ~PHONGO_BSON_ADD_ID, string_key, string_key_len, *value TSRMLS_CC);
+		phongo_bson_append(bson, flags & ~PHONGO_BSON_ADD_ID, string_key, strlen(string_key), *value TSRMLS_CC);
 
 		if (hash_type == HASH_KEY_IS_LONG) {
 			efree(string_key);

--- a/src/bson.c
+++ b/src/bson.c
@@ -1393,6 +1393,12 @@ void phongo_zval_to_bson(zval *data, php_phongo_bson_flags_t flags, bson_t *bson
 					}
 				}
 
+				if (strlen(ZSTR_VAL(string_key)) != ZSTR_LEN(string_key)) {
+					phongo_throw_exception(PHONGO_ERROR_UNEXPECTED_VALUE TSRMLS_CC, "BSON keys cannot contain null bytes. Unexpected null byte after \"%s\".", ZSTR_VAL(string_key));
+
+					return;
+				}
+
 				if (flags & PHONGO_BSON_ADD_ID) {
 					if (!strcmp(ZSTR_VAL(string_key), "_id")) {
 						flags &= ~PHONGO_BSON_ADD_ID;
@@ -1437,6 +1443,12 @@ void phongo_zval_to_bson(zval *data, php_phongo_bson_flags_t flags, bson_t *bson
 				if (string_key[0] == '\0' && string_key_len > 1) {
 					continue;
 				}
+			}
+
+			if (strlen(string_key) != string_key_len - 1) {
+				phongo_throw_exception(PHONGO_ERROR_UNEXPECTED_VALUE TSRMLS_CC, "BSON keys cannot contain null bytes. Unexpected null byte after \"%s\".", ZSTR_VAL(string_key));
+
+				return;
 			}
 
 			if (flags & PHONGO_BSON_ADD_ID) {

--- a/tests/bson/bson-fromPHP-005.phpt
+++ b/tests/bson/bson-fromPHP-005.phpt
@@ -1,0 +1,27 @@
+--TEST--
+BSON\fromPHP(): PHP document with public property whose name is an empty string
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/tools.php';
+
+$tests = [
+    ['' => 1],
+    (object) ['' => 1],
+];
+
+foreach ($tests as $document) {
+    $s = fromPHP($document);
+    echo "Test ", toJSON($s), "\n";
+    hex_dump($s);
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+Test { "" : 1 }
+     0 : 0b 00 00 00 10 00 01 00 00 00 00                 [...........]
+Test { "" : 1 }
+     0 : 0b 00 00 00 10 00 01 00 00 00 00                 [...........]
+===DONE===

--- a/tests/bson/bson-fromPHP-006.phpt
+++ b/tests/bson/bson-fromPHP-006.phpt
@@ -6,13 +6,19 @@ BSON\fromPHP(): PHP documents with null bytes in field name
 require_once __DIR__ . '/../utils/tools.php';
 
 echo "\nTesting array with one leading null byte in field name\n";
-hex_dump(fromPHP(["\0" => 1]));
+echo throws(function() {
+    fromPHP(["\0" => 1]);
+}, 'MongoDB\Driver\Exception\UnexpectedValueException'), "\n";
 
 echo "\nTesting array with one trailing null byte in field name\n";
-hex_dump(fromPHP(["a\0" => 1]));
+echo throws(function() {
+    fromPHP(["a\0" => 1]);
+}, 'MongoDB\Driver\Exception\UnexpectedValueException'), "\n";
 
 echo "\nTesting array with multiple null bytes in field name\n";
-hex_dump(fromPHP(["\0\0\0" => 1]));
+echo throws(function() {
+    fromPHP(["\0\0\0" => 1]);
+}, 'MongoDB\Driver\Exception\UnexpectedValueException'), "\n";
 
 /* Per PHPC-884, field names with a leading null byte are ignored when encoding
  * a document from an object's property hash table, since PHP uses leading bytes
@@ -21,7 +27,9 @@ echo "\nTesting object with one leading null byte in field name\n";
 hex_dump(fromPHP((object) ["\0" => 1]));
 
 echo "\nTesting object with one trailing null byte in field name\n";
-hex_dump(fromPHP((object) ["a\0" => 1]));
+echo throws(function() {
+    fromPHP((object) ["a\0" => 1]);
+}, 'MongoDB\Driver\Exception\UnexpectedValueException'), "\n";
 
 echo "\nTesting object with multiple null bytes in field name\n";
 hex_dump(fromPHP((object) ["\0\0\0" => 1]));
@@ -31,19 +39,23 @@ hex_dump(fromPHP((object) ["\0\0\0" => 1]));
 <?php exit(0); ?>
 --EXPECT--
 Testing array with one leading null byte in field name
-     0 : 0b 00 00 00 10 00 01 00 00 00 00                 [...........]
+OK: Got MongoDB\Driver\Exception\UnexpectedValueException
+BSON keys cannot contain null bytes. Unexpected null byte after "".
 
 Testing array with one trailing null byte in field name
-     0 : 0c 00 00 00 10 61 00 01 00 00 00 00              [.....a......]
+OK: Got MongoDB\Driver\Exception\UnexpectedValueException
+BSON keys cannot contain null bytes. Unexpected null byte after "a".
 
 Testing array with multiple null bytes in field name
-     0 : 0b 00 00 00 10 00 01 00 00 00 00                 [...........]
+OK: Got MongoDB\Driver\Exception\UnexpectedValueException
+BSON keys cannot contain null bytes. Unexpected null byte after "".
 
 Testing object with one leading null byte in field name
      0 : 05 00 00 00 00                                   [.....]
 
 Testing object with one trailing null byte in field name
-     0 : 0c 00 00 00 10 61 00 01 00 00 00 00              [.....a......]
+OK: Got MongoDB\Driver\Exception\UnexpectedValueException
+BSON keys cannot contain null bytes. Unexpected null byte after "a".
 
 Testing object with multiple null bytes in field name
      0 : 05 00 00 00 00                                   [.....]

--- a/tests/bson/bson-fromPHP-006.phpt
+++ b/tests/bson/bson-fromPHP-006.phpt
@@ -1,0 +1,50 @@
+--TEST--
+BSON\fromPHP(): PHP documents with null bytes in field name
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/tools.php';
+
+echo "\nTesting array with one leading null byte in field name\n";
+hex_dump(fromPHP(["\0" => 1]));
+
+echo "\nTesting array with one trailing null byte in field name\n";
+hex_dump(fromPHP(["a\0" => 1]));
+
+echo "\nTesting array with multiple null bytes in field name\n";
+hex_dump(fromPHP(["\0\0\0" => 1]));
+
+/* Per PHPC-884, field names with a leading null byte are ignored when encoding
+ * a document from an object's property hash table, since PHP uses leading bytes
+ * to denote protected and private properties. */
+echo "\nTesting object with one leading null byte in field name\n";
+hex_dump(fromPHP((object) ["\0" => 1]));
+
+echo "\nTesting object with one trailing null byte in field name\n";
+hex_dump(fromPHP((object) ["a\0" => 1]));
+
+echo "\nTesting object with multiple null bytes in field name\n";
+hex_dump(fromPHP((object) ["\0\0\0" => 1]));
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+Testing array with one leading null byte in field name
+     0 : 0b 00 00 00 10 00 01 00 00 00 00                 [...........]
+
+Testing array with one trailing null byte in field name
+     0 : 0c 00 00 00 10 61 00 01 00 00 00 00              [.....a......]
+
+Testing array with multiple null bytes in field name
+     0 : 0b 00 00 00 10 00 01 00 00 00 00                 [...........]
+
+Testing object with one leading null byte in field name
+     0 : 05 00 00 00 00                                   [.....]
+
+Testing object with one trailing null byte in field name
+     0 : 0c 00 00 00 10 61 00 01 00 00 00 00              [.....a......]
+
+Testing object with multiple null bytes in field name
+     0 : 05 00 00 00 00                                   [.....]
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-884
https://jira.mongodb.org/browse/PHPC-886
https://jira.mongodb.org/browse/PHPC-891