### PR TITLE
PHPC-894: Implement get_gc handlers for BSON classes

### DIFF
--- a/phongo_compat.h
+++ b/phongo_compat.h
@@ -83,6 +83,7 @@
 #endif
 # define SIZEOF_PHONGO_LONG SIZEOF_ZEND_LONG
 # define phongo_create_object_retval zend_object*
+# define phongo_get_gc_table zval **
 # define PHONGO_ALLOC_OBJECT_T(_obj_t, _class_type) (_obj_t *)ecalloc(1, sizeof(_obj_t)+zend_object_properties_size(_class_type))
 # define PHONGO_TSRMLS_FETCH_FROM_CTX(user_data)
 # define SUPPRESS_UNUSED_WARNING(x)
@@ -112,6 +113,7 @@
 # define SIZEOF_PHONGO_LONG SIZEOF_LONG
 # define ZSTR_VAL(str) str
 # define phongo_create_object_retval zend_object_value
+# define phongo_get_gc_table zval ***
 # define PHONGO_ALLOC_OBJECT_T(_obj_t, _class_type) (_obj_t *)ecalloc(1, sizeof(_obj_t))
 # define PHONGO_TSRMLS_FETCH_FROM_CTX(user_data) TSRMLS_FETCH_FROM_CTX(user_data)
 # define SUPPRESS_UNUSED_WARNING(x) (void)x;

--- a/src/BSON/Binary.c
+++ b/src/BSON/Binary.c
@@ -401,6 +401,14 @@ static int php_phongo_binary_compare_objects(zval *o1, zval *o2 TSRMLS_DC) /* {{
 	return zend_binary_strcmp(intern1->data, intern1->data_len, intern2->data, intern2->data_len);
 } /* }}} */
 
