### PR TITLE
Ensure INT64 macros use their actual parameters

### DIFF
--- a/phongo_compat.h
+++ b/phongo_compat.h
@@ -150,13 +150,13 @@
     if (value > INT32_MAX || value < INT32_MIN) { \
         phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Integer overflow detected on your platform: %lld", value); \
     } else { \
-        add_index_long(zval, index, val); \
+        add_index_long(zval, index, value); \
     }
 # define ADD_NEXT_INDEX_INT64(zval, value) \
     if (value > INT32_MAX || value < INT32_MIN) { \
         phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Integer overflow detected on your platform: %lld", value); \
     } else { \
-        add_next_index_long(zval, val); \
+        add_next_index_long(zval, value); \
     }
 # define ADD_ASSOC_INT64(zval, key, value) \
     if (value > INT32_MAX || value < INT32_MIN) { \


### PR DESCRIPTION
This fixes a build error from ADD_NEXT_INDEX_INT64 (added in 3a4da1c74c725d7b6acceadf1bb4091f63872f0b), where we referenced "val" instead of "value". That macro was based on ADD_INDEX_INT64 (added in 6bcba59cb57a92f091b29e4f11e1c99a96eaed95), which also incorrectly referenced "val"; however, that never resulted in a build error since a "val" was declared in the calling scope.