### PR TITLE
PHPC-940: php_phongo_free_ssl_opt() attempts to free interned strings

### DIFF
--- a/src/contrib/php_array_api.h
+++ b/src/contrib/php_array_api.h
@@ -355,13 +355,10 @@ char *php_array_zval_to_string(zval *z, int *plen, zend_bool *pfree) {
 	*plen = 0;
 	*pfree = 0;
 	if (!z) { return NULL; }
-	*pfree = 1;
 	switch (Z_TYPE_P(z)) {
 		case IS_NULL:
-			*pfree = 0;
 			return (char *)"";
 		case IS_STRING:
-			*pfree = 0;
 			*plen = Z_STRLEN_P(z);
 			return Z_STRVAL_P(z);
 		default:
@@ -369,6 +366,11 @@ char *php_array_zval_to_string(zval *z, int *plen, zend_bool *pfree) {
 			zval c = *z;
 			zval_copy_ctor(&c);
 			convert_to_string(&c);
+#ifdef ZEND_ENGINE_3
+			*pfree = ! IS_INTERNED(Z_STR(c));
+#else
+			*pfree = ! IS_INTERNED(Z_STRVAL(c));
+#endif
 			*plen = Z_STRLEN(c);
 			return Z_STRVAL(c);
 		}

--- a/tests/manager/bug0940-001.phpt
+++ b/tests/manager/bug0940-001.phpt
@@ -1,0 +1,21 @@
+--TEST--
+PHPC-940: php_phongo_free_ssl_opt() attempts to free interned strings
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+--FILE--
+<?php
+
+var_dump(new MongoDB\Driver\Manager(null, [], ['ca_file' => false]));
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+object(MongoDB\Driver\Manager)#%d (%d) {
+  ["uri"]=>
+  string(20) "mongodb://127.0.0.1/"
+  ["cluster"]=>
+  array(0) {
+  }
+}
+===DONE===

--- a/tests/manager/bug0940-002.phpt
+++ b/tests/manager/bug0940-002.phpt
@@ -1,0 +1,23 @@
+--TEST--
+PHPC-940: php_phongo_free_ssl_opt() attempts to free interned strings (context option)
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+--FILE--
+<?php
+
+$context = stream_context_create(['ssl' => ['cafile' => false]]); 
+
+var_dump(new MongoDB\Driver\Manager(null, [], ['context' => $context]));
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+object(MongoDB\Driver\Manager)#%d (%d) {
+  ["uri"]=>
+  string(20) "mongodb://127.0.0.1/"
+  ["cluster"]=>
+  array(0) {
+  }
+}
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-940

This issue only manifests itself on PHP 7, since interned strings are tracked in the zval struct instead of the character pointer as in PHP 5.x.