### PR TITLE
PHPC-302: Throw exceptions for unsupported BSON types

### DIFF
--- a/src/bson.c
+++ b/src/bson.c
@@ -137,6 +137,14 @@ static bool php_phongo_bson_visit_binary(const bson_iter_t *iter ARG_UNUSED, con
 	return false;
 } /* }}} */
 
+static bool php_phongo_bson_visit_undefined(const bson_iter_t *iter, const char *key, void *data) /* {{{ */
+{
+	TSRMLS_FETCH();
+	phongo_throw_exception(PHONGO_ERROR_UNEXPECTED_VALUE TSRMLS_CC, "Detected unsupported BSON type 0x06 (undefined) for fieldname \"%s\"", key);
+
+	return false;
+} /* }}} */
+
 static bool php_phongo_bson_visit_oid(const bson_iter_t *iter ARG_UNUSED, const char *key, const bson_oid_t *v_oid, void *data) /* {{{ */
 {
 #if PHP_VERSION_ID >= 70000
@@ -308,6 +316,14 @@ static bool php_phongo_bson_visit_regex(const bson_iter_t *iter ARG_UNUSED, cons
 	return false;
 } /* }}} */
 
+static bool php_phongo_bson_visit_symbol(const bson_iter_t *iter, const char *key, size_t symbol_len, const char *symbol, void *data) /* {{{ */
+{
+	TSRMLS_FETCH();
+	phongo_throw_exception(PHONGO_ERROR_UNEXPECTED_VALUE TSRMLS_CC, "Detected unsupported BSON type 0x0E (symbol) for fieldname \"%s\"", key);
+
+	return false;
+} /* }}} */
+
 static bool php_phongo_bson_visit_code(const bson_iter_t *iter ARG_UNUSED, const char *key, size_t v_code_len, const char *v_code, void *data) /* {{{ */
 {
 #if PHP_VERSION_ID >= 70000
@@ -339,6 +355,14 @@ static bool php_phongo_bson_visit_code(const bson_iter_t *iter ARG_UNUSED, const
 	}
 	Z_SET_REFCOUNT_P(zchild, 1);
 #endif
+
+	return false;
+} /* }}} */
+
+static bool php_phongo_bson_visit_dbpointer(const bson_iter_t *iter, const char *key, size_t collection_len, const char *collection, const bson_oid_t *oid, void *data) /* {{{ */
+{
+	TSRMLS_FETCH();
+	phongo_throw_exception(PHONGO_ERROR_UNEXPECTED_VALUE TSRMLS_CC, "Detected unsupported BSON type 0x0C (DBPointer) for fieldname \"%s\"", key);
 
 	return false;
 } /* }}} */
@@ -529,15 +553,15 @@ static const bson_visitor_t php_bson_visitors = {
    php_phongo_bson_visit_document,
    php_phongo_bson_visit_array,
    php_phongo_bson_visit_binary,
-   NULL /*php_phongo_bson_visit_undefined*/,
+   php_phongo_bson_visit_undefined,
    php_phongo_bson_visit_oid,
    php_phongo_bson_visit_bool,
    php_phongo_bson_visit_date_time,
    php_phongo_bson_visit_null,
    php_phongo_bson_visit_regex,
-   NULL /*php_phongo_bson_visit_dbpointer*/,
+   php_phongo_bson_visit_dbpointer,
    php_phongo_bson_visit_code,
-   NULL /*php_phongo_bson_visit_symbol*/,
+   php_phongo_bson_visit_symbol,
    php_phongo_bson_visit_codewscope,
    php_phongo_bson_visit_int32,
    php_phongo_bson_visit_timestamp,

--- a/tests/bson/bson-toPHP_error-005.phpt
+++ b/tests/bson/bson-toPHP_error-005.phpt
@@ -1,0 +1,30 @@
+--TEST--
+MongoDB\BSON\toPHP(): BSON decoding exceptions for unsupported BSON types
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/tools.php';
+
+$tests = [
+    pack('VCa*xx', 10, 0x06, 'foo'), // undefined
+    pack('VCa*xVa*xx12x', 37, 0x0C, 'foo', 11, 'collection'), // DBPointer
+    pack('VCa*xVa*xx', 18, 0x0E, 'foo', 4, 'bar'), // symbol
+];
+
+foreach ($tests as $bson) {
+    echo throws(function() use ($bson) {
+        var_dump(toPHP($bson));
+    }, 'MongoDB\Driver\Exception\UnexpectedValueException'), "\n";
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+OK: Got MongoDB\Driver\Exception\UnexpectedValueException
+Detected unsupported BSON type 0x06 (undefined) for fieldname "foo"
+OK: Got MongoDB\Driver\Exception\UnexpectedValueException
+Detected unsupported BSON type 0x0C (DBPointer) for fieldname "foo"
+OK: Got MongoDB\Driver\Exception\UnexpectedValueException
+Detected unsupported BSON type 0x0E (symbol) for fieldname "foo"
+===DONE===

--- a/tests/bson/bson-toPHP_error-006.phpt
+++ b/tests/bson/bson-toPHP_error-006.phpt
@@ -1,0 +1,62 @@
+--TEST--
+MongoDB\BSON\toPHP(): BSON decoding throws multiple exceptions
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/tools.php';
+
+$tests = [
+    // two undefined fields in root document
+    pack('VCa*xCa*xx', 13, 0x06, 'u1', 0x06, 'u2'),
+    // undefined field and symbol field in root document
+    pack('VCa*xCa*xVa*xx', 21, 0x06, 'u1', 0x0E, 's1', 4, 'foo'),
+    // two undefined fields in root (first) and embedded (second) documents
+    pack('VCa*xCa*xVCa*xxx', 22, 0x06, 'u1', 0x03, 'e1', 9, 0x06, 'u2'),
+    // two undefined fields in embedded (first) and root (second) documents
+    pack('VCa*xVCa*xxCa*xx', 22, 0x03, 'e1', 9, 0x06, 'u1', 0x06, 'u2'),
+    // two undefined fields in separate embedded documents
+    pack('VCa*xVCa*xxCa*xVCa*xxx', 31, 0x03, 'e1', 9, 0x06, 'u1', 0x03, 'e2', 9, 0x06, 'u2'),
+];
+
+foreach ($tests as $bson) {
+    try {
+        var_dump(toPHP($bson));
+    } catch (MongoDB\Driver\Exception\UnexpectedValueException $e) {
+        do {
+            printf("OK: %s\n%s\n", get_class($e), $e->getMessage());
+        } while ($e = $e->getPrevious());
+    }
+
+    echo "\n";
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+OK: MongoDB\Driver\Exception\UnexpectedValueException
+Detected unsupported BSON type 0x06 (undefined) for fieldname "u2"
+OK: MongoDB\Driver\Exception\UnexpectedValueException
+Detected unsupported BSON type 0x06 (undefined) for fieldname "u1"
+
+OK: MongoDB\Driver\Exception\UnexpectedValueException
+Detected unsupported BSON type 0x0E (symbol) for fieldname "s1"
+OK: MongoDB\Driver\Exception\UnexpectedValueException
+Detected unsupported BSON type 0x06 (undefined) for fieldname "u1"
+
+OK: MongoDB\Driver\Exception\UnexpectedValueException
+Detected unsupported BSON type 0x06 (undefined) for fieldname "u2"
+OK: MongoDB\Driver\Exception\UnexpectedValueException
+Detected unsupported BSON type 0x06 (undefined) for fieldname "u1"
+
+OK: MongoDB\Driver\Exception\UnexpectedValueException
+Detected unsupported BSON type 0x06 (undefined) for fieldname "u2"
+OK: MongoDB\Driver\Exception\UnexpectedValueException
+Detected unsupported BSON type 0x06 (undefined) for fieldname "u1"
+
+OK: MongoDB\Driver\Exception\UnexpectedValueException
+Detected unsupported BSON type 0x06 (undefined) for fieldname "u2"
+OK: MongoDB\Driver\Exception\UnexpectedValueException
+Detected unsupported BSON type 0x06 (undefined) for fieldname "u1"
+
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-302

Previously, the undefined, DBPointer, and symbol types were ignored since they were known to libbson and no visitor function was defined.