### PR TITLE
PHPC-932: Remove reference to Manager on Cursor, Server, and WriteResult

### DIFF
--- a/php_phongo.h
+++ b/php_phongo.h
@@ -113,14 +113,14 @@ void phongo_throw_exception_from_bson_error_t(bson_error_t *error TSRMLS_DC);
 
 zend_object_handlers *phongo_get_std_object_handlers(void);
 
-void                     phongo_server_init          (zval *return_value, zval *manager, int server_id TSRMLS_DC);
+void                     phongo_server_init          (zval *return_value, mongoc_client_t *client, int server_id TSRMLS_DC);
 void                     phongo_readconcern_init     (zval *return_value, const mongoc_read_concern_t *read_concern TSRMLS_DC);
 void                     phongo_readpreference_init  (zval *return_value, const mongoc_read_prefs_t *read_prefs TSRMLS_DC);
 void                     phongo_writeconcern_init    (zval *return_value, const mongoc_write_concern_t *write_concern TSRMLS_DC);
 mongoc_bulk_operation_t* phongo_bulkwrite_init       (zend_bool ordered);
-bool                     phongo_execute_write        (zval *manager, const char *namespace, php_phongo_bulkwrite_t  *bulk_write, const mongoc_write_concern_t *write_concern, int server_id, zval *return_value, int return_value_used TSRMLS_DC);
-int                      phongo_execute_command      (zval *manager, const char *db, zval *zcommand, zval *zreadPreference, int server_id, zval *return_value, int return_value_used TSRMLS_DC);
-int                      phongo_execute_query        (zval *manager, const char *namespace, zval *zquery, zval *zreadPreference, int server_id, zval *return_value, int return_value_used TSRMLS_DC);
+bool                     phongo_execute_write        (mongoc_client_t *client, const char *namespace, php_phongo_bulkwrite_t  *bulk_write, const mongoc_write_concern_t *write_concern, int server_id, zval *return_value, int return_value_used TSRMLS_DC);
+int                      phongo_execute_command      (mongoc_client_t *client, const char *db, zval *zcommand, zval *zreadPreference, int server_id, zval *return_value, int return_value_used TSRMLS_DC);
+int                      phongo_execute_query        (mongoc_client_t *client, const char *namespace, zval *zquery, zval *zreadPreference, int server_id, zval *return_value, int return_value_used TSRMLS_DC);
 
 const mongoc_read_concern_t*  phongo_read_concern_from_zval   (zval *zread_concern TSRMLS_DC);
 const mongoc_read_prefs_t*    phongo_read_preference_from_zval(zval *zread_preference TSRMLS_DC);

