### PR TITLE
PHPC-923: Use zend_string_release() to free class names

### DIFF
--- a/src/bson.c
+++ b/src/bson.c
@@ -243,7 +243,7 @@ bool php_phongo_bson_visit_binary(const bson_iter_t *iter ARG_UNUSED, const char
 #if PHP_VERSION_ID >= 70000
 		zend_string *zs_classname = zend_string_init((const char *)v_binary, v_binary_len, 0);
 		zend_class_entry *found_ce = zend_fetch_class(zs_classname, ZEND_FETCH_CLASS_AUTO|ZEND_FETCH_CLASS_SILENT TSRMLS_CC);
-		zend_string_free(zs_classname);
+		zend_string_release(zs_classname);
 #else
 		zend_class_entry *found_ce = zend_fetch_class((const char *)v_binary, v_binary_len, ZEND_FETCH_CLASS_AUTO|ZEND_FETCH_CLASS_SILENT TSRMLS_CC);
 #endif
@@ -1653,7 +1653,7 @@ static void apply_classname_to_state(const char *classname, int classname_len, p
 #if PHP_VERSION_ID >= 70000
 		zend_string* zs_classname = zend_string_init(classname, classname_len, 0);
 		zend_class_entry *found_ce = zend_fetch_class(zs_classname, ZEND_FETCH_CLASS_AUTO|ZEND_FETCH_CLASS_SILENT TSRMLS_CC);
-		zend_string_free(zs_classname);
+		zend_string_release(zs_classname);
 #else
 		zend_class_entry *found_ce = zend_fetch_class(classname, classname_len, ZEND_FETCH_CLASS_AUTO|ZEND_FETCH_CLASS_SILENT TSRMLS_CC);
 #endif

--- a/tests/bson/bug0923-001.phpt
+++ b/tests/bson/bug0923-001.phpt
@@ -1,0 +1,34 @@
+--TEST--
+PHPC-923: Use zend_string_release() to free class names (type map)
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/tools.php';
+
+/* Register an autoloader that does nothing more than append the class name to
+ * an array. This adds a reference to the zend_string in PHP 7, which exposes an
+ * assert failure if the value is then freed with zend_string_free() instead of
+ * zend_string_release(). */
+$classes = [];
+
+spl_autoload_register(function ($class) use (&$classes) {
+    $classes[] = $class;
+});
+
+echo throws(function() {
+    var_dump(toPHP(fromJSON('{"x":1}'), ['root' => 'MissingClass']));
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+var_dump($classes);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Class MissingClass does not exist
+array(1) {
+  [0]=>
+  string(12) "MissingClass"
+}
+===DONE===

--- a/tests/bson/bug0923-002.phpt
+++ b/tests/bson/bug0923-002.phpt
@@ -1,0 +1,44 @@
+--TEST--
+PHPC-923: Use zend_string_release() to free class names (__pclass)
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/tools.php';
+
+/* Register an autoloader that does nothing more than append the class name to
+ * an array. This adds a reference to the zend_string in PHP 7, which exposes an
+ * assert failure if the value is then freed with zend_string_free() instead of
+ * zend_string_release(). */
+$classes = [];
+
+spl_autoload_register(function ($class) use (&$classes) {
+    $classes[] = $class;
+});
+
+/* Note: An exception is not thrown if the __pclass field fails to denote a
+ * valid class. Instead, it is left as-is and the general type map applies. */
+var_dump(toPHP(fromJSON('{"x":{"__pclass":{"$binary":"TWlzc2luZ0NsYXNz","$type":"80"}}}')));
+
+var_dump($classes);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+object(stdClass)#%d (%d) {
+  ["x"]=>
+  object(stdClass)#%d (%d) {
+    ["__pclass"]=>
+    object(MongoDB\BSON\Binary)#%d (%d) {
+      ["data"]=>
+      string(12) "MissingClass"
+      ["type"]=>
+      int(128)
+    }
+  }
+}
+array(1) {
+  [0]=>
+  string(12) "MissingClass"
+}
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-923

Fixes https://github.com/mongodb/mongo-php-driver/issues/529