### PR TITLE
[WAIT] PHPC-828: Use canonical extended JSON for Timestamp::jsonSerialize()

### DIFF
--- a/tests/bson/bson-timestamp-jsonserialize-001.phpt
+++ b/tests/bson/bson-timestamp-jsonserialize-001.phpt
@@ -12,11 +12,6 @@ var_dump($ts->jsonSerialize());
 --EXPECT--
 array(1) {
   ["$timestamp"]=>
-  array(2) {
-    ["t"]=>
-    int(5678)
-    ["i"]=>
-    int(1234)
-  }
+  string(14) "24386824307922"
 }
 ===DONE===

--- a/tests/bson/bson-timestamp-jsonserialize-002.phpt
+++ b/tests/bson/bson-timestamp-jsonserialize-002.phpt
@@ -17,7 +17,7 @@ var_dump(toPHP(fromJSON($json)));
 <?php exit(0); ?>
 --EXPECTF--
 { "foo" : { "$timestamp" : { "t" : 5678, "i" : 1234 } } }
-{"foo":{"$timestamp":{"t":5678,"i":1234}}}
+{"foo":{"$timestamp":"24386824307922"}}
 object(stdClass)#%d (%d) {
   ["foo"]=>
   object(MongoDB\BSON\Timestamp)#%d (%d) {


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-828

This is waiting on https://github.com/mongodb/libbson/commit/578b832e9b8f4bc3f5b57fc64c4cd1ccab09023a to be released in libbson 1.7.0.