--- a/php_phongo_structs.h
+++ b/php_phongo_structs.h
@@ -52,7 +52,6 @@ typedef struct {
 typedef struct {
 	PHONGO_ZEND_OBJECT_PRE
 	mongoc_cursor_t       *cursor;
-	PHONGO_STRUCT_ZVAL     manager;
 	mongoc_client_t       *client;
 	int                    server_id;
 	php_phongo_bson_state  visitor_data;
@@ -100,7 +99,6 @@ typedef struct {
 
 typedef struct {
 	PHONGO_ZEND_OBJECT_PRE
-	PHONGO_STRUCT_ZVAL  manager;
 	mongoc_client_t    *client;
 	int                 server_id;
 	PHONGO_ZEND_OBJECT_POST
@@ -133,7 +131,6 @@ typedef struct {
 	PHONGO_ZEND_OBJECT_PRE
 	mongoc_write_concern_t *write_concern;
 	bson_t                 *reply;
-	PHONGO_STRUCT_ZVAL      manager;
 	mongoc_client_t        *client;
 	int                     server_id;
 	PHONGO_ZEND_OBJECT_POST

--- a/src/MongoDB/Cursor.c
+++ b/src/MongoDB/Cursor.c
@@ -313,11 +313,7 @@ static PHP_METHOD(Cursor, getServer)
 		return;
 	}
 
-#if PHP_VERSION_ID >= 70000
-	phongo_server_init(return_value, &intern->manager, intern->server_id TSRMLS_CC);
-#else
-	phongo_server_init(return_value, intern->manager, intern->server_id TSRMLS_CC);
-#endif
+	phongo_server_init(return_value, intern->client, intern->server_id TSRMLS_CC);
 } /* }}} */
 
 /* {{{ proto boolean MongoDB\Driver\Cursor::isDead()
@@ -391,8 +387,6 @@ static void php_phongo_cursor_free_object(phongo_free_object_arg *object TSRMLS_
 	}
 
 	php_phongo_cursor_free_current(intern);
-
-	zval_ptr_dtor(&intern->manager);
 
 #if PHP_VERSION_ID < 70000
 	efree(intern);
@@ -506,13 +500,13 @@ static HashTable *php_phongo_cursor_get_debug_info(zval *object, int *is_temp TS
 #if PHP_VERSION_ID >= 70000
 		zval server;
 
-		phongo_server_init(&server, &intern->manager, intern->server_id TSRMLS_CC);
+		phongo_server_init(&server, intern->client, intern->server_id TSRMLS_CC);
 		ADD_ASSOC_ZVAL_EX(&retval, "server", &server);
 #else
 		zval *server = NULL;
 
 		MAKE_STD_ZVAL(server);
-		phongo_server_init(server, intern->manager, intern->server_id TSRMLS_CC);
+		phongo_server_init(server, intern->client, intern->server_id TSRMLS_CC);
 		ADD_ASSOC_ZVAL_EX(&retval, "server", server);
 #endif
 	}

--- a/src/MongoDB/Manager.c
+++ b/src/MongoDB/Manager.c
@@ -197,6 +197,7 @@ static PHP_METHOD(Manager, __construct)
    Execute a Command */
 static PHP_METHOD(Manager, executeCommand)
 {
+	php_phongo_manager_t     *intern;
 	char                     *db;
 	phongo_zpp_char_len       db_len;
 	zval                     *command;
@@ -208,13 +209,16 @@ static PHP_METHOD(Manager, executeCommand)
 		return;
 	}
 
-	phongo_execute_command(getThis(), db, command, readPreference, -1, return_value, return_value_used TSRMLS_CC);
+	intern = Z_MANAGER_OBJ_P(getThis());
+
+	phongo_execute_command(intern->client, db, command, readPreference, -1, return_value, return_value_used TSRMLS_CC);
 } /* }}} */
 
 /* {{{ proto MongoDB\Driver\Cursor MongoDB\Driver\Manager::executeQuery(string $namespace, MongoDB\Driver\Query $query[, MongoDB\Driver\ReadPreference $readPreference = null])
    Execute a Query */
 static PHP_METHOD(Manager, executeQuery)
 {
+	php_phongo_manager_t     *intern;
 	char                     *namespace;
 	phongo_zpp_char_len       namespace_len;
 	zval                     *query;
@@ -226,13 +230,16 @@ static PHP_METHOD(Manager, executeQuery)
 		return;
 	}
 
-	phongo_execute_query(getThis(), namespace, query, readPreference, -1, return_value, return_value_used TSRMLS_CC);
+	intern = Z_MANAGER_OBJ_P(getThis());
+
+	phongo_execute_query(intern->client, namespace, query, readPreference, -1, return_value, return_value_used TSRMLS_CC);
 } /* }}} */
 
 /* {{{ proto MongoDB\Driver\WriteResult MongoDB\Driver\Manager::executeBulkWrite(string $namespace, MongoDB\Driver\BulkWrite $zbulk[, MongoDB\Driver\WriteConcern $writeConcern = null])
    Executes a BulkWrite (i.e. any number of insert, update, and delete ops) */
 static PHP_METHOD(Manager, executeBulkWrite)
 {
+	php_phongo_manager_t      *intern;
 	char                      *namespace;
 	phongo_zpp_char_len        namespace_len;
 	zval                      *zbulk;
@@ -245,9 +252,10 @@ static PHP_METHOD(Manager, executeBulkWrite)
 		return;
 	}
 
-
+	intern = Z_MANAGER_OBJ_P(getThis());
 	bulk = Z_BULKWRITE_OBJ_P(zbulk);
-	phongo_execute_write(getThis(), namespace, bulk, phongo_write_concern_from_zval(zwrite_concern TSRMLS_CC), -1, return_value, return_value_used TSRMLS_CC);
+
+	phongo_execute_write(intern->client, namespace, bulk, phongo_write_concern_from_zval(zwrite_concern TSRMLS_CC), -1, return_value, return_value_used TSRMLS_CC);
 } /* }}} */
 
 /* {{{ proto MongoDB\Driver\ReadConcern MongoDB\Driver\Manager::getReadConcern()
@@ -311,13 +319,13 @@ static PHP_METHOD(Manager, getServers)
 #if PHP_VERSION_ID >= 70000
 		zval obj;
 
-		phongo_server_init(&obj, getThis(), mongoc_server_description_id(sds[i]) TSRMLS_CC);
+		phongo_server_init(&obj, intern->client, mongoc_server_description_id(sds[i]) TSRMLS_CC);
 		add_next_index_zval(return_value, &obj);
 #else
 		zval *obj = NULL;
 
 		MAKE_STD_ZVAL(obj);
-		phongo_server_init(obj, getThis(), mongoc_server_description_id(sds[i]) TSRMLS_CC);
+		phongo_server_init(obj, intern->client, mongoc_server_description_id(sds[i]) TSRMLS_CC);
 		add_next_index_zval(return_value, obj);
 #endif
 	}
@@ -365,7 +373,7 @@ static PHP_METHOD(Manager, selectServer)
 	readPreference = phongo_read_preference_from_zval(zreadPreference TSRMLS_CC);
 	selected_server = mongoc_client_select_server(intern->client, false, readPreference, &error);
 	if (selected_server) {
-		phongo_server_init(return_value, getThis(), mongoc_server_description_id(selected_server) TSRMLS_CC);
+		phongo_server_init(return_value, intern->client, mongoc_server_description_id(selected_server) TSRMLS_CC);
 		mongoc_server_description_destroy(selected_server);
 	} else {
 		/* Check for connection related exceptions */