+static HashTable *php_phongo_binary_get_gc(zval *object, phongo_get_gc_table table, int *n TSRMLS_DC) /* {{{ */
+{
+	*table = NULL;
+	*n = 0;
+
+	return zend_std_get_properties(object TSRMLS_CC);
+} /* }}} */
+
 HashTable *php_phongo_binary_get_properties(zval *object TSRMLS_DC) /* {{{ */
 {
 	php_phongo_binary_t *intern;
@@ -458,6 +466,7 @@ PHP_MINIT_FUNCTION(Binary)
 
 	memcpy(&php_phongo_handler_binary, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 	php_phongo_handler_binary.compare_objects = php_phongo_binary_compare_objects;
+	php_phongo_handler_binary.get_gc = php_phongo_binary_get_gc;
 	php_phongo_handler_binary.get_properties = php_phongo_binary_get_properties;
 #if PHP_VERSION_ID >= 70000
 	php_phongo_handler_binary.free_obj = php_phongo_binary_free_object;

--- a/src/BSON/Decimal128.c
+++ b/src/BSON/Decimal128.c
@@ -320,6 +320,14 @@ phongo_create_object_retval php_phongo_decimal128_create_object(zend_class_entry
 #endif
 } /* }}} */
 
+static HashTable *php_phongo_decimal128_get_gc(zval *object, phongo_get_gc_table table, int *n TSRMLS_DC) /* {{{ */
+{
+	*table = NULL;
+	*n = 0;
+
+	return zend_std_get_properties(object TSRMLS_CC);
+} /* }}} */
+
 HashTable *php_phongo_decimal128_get_properties(zval *object TSRMLS_DC) /* {{{ */
 {
 	php_phongo_decimal128_t *intern;
@@ -372,6 +380,7 @@ PHP_MINIT_FUNCTION(Decimal128)
 	zend_class_implements(php_phongo_decimal128_ce TSRMLS_CC, 1, zend_ce_serializable);
 
 	memcpy(&php_phongo_handler_decimal128, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
+	php_phongo_handler_decimal128.get_gc = php_phongo_decimal128_get_gc;
 	php_phongo_handler_decimal128.get_properties = php_phongo_decimal128_get_properties;
 #if PHP_VERSION_ID >= 70000
 	php_phongo_handler_decimal128.free_obj = php_phongo_decimal128_free_object;

--- a/src/BSON/Javascript.c
+++ b/src/BSON/Javascript.c
@@ -443,6 +443,14 @@ static int php_phongo_javascript_compare_objects(zval *o1, zval *o2 TSRMLS_DC) /
 	return strcmp(intern1->code, intern2->code);
 } /* }}} */
 
+static HashTable *php_phongo_javascript_get_gc(zval *object, phongo_get_gc_table table, int *n TSRMLS_DC) /* {{{ */
+{
+	*table = NULL;
+	*n = 0;
+
+	return zend_std_get_properties(object TSRMLS_CC);
+} /* }}} */
+
 HashTable *php_phongo_javascript_get_properties(zval *object TSRMLS_DC) /* {{{ */
 {
 	php_phongo_javascript_t *intern;
@@ -538,6 +546,7 @@ PHP_MINIT_FUNCTION(Javascript)
 
 	memcpy(&php_phongo_handler_javascript, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 	php_phongo_handler_javascript.compare_objects = php_phongo_javascript_compare_objects;
+	php_phongo_handler_javascript.get_gc = php_phongo_javascript_get_gc;
 	php_phongo_handler_javascript.get_properties = php_phongo_javascript_get_properties;
 #if PHP_VERSION_ID >= 70000
 	php_phongo_handler_javascript.free_obj = php_phongo_javascript_free_object;

--- a/src/BSON/ObjectID.c
+++ b/src/BSON/ObjectID.c
@@ -373,6 +373,14 @@ static int php_phongo_objectid_compare_objects(zval *o1, zval *o2 TSRMLS_DC) /* 
 	return strcmp(intern1->oid, intern2->oid);
 } /* }}} */
 
+static HashTable *php_phongo_objectid_get_gc(zval *object, phongo_get_gc_table table, int *n TSRMLS_DC) /* {{{ */
+{
+	*table = NULL;
+	*n = 0;
+
+	return zend_std_get_properties(object TSRMLS_CC);
+} /* }}} */
+
 HashTable *php_phongo_objectid_get_properties(zval *object TSRMLS_DC) /* {{{ */
 {
 	php_phongo_objectid_t *intern;
@@ -423,6 +431,7 @@ PHP_MINIT_FUNCTION(ObjectID)
 
 	memcpy(&php_phongo_handler_objectid, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 	php_phongo_handler_objectid.compare_objects = php_phongo_objectid_compare_objects;
+	php_phongo_handler_objectid.get_gc = php_phongo_objectid_get_gc;
 	php_phongo_handler_objectid.get_properties = php_phongo_objectid_get_properties;
 #if PHP_VERSION_ID >= 70000
 	php_phongo_handler_objectid.free_obj = php_phongo_objectid_free_object;

--- a/src/BSON/Regex.c
+++ b/src/BSON/Regex.c
@@ -413,6 +413,14 @@ static int php_phongo_regex_compare_objects(zval *o1, zval *o2 TSRMLS_DC) /* {{{
 	return strcmp(intern1->flags, intern2->flags);
 } /* }}} */
 
+static HashTable *php_phongo_regex_get_gc(zval *object, phongo_get_gc_table table, int *n TSRMLS_DC) /* {{{ */
+{
+	*table = NULL;
+	*n = 0;
+
+	return zend_std_get_properties(object TSRMLS_CC);
+} /* }}} */
+
 HashTable *php_phongo_regex_get_properties(zval *object TSRMLS_DC) /* {{{ */
 {
 	php_phongo_regex_t *intern;
@@ -470,6 +478,7 @@ PHP_MINIT_FUNCTION(Regex)
 
 	memcpy(&php_phongo_handler_regex, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 	php_phongo_handler_regex.compare_objects = php_phongo_regex_compare_objects;
+	php_phongo_handler_regex.get_gc = php_phongo_regex_get_gc;
 	php_phongo_handler_regex.get_properties = php_phongo_regex_get_properties;
 #if PHP_VERSION_ID >= 70000
 	php_phongo_handler_regex.free_obj = php_phongo_regex_free_object;

--- a/src/BSON/Timestamp.c
+++ b/src/BSON/Timestamp.c
@@ -439,6 +439,14 @@ static int php_phongo_timestamp_compare_objects(zval *o1, zval *o2 TSRMLS_DC) /*
 	return 0;
 } /* }}} */
 
+static HashTable *php_phongo_timestamp_get_gc(zval *object, phongo_get_gc_table table, int *n TSRMLS_DC) /* {{{ */
+{
+	*table = NULL;
+	*n = 0;
+
+	return zend_std_get_properties(object TSRMLS_CC);
+} /* }}} */
+
 HashTable *php_phongo_timestamp_get_properties(zval *object TSRMLS_DC) /* {{{ */
 {
 	php_phongo_timestamp_t *intern;
@@ -503,6 +511,7 @@ PHP_MINIT_FUNCTION(Timestamp)
 
 	memcpy(&php_phongo_handler_timestamp, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 	php_phongo_handler_timestamp.compare_objects = php_phongo_timestamp_compare_objects;
+	php_phongo_handler_timestamp.get_gc = php_phongo_timestamp_get_gc;
 	php_phongo_handler_timestamp.get_properties = php_phongo_timestamp_get_properties;
 #if PHP_VERSION_ID >= 70000
 	php_phongo_handler_timestamp.free_obj = php_phongo_timestamp_free_object;

--- a/src/BSON/UTCDateTime.c
+++ b/src/BSON/UTCDateTime.c
@@ -490,6 +490,14 @@ static int php_phongo_utcdatetime_compare_objects(zval *o1, zval *o2 TSRMLS_DC) 
 	return 0;
 } /* }}} */
 
+static HashTable *php_phongo_utcdatetime_get_gc(zval *object, phongo_get_gc_table table, int *n TSRMLS_DC) /* {{{ */
+{
+	*table = NULL;
+	*n = 0;
+
+	return zend_std_get_properties(object TSRMLS_CC);
+} /* }}} */
+
 HashTable *php_phongo_utcdatetime_get_properties(zval *object TSRMLS_DC) /* {{{ */
 {
 	php_phongo_utcdatetime_t *intern;
@@ -544,6 +552,7 @@ PHP_MINIT_FUNCTION(UTCDateTime)
 
 	memcpy(&php_phongo_handler_utcdatetime, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 	php_phongo_handler_utcdatetime.compare_objects = php_phongo_utcdatetime_compare_objects;
+	php_phongo_handler_utcdatetime.get_gc = php_phongo_utcdatetime_get_gc;
 	php_phongo_handler_utcdatetime.get_properties = php_phongo_utcdatetime_get_properties;
 #if PHP_VERSION_ID >= 70000
 	php_phongo_handler_utcdatetime.free_obj = php_phongo_utcdatetime_free_object;

--- a/tests/bson/bug0894-001.phpt
+++ b/tests/bson/bug0894-001.phpt
@@ -1,0 +1,27 @@
+--TEST--
+PHPC-849: BSON get_properties handlers leak during gc_possible_root() checks
+--FILE--
+<?php
+
+$objects = [
+    new MongoDB\BSON\Binary('foo', MongoDB\BSON\Binary::TYPE_GENERIC),
+    new MongoDB\BSON\Decimal128('3.14'),
+    new MongoDB\BSON\Javascript('function foo() { return bar; }', ['bar' => 42]),
+    new MongoDB\BSON\MaxKey,
+    new MongoDB\BSON\MinKey,
+    new MongoDB\BSON\ObjectID,
+    new MongoDB\BSON\Regex('foo', 'i'),
+    new MongoDB\BSON\Timestamp(1234, 5678),
+    new MongoDB\BSON\UTCDateTime,
+];
+
+printf("Created array of %d BSON objects\n", count($objects));
+
+gc_collect_cycles();
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+Created array of 9 BSON objects
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-894

This addresses a memory leak if gc_possible_root() were to invoke the existing get_properties handlers.