### PR TITLE
PHPC-949: Fix leak if bsonSerialize() returns keys with null bytes

### DIFF
--- a/src/bson.c
+++ b/src/bson.c
@@ -1384,7 +1384,7 @@ void phongo_zval_to_bson(zval *data, php_phongo_bson_flags_t flags, bson_t *bson
 				if (strlen(ZSTR_VAL(string_key)) != ZSTR_LEN(string_key)) {
 					phongo_throw_exception(PHONGO_ERROR_UNEXPECTED_VALUE TSRMLS_CC, "BSON keys cannot contain null bytes. Unexpected null byte after \"%s\".", ZSTR_VAL(string_key));
 
-					return;
+					goto cleanup;
 				}
 
 				if (flags & PHONGO_BSON_ADD_ID) {
@@ -1436,7 +1436,7 @@ void phongo_zval_to_bson(zval *data, php_phongo_bson_flags_t flags, bson_t *bson
 			if (strlen(string_key) != string_key_len - 1) {
 				phongo_throw_exception(PHONGO_ERROR_UNEXPECTED_VALUE TSRMLS_CC, "BSON keys cannot contain null bytes. Unexpected null byte after \"%s\".", ZSTR_VAL(string_key));
 
-				return;
+				goto cleanup;
 			}
 
 			if (flags & PHONGO_BSON_ADD_ID) {

--- a/tests/bson/bson-fromPHP_error-007.phpt
+++ b/tests/bson/bson-fromPHP_error-007.phpt
@@ -1,0 +1,85 @@
+--TEST--
+BSON\fromPHP(): Serializable returns document with null bytes in field name
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/tools.php';
+
+class MySerializable implements MongoDB\BSON\Serializable
+{
+    private $data;
+
+    public function __construct($data)
+    {
+        $this->data = $data;
+    }
+
+    public function bsonSerialize()
+    {
+        return $this->data;
+    }
+}
+
+echo "\nTesting array with one leading null byte in field name\n";
+echo throws(function() {
+    fromPHP(new MySerializable(["\0" => 1]));
+}, 'MongoDB\Driver\Exception\UnexpectedValueException'), "\n";
+
+echo "\nTesting array with one trailing null byte in field name\n";
+echo throws(function() {
+    fromPHP(new MySerializable(["a\0" => 1]));
+}, 'MongoDB\Driver\Exception\UnexpectedValueException'), "\n";
+
+echo "\nTesting array with multiple null bytes in field name\n";
+echo throws(function() {
+    fromPHP(new MySerializable(["\0\0\0" => 1]));
+}, 'MongoDB\Driver\Exception\UnexpectedValueException'), "\n";
+
+/* Per PHPC-884, field names with a leading null byte are ignored when encoding
+ * a document from an object's property hash table, since PHP uses leading bytes
+ * to denote protected and private properties. However, in this case the object
+ * was returned from Serializable::bsonSerialize() and we skip the check for
+ * protected and private properties. */
+echo "\nTesting object with one leading null byte in field name\n";
+echo throws(function() {
+    fromPHP(new MySerializable((object) ["\0" => 1]));
+}, 'MongoDB\Driver\Exception\UnexpectedValueException'), "\n";
+
+echo "\nTesting object with one trailing null byte in field name\n";
+echo throws(function() {
+    fromPHP(new MySerializable((object) ["a\0" => 1]));
+}, 'MongoDB\Driver\Exception\UnexpectedValueException'), "\n";
+
+echo "\nTesting object with multiple null bytes in field name\n";
+echo throws(function() {
+    fromPHP(new MySerializable((object) ["\0\0\0" => 1]));
+}, 'MongoDB\Driver\Exception\UnexpectedValueException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+Testing array with one leading null byte in field name
+OK: Got MongoDB\Driver\Exception\UnexpectedValueException
+BSON keys cannot contain null bytes. Unexpected null byte after "".
+
+Testing array with one trailing null byte in field name
+OK: Got MongoDB\Driver\Exception\UnexpectedValueException
+BSON keys cannot contain null bytes. Unexpected null byte after "a".
+
+Testing array with multiple null bytes in field name
+OK: Got MongoDB\Driver\Exception\UnexpectedValueException
+BSON keys cannot contain null bytes. Unexpected null byte after "".
+
+Testing object with one leading null byte in field name
+OK: Got MongoDB\Driver\Exception\UnexpectedValueException
+BSON keys cannot contain null bytes. Unexpected null byte after "".
+
+Testing object with one trailing null byte in field name
+OK: Got MongoDB\Driver\Exception\UnexpectedValueException
+BSON keys cannot contain null bytes. Unexpected null byte after "a".
+
+Testing object with multiple null bytes in field name
+OK: Got MongoDB\Driver\Exception\UnexpectedValueException
+BSON keys cannot contain null bytes. Unexpected null byte after "".
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-949

Depends on https://github.com/mongodb/mongo-php-driver/pull/575. Only the last commit is relevant to the fix.