--- a/src/MongoDB/Server.c
+++ b/src/MongoDB/Server.c
@@ -46,11 +46,7 @@ static PHP_METHOD(Server, executeCommand)
 		return;
 	}
 
-#if PHP_VERSION_ID >= 70000
-	phongo_execute_command(&intern->manager, db, command, readPreference, intern->server_id, return_value, return_value_used TSRMLS_CC);
-#else
-	phongo_execute_command(intern->manager, db, command, readPreference, intern->server_id, return_value, return_value_used TSRMLS_CC);
-#endif
+	phongo_execute_command(intern->client, db, command, readPreference, intern->server_id, return_value, return_value_used TSRMLS_CC);
 } /* }}} */
 
 /* {{{ proto MongoDB\Driver\Cursor MongoDB\Driver\Server::executeQuery(string $namespace, MongoDB\Driver\Query $query[, MongoDB\Driver\ReadPreference $readPreference = null]))
@@ -72,11 +68,7 @@ static PHP_METHOD(Server, executeQuery)
 		return;
 	}
 
-#if PHP_VERSION_ID >= 70000
-	phongo_execute_query(&intern->manager, namespace, query, readPreference, intern->server_id, return_value, return_value_used TSRMLS_CC);
-#else
-	phongo_execute_query(intern->manager, namespace, query, readPreference, intern->server_id, return_value, return_value_used TSRMLS_CC);
-#endif
+	phongo_execute_query(intern->client, namespace, query, readPreference, intern->server_id, return_value, return_value_used TSRMLS_CC);
 } /* }}} */
 
 /* {{{ proto MongoDB\Driver\WriteResult MongoDB\Driver\Server::executeBulkWrite(string $namespace, MongoDB\Driver\BulkWrite $zbulk[, MongoDB\Driver\WriteConcern $writeConcern = null])
@@ -102,11 +94,8 @@ static PHP_METHOD(Server, executeBulkWrite)
 
 
 	bulk = Z_BULKWRITE_OBJ_P(zbulk);
-#if PHP_VERSION_ID >= 70000
-	phongo_execute_write(&intern->manager, namespace, bulk, phongo_write_concern_from_zval(zwrite_concern TSRMLS_CC), intern->server_id, return_value, return_value_used TSRMLS_CC);
-#else
-	phongo_execute_write(intern->manager, namespace, bulk, phongo_write_concern_from_zval(zwrite_concern TSRMLS_CC), intern->server_id, return_value, return_value_used TSRMLS_CC);
-#endif
+
+	phongo_execute_write(intern->client, namespace, bulk, phongo_write_concern_from_zval(zwrite_concern TSRMLS_CC), intern->server_id, return_value, return_value_used TSRMLS_CC);
 } /* }}} */
 
 /* {{{ proto string MongoDB\Driver\Server::getHost()
@@ -491,8 +480,6 @@ static void php_phongo_server_free_object(phongo_free_object_arg *object TSRMLS_
 	php_phongo_server_t *intern = Z_OBJ_SERVER(object);
 
 	zend_object_std_dtor(&intern->std TSRMLS_CC);
-
-	zval_ptr_dtor(&intern->manager);
 
 #if PHP_VERSION_ID < 70000
 	efree(intern);

--- a/src/MongoDB/WriteResult.c
+++ b/src/MongoDB/WriteResult.c
@@ -238,11 +238,7 @@ static PHP_METHOD(WriteResult, getServer)
 		return;
 	}
 
-#if PHP_VERSION_ID >= 70000
-	phongo_server_init(return_value, &intern->manager, intern->server_id TSRMLS_CC);
-#else
-	phongo_server_init(return_value, intern->manager, intern->server_id TSRMLS_CC);
-#endif
+	phongo_server_init(return_value, intern->client, intern->server_id TSRMLS_CC);
 } /* }}} */
 
 /* {{{ proto array MongoDB\Driver\WriteResult::getUpsertedIds()
@@ -397,8 +393,6 @@ static void php_phongo_writeresult_free_object(phongo_free_object_arg *object TS
 	if (intern->write_concern) {
 		mongoc_write_concern_destroy(intern->write_concern);
 	}
-
-	zval_ptr_dtor(&intern->manager);
 
 #if PHP_VERSION_ID < 70000
 	efree(intern);


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-932

This reverts changes introduced in PHPC-671, which are no longer necessary due to mongoc_client_t persistence (PHPC-433).