### PR TITLE
Fix source file enumeration in config.w32 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,12 +120,19 @@ bin\phpsdk_setvars.bat
 cd C:\php-sdk\phpdev\vc11\x86\php-5.6.12-src
 nmake clean
 buildconf --force
-configure --disable-all --with-openssl --enable-cli --enable-json --enable-mongodb
+configure --disable-all --with-openssl --enable-cli --enable-json --enable-mongodb=shared
 nmake
 ```
 
-If the extension was successfully compiled, "mongodb" should be reported by
-`Release_TS\php.exe -m`.
+If the extension was successfully compiled, a `php_mongodb.dll` file should be
+generated in the build directory (e.g. `Release_TS`). You should then verify
+that the extension loads and executes properly:
+
+```
+cd Release_TS
+php.exe -d extension=./php_mongodb.dll -m
+php.exe -d extension=./php_mongodb.dll -r "var_dump(new MongoDB\Driver\Manager);"
+```
 
 See the [internals wiki](https://wiki.php.net/internals/windows/stepbystepbuild)
 for more information.

--- a/config.w32
+++ b/config.w32
@@ -70,50 +70,6 @@ if (PHP_MONGODB != "no") {
     /I" + configure_module_dirname + "/src/libmongoc/src/mongoc \
   ";
 
-  var PHP_MONGODB_SOURCES="\
-    php_phongo.c \
-    phongo_compat.c \
-    src/bson.c \
-    src/BSON/Binary.c \
-    src/BSON/Decimal128.c \
-    src/BSON/Javascript.c \
-    src/BSON/MaxKey.c \
-    src/BSON/MinKey.c \
-    src/BSON/ObjectID.c \
-    src/BSON/Persistable.c \
-    src/BSON/Regex.c \
-    src/BSON/Serializable.c \
-    src/BSON/Timestamp.c \
-    src/BSON/Type.c \
-    src/BSON/Unserializable.c \
-    src/BSON/UTCDateTime.c \
-    src/MongoDB/BulkWrite.c \
-    src/MongoDB/Command.c \
-    src/MongoDB/Cursor.c \
-    src/MongoDB/CursorId.c \
-    src/MongoDB/Manager.c \
-    src/MongoDB/Query.c \
-    src/MongoDB/ReadConcern.c \
-    src/MongoDB/ReadPreference.c \
-    src/MongoDB/Server.c \
-    src/MongoDB/WriteConcern.c \
-    src/MongoDB/WriteConcernError.c \
-    src/MongoDB/WriteError.c \
-    src/MongoDB/WriteResult.c \
-    src/MongoDB/Exception/AuthenticationException.c \
-    src/MongoDB/Exception/BulkWriteException.c \
-    src/MongoDB/Exception/ConnectionException.c \
-    src/MongoDB/Exception/ConnectionTimeoutException.c \
-    src/MongoDB/Exception/Exception.c \
-    src/MongoDB/Exception/ExecutionTimeoutException.c \
-    src/MongoDB/Exception/InvalidArgumentException.c \
-    src/MongoDB/Exception/LogicException.c \
-    src/MongoDB/Exception/RuntimeException.c \
-    src/MongoDB/Exception/SSLConnectionException.c \
-    src/MongoDB/Exception/UnexpectedValueException.c \
-    src/MongoDB/Exception/WriteException.c \
-  ";
-
   // Generated with: find src/libbson/src/bson -name '*.c' -print0 | cut -sz -d / -f 5- | sort -z | tr '\000' ' '
   var PHP_MONGODB_BSON_SOURCES="bcon.c bson-atomic.c bson.c bson-clock.c bson-context.c bson-decimal128.c bson-error.c bson-iso8601.c bson-iter.c bson-json.c bson-keys.c bson-md5.c bson-memory.c bson-oid.c bson-reader.c bson-string.c bson-timegm.c bson-utf8.c bson-value.c bson-version-functions.c bson-writer.c";
 
@@ -123,7 +79,11 @@ if (PHP_MONGODB != "no") {
   // Generated with: find src/libmongoc/src/mongoc -name '*.c' -print0 | cut -sz -d / -f 4- | sort -z | tr '\000' ' '
   var PHP_MONGODB_MONGOC_SOURCES="mongoc-apm.c mongoc-array.c mongoc-async.c mongoc-async-cmd.c mongoc-b64.c mongoc-buffer.c mongoc-bulk-operation.c mongoc-client.c mongoc-client-pool.c mongoc-cluster.c mongoc-collection.c mongoc-counters.c mongoc-crypto.c mongoc-crypto-cng.c mongoc-crypto-common-crypto.c mongoc-crypto-openssl.c mongoc-cursor-array.c mongoc-cursor.c mongoc-cursor-cursorid.c mongoc-cursor-transform.c mongoc-database.c mongoc-find-and-modify.c mongoc-gridfs.c mongoc-gridfs-file.c mongoc-gridfs-file-list.c mongoc-gridfs-file-page.c mongoc-handshake.c mongoc-host-list.c mongoc-index.c mongoc-init.c mongoc-libressl.c mongoc-linux-distro-scanner.c mongoc-list.c mongoc-log.c mongoc-matcher.c mongoc-matcher-op.c mongoc-memcmp.c mongoc-opcode.c mongoc-openssl.c mongoc-queue.c mongoc-rand-cng.c mongoc-rand-common-crypto.c mongoc-rand-openssl.c mongoc-read-concern.c mongoc-read-prefs.c mongoc-rpc.c mongoc-sasl.c mongoc-scram.c mongoc-secure-channel.c mongoc-secure-transport.c mongoc-server-description.c mongoc-server-stream.c mongoc-set.c mongoc-socket.c mongoc-ssl.c mongoc-stream-buffered.c mongoc-stream.c mongoc-stream-file.c mongoc-stream-gridfs.c mongoc-stream-socket.c mongoc-stream-tls.c mongoc-stream-tls-libressl.c mongoc-stream-tls-openssl-bio.c mongoc-stream-tls-openssl.c mongoc-stream-tls-secure-channel.c mongoc-stream-tls-secure-transport.c mongoc-topology.c mongoc-topology-description-apm.c mongoc-topology-description.c mongoc-topology-scanner.c mongoc-uri.c mongoc-util.c mongoc-version-functions.c mongoc-write-command.c mongoc-write-concern.c";
 
-  EXTENSION("mongodb", PHP_MONGODB_SOURCES, null, PHP_MONGODB_CFLAGS);
+  EXTENSION("mongodb", "php_phongo.c phongo_compat.c", null, PHP_MONGODB_CFLAGS);
+  ADD_SOURCES(configure_module_dirname + "/src", "bson.c", "mongodb");
+  ADD_SOURCES(configure_module_dirname + "/src/BSON", "Binary.c Decimal128.c Javascript.c MaxKey.c MinKey.c ObjectID.c Persistable.c Regex.c Serializable.c Timestamp.c Type.c Unserializable.c UTCDateTime.c", "mongodb");
+  ADD_SOURCES(configure_module_dirname + "/src/MongoDB", "BulkWrite.c Command.c Cursor.c CursorId.c Manager.c Query.c ReadConcern.c ReadPreference.c Server.c WriteConcern.c WriteConcernError.c WriteError.c WriteResult.c", "mongodb");
+  ADD_SOURCES(configure_module_dirname + "/src/MongoDB/Exception", "AuthenticationException.c BulkWriteException.c ConnectionException.c ConnectionTimeoutException.c Exception.c ExecutionTimeoutException.c InvalidArgumentException.c LogicException.c RuntimeException.c SSLConnectionException.c UnexpectedValueException.c WriteException.c", "mongodb");
   ADD_SOURCES(configure_module_dirname + "/src/libbson/src/bson", PHP_MONGODB_BSON_SOURCES, "mongodb");
   ADD_SOURCES(configure_module_dirname + "/src/libbson/src/yajl", PHP_MONGODB_YAJL_SOURCES, "mongodb");
   ADD_SOURCES(configure_module_dirname + "/src/libmongoc/src/mongoc", PHP_MONGODB_MONGOC_SOURCES, "mongodb");

--- a/config.w32
+++ b/config.w32
@@ -70,6 +70,9 @@ if (PHP_MONGODB != "no") {
     /I" + configure_module_dirname + "/src/libmongoc/src/mongoc \
   ";
 
+  // Condense whitespace in CFLAGS
+  PHP_MONGODB_CFLAGS = PHP_MONGODB_CFLAGS.replace(/\s+/g, ' ');
+
   // Generated with: find src/libbson/src/bson -name '*.c' -print0 | cut -sz -d / -f 5- | sort -z | tr '\000' ' '
   var PHP_MONGODB_BSON_SOURCES="bcon.c bson-atomic.c bson.c bson-clock.c bson-context.c bson-decimal128.c bson-error.c bson-iso8601.c bson-iter.c bson-json.c bson-keys.c bson-md5.c bson-memory.c bson-oid.c bson-reader.c bson-string.c bson-timegm.c bson-utf8.c bson-value.c bson-version-functions.c bson-writer.c";
 


### PR DESCRIPTION
This fixes 906d0398fa035293bad5521060274d5a0a25c400 from #518. `config.w32` requires sources to be segregated by path.

Note: when I said I [verified the previous refactoring](https://github.com/mongodb/mongo-php-driver/pull/518#issuecomment-275204181), that was just building the configuration script and then executing it without compiling the final DLL:

```
buildconf --force
configure --disable-all --with-openssl --enable-cli --enable-json --enable-mongodb=shared
```

For this change, I am verifying that we can also build the DLL with `nmake`.