### PR TITLE
PHPC-772, PHPC-953, PHPC-957: Parse "authMechanism" and "authMechanismProperties" URI options and ignore "database"

### DIFF
--- a/php_phongo.c
+++ b/php_phongo.c
@@ -930,15 +930,15 @@ static mongoc_uri_t *php_phongo_make_uri(const char *uri_string, bson_t *options
 
 			/* Skip read preference and write concern options, as those must be
 			 * processed after the mongoc_client_t is constructed. */
-			if (!strcasecmp(key, "journal") ||
-			    !strcasecmp(key, "readpreference") ||
-			    !strcasecmp(key, "readpreferencetags") ||
-			    !strcasecmp(key, "safe") ||
-			    !strcasecmp(key, "slaveok") ||
-			    !strcasecmp(key, "w") ||
-			    !strcasecmp(key, "wtimeoutms") ||
-			    !strcasecmp(key, "maxstalenessseconds") ||
-			    !strcasecmp(key, "appname")
+			if (!strcasecmp(key, MONGOC_URI_JOURNAL) ||
+			    !strcasecmp(key, MONGOC_URI_READPREFERENCE) ||
+			    !strcasecmp(key, MONGOC_URI_READPREFERENCETAGS) ||
+			    !strcasecmp(key, MONGOC_URI_SAFE) ||
+			    !strcasecmp(key, MONGOC_URI_SLAVEOK) ||
+			    !strcasecmp(key, MONGOC_URI_W) ||
+			    !strcasecmp(key, MONGOC_URI_WTIMEOUTMS) ||
+			    !strcasecmp(key, MONGOC_URI_MAXSTALENESSSECONDS) ||
+			    !strcasecmp(key, MONGOC_URI_APPNAME)
 			) {
 				continue;
 			}
@@ -961,7 +961,7 @@ static mongoc_uri_t *php_phongo_make_uri(const char *uri_string, bson_t *options
 					mongoc_uri_set_password(uri, value);
 				} else if (!strcasecmp(key, "database")) {
 					mongoc_uri_set_database(uri, value);
-				} else if (!strcasecmp(key, "authsource")) {
+				} else if (!strcasecmp(key, MONGOC_URI_AUTHSOURCE)) {
 					mongoc_uri_set_auth_source(uri, value);
 				}
 			}
@@ -1023,21 +1023,21 @@ static bool php_phongo_apply_rp_options_to_uri(mongoc_uri_t *uri, bson_t *option
 		return true;
 	}
 
-	if (!bson_iter_init_find_case(&iter, options, "slaveok") &&
-	    !bson_iter_init_find_case(&iter, options, "readpreference") &&
-	    !bson_iter_init_find_case(&iter, options, "readpreferencetags") &&
-	    !bson_iter_init_find_case(&iter, options, "maxstalenessseconds")
+	if (!bson_iter_init_find_case(&iter, options, MONGOC_URI_SLAVEOK) &&
+	    !bson_iter_init_find_case(&iter, options, MONGOC_URI_READPREFERENCE) &&
+	    !bson_iter_init_find_case(&iter, options, MONGOC_URI_READPREFERENCETAGS) &&
+	    !bson_iter_init_find_case(&iter, options, MONGOC_URI_MAXSTALENESSSECONDS)
 	) {
 		return true;
 	}
 
 	new_rp = mongoc_read_prefs_copy(old_rp);
 
-	if (bson_iter_init_find_case(&iter, options, "slaveok") && BSON_ITER_HOLDS_BOOL(&iter) && bson_iter_bool(&iter)) {
+	if (bson_iter_init_find_case(&iter, options, MONGOC_URI_SLAVEOK) && BSON_ITER_HOLDS_BOOL(&iter) && bson_iter_bool(&iter)) {
 		mongoc_read_prefs_set_mode(new_rp, MONGOC_READ_SECONDARY_PREFERRED);
 	}
 
-	if (bson_iter_init_find_case(&iter, options, "readpreference") && BSON_ITER_HOLDS_UTF8(&iter)) {
+	if (bson_iter_init_find_case(&iter, options, MONGOC_URI_READPREFERENCE) && BSON_ITER_HOLDS_UTF8(&iter)) {
 		const char *str = bson_iter_utf8(&iter, NULL);
 
 		if (0 == strcasecmp("primary", str)) {
@@ -1058,7 +1058,7 @@ static bool php_phongo_apply_rp_options_to_uri(mongoc_uri_t *uri, bson_t *option
 		}
 	}
 
-	if (bson_iter_init_find_case(&iter, options, "readpreferencetags") && BSON_ITER_HOLDS_ARRAY(&iter)) {
+	if (bson_iter_init_find_case(&iter, options, MONGOC_URI_READPREFERENCETAGS) && BSON_ITER_HOLDS_ARRAY(&iter)) {
 		bson_t tags;
 		uint32_t len;
 		const uint8_t *data;
@@ -1092,7 +1092,7 @@ static bool php_phongo_apply_rp_options_to_uri(mongoc_uri_t *uri, bson_t *option
 
 	/* Handle maxStalenessSeconds, and make sure it is not combined with primary
 	 * readPreference */
-	if (bson_iter_init_find_case(&iter, options, "maxstalenessseconds") && BSON_ITER_HOLDS_INT32(&iter)) {
+	if (bson_iter_init_find_case(&iter, options, MONGOC_URI_MAXSTALENESSSECONDS) && BSON_ITER_HOLDS_INT32(&iter)) {
 		int32_t max_staleness_seconds = bson_iter_int32(&iter);
 
 		if (max_staleness_seconds != MONGOC_NO_MAX_STALENESS) {
@@ -1151,10 +1151,10 @@ static bool php_phongo_apply_wc_options_to_uri(mongoc_uri_t *uri, bson_t *option
 		return true;
 	}
 
-	if (!bson_iter_init_find_case(&iter, options, "journal") &&
-	    !bson_iter_init_find_case(&iter, options, "safe") &&
-	    !bson_iter_init_find_case(&iter, options, "w") &&
-	    !bson_iter_init_find_case(&iter, options, "wtimeoutms")) {
+	if (!bson_iter_init_find_case(&iter, options, MONGOC_URI_JOURNAL) &&
+	    !bson_iter_init_find_case(&iter, options, MONGOC_URI_SAFE) &&
+	    !bson_iter_init_find_case(&iter, options, MONGOC_URI_W) &&
+	    !bson_iter_init_find_case(&iter, options, MONGOC_URI_WTIMEOUTMS)) {
 		return true;
 	}
 
@@ -1162,19 +1162,19 @@ static bool php_phongo_apply_wc_options_to_uri(mongoc_uri_t *uri, bson_t *option
 
 	new_wc = mongoc_write_concern_copy(old_wc);
 
-	if (bson_iter_init_find_case(&iter, options, "safe") && BSON_ITER_HOLDS_BOOL(&iter)) {
+	if (bson_iter_init_find_case(&iter, options, MONGOC_URI_SAFE) && BSON_ITER_HOLDS_BOOL(&iter)) {
 		mongoc_write_concern_set_w(new_wc, bson_iter_bool(&iter) ? 1 : MONGOC_WRITE_CONCERN_W_UNACKNOWLEDGED);
 	}
 
-	if (bson_iter_init_find_case(&iter, options, "wtimeoutms") && BSON_ITER_HOLDS_INT32(&iter)) {
+	if (bson_iter_init_find_case(&iter, options, MONGOC_URI_WTIMEOUTMS) && BSON_ITER_HOLDS_INT32(&iter)) {
 		wtimeoutms = bson_iter_int32(&iter);
 	}
 
-	if (bson_iter_init_find_case(&iter, options, "journal") && BSON_ITER_HOLDS_BOOL(&iter)) {
+	if (bson_iter_init_find_case(&iter, options, MONGOC_URI_JOURNAL) && BSON_ITER_HOLDS_BOOL(&iter)) {
 		mongoc_write_concern_set_journal(new_wc, bson_iter_bool(&iter));
 	}
 
-	if (bson_iter_init_find_case(&iter, options, "w")) {
+	if (bson_iter_init_find_case(&iter, options, MONGOC_URI_W)) {
 		if (BSON_ITER_HOLDS_INT32(&iter)) {
 			int32_t value = bson_iter_int32(&iter);
 
@@ -1728,7 +1728,7 @@ void phongo_manager_init(php_phongo_manager_t *manager, const char *uri_string, 
 		goto cleanup;
 	}
 
-	if (bson_iter_init_find_case(&iter, &bson_options, "appname") && BSON_ITER_HOLDS_UTF8(&iter)) {
+	if (bson_iter_init_find_case(&iter, &bson_options, MONGOC_URI_APPNAME) && BSON_ITER_HOLDS_UTF8(&iter)) {
 		const char *str = bson_iter_utf8(&iter, NULL);
 
 		if (!mongoc_uri_set_appname(uri, str)) {

--- a/php_phongo.c
+++ b/php_phongo.c
@@ -959,8 +959,6 @@ static mongoc_uri_t *php_phongo_make_uri(const char *uri_string, bson_t *options
 					mongoc_uri_set_username(uri, value);
 				} else if (!strcasecmp(key, "password")) {
 					mongoc_uri_set_password(uri, value);
-				} else if (!strcasecmp(key, "database")) {
-					mongoc_uri_set_database(uri, value);
 				} else if (!strcasecmp(key, MONGOC_URI_AUTHSOURCE)) {
 					mongoc_uri_set_auth_source(uri, value);
 				}

--- a/src/MongoDB/Manager.c
+++ b/src/MongoDB/Manager.c
@@ -92,12 +92,87 @@ static bool php_phongo_manager_merge_context_options(zval *zdriverOptions TSRMLS
 	return true;
 } /* }}} */
 
-/* Prepare tagSets for BSON encoding by converting each array in the set to an
- * object. This ensures that empty arrays will serialize as empty documents.
+/* Prepare authMechanismProperties for BSON encoding by converting a boolean
+ * value for the "CANONICALIZE_HOST_NAME" option to a string.
  *
- * php_phongo_read_preference_tags_are_valid() handles actual validation of the
- * tag set structure. */
-static void php_phongo_manager_prep_tagsets(zval *options TSRMLS_DC) /* {{{ */
+ * Note: URI options are case-insensitive, so we must iterate through the
+ * HashTable in order to detect options. */
+static void php_phongo_manager_prep_authmechanismproperties(zval *properties TSRMLS_DC) /* {{{ */
+{
+	HashTable *ht_data;
+
+	if (Z_TYPE_P(properties) != IS_ARRAY && Z_TYPE_P(properties) != IS_OBJECT) {
+		return;
+	}
+
+	ht_data = HASH_OF(properties);
+
+#if PHP_VERSION_ID >= 70000
+	{
+		zend_string *string_key = NULL;
+		zend_ulong   num_key = 0;
+		zval        *property;
+
+		ZEND_HASH_FOREACH_KEY_VAL(ht_data, num_key, string_key, property) {
+			if (!string_key) {
+				continue;
+			}
+
+			/* URI options are case-insensitive */
+			if (!strcasecmp(ZSTR_VAL(string_key), "CANONICALIZE_HOST_NAME")) {
+				ZVAL_DEREF(property);
+				if (Z_TYPE_P(property) != IS_STRING && zend_is_true(property)) {
+					SEPARATE_ZVAL_NOREF(property);
+					ZVAL_NEW_STR(property, zend_string_init(ZEND_STRL("true"), 0));
+				}
+			}
+		} ZEND_HASH_FOREACH_END();
+	}
+#else
+	{
+		HashPosition   pos;
+		zval         **property;
+
+		for (zend_hash_internal_pointer_reset_ex(ht_data, &pos);
+		     zend_hash_get_current_data_ex(ht_data, (void **) &property, &pos) == SUCCESS;
+		     zend_hash_move_forward_ex(ht_data, &pos)) {
+			char  *string_key = NULL;
+			uint   string_key_len = 0;
+			ulong  num_key = 0;
+
+			if (HASH_KEY_IS_STRING != zend_hash_get_current_key_ex(ht_data, &string_key, &string_key_len, &num_key, 0, &pos)) {
+				continue;
+			}
+
+			/* URI options are case-insensitive */
+			if (!strcasecmp(string_key, "CANONICALIZE_HOST_NAME")) {
+				if (Z_TYPE_PP(property) != IS_STRING && zend_is_true(*property)) {
+					SEPARATE_ZVAL_IF_NOT_REF(property);
+					Z_TYPE_PP(property) = IS_STRING;
+					Z_STRVAL_PP(property) = estrndup("true", sizeof("true")-1);
+					Z_STRLEN_PP(property) = sizeof("true")-1;
+				}
+			}
+		}
+	}
+#endif
+
+	return;
+} /* }}} */
+
+/* Prepare URI options for BSON encoding.
+ *
+ * Read preference tag sets must be an array of documents. In order to ensure
+ * that empty arrays serialize as empty documents, array elements will be
+ * converted to objects. php_phongo_read_preference_tags_are_valid() handles
+ * actual validation of the tag set structure.
+ *
+ * Auth mechanism properties must have string values, so a boolean true value
+ * for the "CANONICALIZE_HOST_NAME" property will be converted to "true".
+ *
+ * Note: URI options are case-insensitive, so we must iterate through the
+ * HashTable in order to detect options. */
+static void php_phongo_manager_prep_uri_options(zval *options TSRMLS_DC) /* {{{ */
 {
 	HashTable     *ht_data;
 
@@ -111,29 +186,35 @@ static void php_phongo_manager_prep_tagsets(zval *options TSRMLS_DC) /* {{{ */
 	{
 		zend_string *string_key = NULL;
 		zend_ulong   num_key = 0;
-		zval        *tagSets;
+		zval        *option;
 
-		ZEND_HASH_FOREACH_KEY_VAL(ht_data, num_key, string_key, tagSets) {
+		ZEND_HASH_FOREACH_KEY_VAL(ht_data, num_key, string_key, option) {
 			if (!string_key) {
 				continue;
 			}
 
-			/* php_phongo_make_uri() and php_phongo_apply_rp_options_to_uri()
-			 * are both case-insensitive, so we need to be as well. */
 			if (!strcasecmp(ZSTR_VAL(string_key), MONGOC_URI_READPREFERENCETAGS)) {
-				ZVAL_DEREF(tagSets);
-				SEPARATE_ZVAL_NOREF(tagSets);
-				php_phongo_read_preference_prep_tagsets(tagSets TSRMLS_CC);
+				ZVAL_DEREF(option);
+				SEPARATE_ZVAL_NOREF(option);
+				php_phongo_read_preference_prep_tagsets(option TSRMLS_CC);
+				continue;
+			}
+
+			if (!strcasecmp(ZSTR_VAL(string_key), MONGOC_URI_AUTHMECHANISMPROPERTIES)) {
+				ZVAL_DEREF(option);
+				SEPARATE_ZVAL_NOREF(option);
+				php_phongo_manager_prep_authmechanismproperties(option TSRMLS_CC);
+				continue;
 			}
 		} ZEND_HASH_FOREACH_END();
 	}
 #else
 	{
 		HashPosition   pos;
-		zval         **tagSets;
+		zval         **option;
 
 		for (zend_hash_internal_pointer_reset_ex(ht_data, &pos);
-		     zend_hash_get_current_data_ex(ht_data, (void **) &tagSets, &pos) == SUCCESS;
+		     zend_hash_get_current_data_ex(ht_data, (void **) &option, &pos) == SUCCESS;
 		     zend_hash_move_forward_ex(ht_data, &pos)) {
 			char  *string_key = NULL;
 			uint   string_key_len = 0;
@@ -143,11 +224,16 @@ static void php_phongo_manager_prep_tagsets(zval *options TSRMLS_DC) /* {{{ */
 				continue;
 			}
 
-			/* php_phongo_make_uri() and php_phongo_apply_rp_options_to_uri()
-			 * are both case-insensitive, so we need to be as well. */
 			if (!strcasecmp(string_key, MONGOC_URI_READPREFERENCETAGS)) {
-				SEPARATE_ZVAL_IF_NOT_REF(tagSets);
-				php_phongo_read_preference_prep_tagsets(*tagSets TSRMLS_CC);
+				SEPARATE_ZVAL_IF_NOT_REF(option);
+				php_phongo_read_preference_prep_tagsets(*option TSRMLS_CC);
+				continue;
+			}
+
+			if (!strcasecmp(string_key, MONGOC_URI_AUTHMECHANISMPROPERTIES)) {
+				SEPARATE_ZVAL_IF_NOT_REF(option);
+				php_phongo_manager_prep_authmechanismproperties(*option TSRMLS_CC);
+				continue;
 			}
 		}
 	}
@@ -173,7 +259,7 @@ static PHP_METHOD(Manager, __construct)
 	intern = Z_MANAGER_OBJ_P(getThis());
 
 	/* Separate the options and driverOptions zvals, since we may end up
-	 * modifying them in php_phongo_manager_prep_tagsets() and
+	 * modifying them in php_phongo_manager_prep_uri_options() and
 	 * php_phongo_manager_merge_context_options() below, respectively. */
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|s!a/!a/!", &uri_string, &uri_string_len, &options, &driverOptions) == FAILURE) {
 		zend_restore_error_handling(&error_handling TSRMLS_CC);
@@ -182,7 +268,7 @@ static PHP_METHOD(Manager, __construct)
 	zend_restore_error_handling(&error_handling TSRMLS_CC);
 
 	if (options) {
-		php_phongo_manager_prep_tagsets(options TSRMLS_CC);
+		php_phongo_manager_prep_uri_options(options TSRMLS_CC);
 	}
 
 	if (driverOptions && !php_phongo_manager_merge_context_options(driverOptions TSRMLS_CC)) {

--- a/src/MongoDB/Manager.c
+++ b/src/MongoDB/Manager.c
@@ -120,7 +120,7 @@ static void php_phongo_manager_prep_tagsets(zval *options TSRMLS_DC) /* {{{ */
 
 			/* php_phongo_make_uri() and php_phongo_apply_rp_options_to_uri()
 			 * are both case-insensitive, so we need to be as well. */
-			if (!strcasecmp(ZSTR_VAL(string_key), "readpreferencetags")) {
+			if (!strcasecmp(ZSTR_VAL(string_key), MONGOC_URI_READPREFERENCETAGS)) {
 				ZVAL_DEREF(tagSets);
 				SEPARATE_ZVAL_NOREF(tagSets);
 				php_phongo_read_preference_prep_tagsets(tagSets TSRMLS_CC);
@@ -145,7 +145,7 @@ static void php_phongo_manager_prep_tagsets(zval *options TSRMLS_DC) /* {{{ */
 
 			/* php_phongo_make_uri() and php_phongo_apply_rp_options_to_uri()
 			 * are both case-insensitive, so we need to be as well. */
-			if (!strcasecmp(string_key, "readpreferencetags")) {
+			if (!strcasecmp(string_key, MONGOC_URI_READPREFERENCETAGS)) {
 				SEPARATE_ZVAL_IF_NOT_REF(tagSets);
 				php_phongo_read_preference_prep_tagsets(*tagSets TSRMLS_CC);
 			}

--- a/tests/connect/standalone-x509-extract_username-001.phpt
+++ b/tests/connect/standalone-x509-extract_username-001.phpt
@@ -17,11 +17,12 @@ $driverOptions = [
     'pem_file' => $SSL_DIR . '/client.pem',
 ];
 
-$parsed = parse_url(STANDALONE_X509);
-// TODO: authMechanism cannot be parsed from URI options array (PHPC-772)
-$uri = sprintf('mongodb://%s:%d/?ssl=true&authMechanism=MONGODB-X509', $parsed['host'], $parsed['port']);
+$uriOptions = ['authMechanism' => 'MONGODB-X509', 'ssl' => true];
 
-$manager = new MongoDB\Driver\Manager($uri, [], $driverOptions);
+$parsed = parse_url(STANDALONE_X509);
+$uri = sprintf('mongodb://%s:%d', $parsed['host'], $parsed['port']);
+
+$manager = new MongoDB\Driver\Manager($uri, $uriOptions, $driverOptions);
 $cursor = $manager->executeCommand(DATABASE_NAME, new MongoDB\Driver\Command(['ping' => 1]));
 var_dump($cursor->toArray()[0]);
 

--- a/tests/connect/standalone-x509-extract_username-002.phpt
+++ b/tests/connect/standalone-x509-extract_username-002.phpt
@@ -21,11 +21,12 @@ $driverOptions = [
     ]),
 ];
 
-$parsed = parse_url(STANDALONE_X509);
-// TODO: authMechanism cannot be parsed from URI options array (PHPC-772)
-$uri = sprintf('mongodb://%s:%d/?ssl=true&authMechanism=MONGODB-X509', $parsed['host'], $parsed['port']);
+$uriOptions = ['authMechanism' => 'MONGODB-X509', 'ssl' => true];
 
-$manager = new MongoDB\Driver\Manager($uri, [], $driverOptions);
+$parsed = parse_url(STANDALONE_X509);
+$uri = sprintf('mongodb://%s:%d', $parsed['host'], $parsed['port']);
+
+$manager = new MongoDB\Driver\Manager($uri, $uriOptions, $driverOptions);
 $cursor = $manager->executeCommand(DATABASE_NAME, new MongoDB\Driver\Command(['ping' => 1]));
 var_dump($cursor->toArray()[0]);
 

--- a/tests/manager/manager-ctor-auth_mechanism-001.phpt
+++ b/tests/manager/manager-ctor-auth_mechanism-001.phpt
@@ -1,0 +1,25 @@
+--TEST--
+MongoDB\Driver\Manager::__construct(): authMechanism option
+--FILE--
+<?php
+
+$tests = [
+    ['mongodb://127.0.0.1/?authMechanism=MONGODB-X509', []],
+    ['mongodb://127.0.0.1/?authMechanism=GSSAPI', []],
+    [null, ['authMechanism' => 'MONGODB-X509']],
+    [null, ['authMechanism' => 'GSSAPI']],
+];
+
+foreach ($tests as $test) {
+    list($uri, $options) = $test;
+
+    /* Note: the Manager's debug information does not include the auth mechanism
+     * so we are merely testing that no exception is thrown. */
+    $manager = new MongoDB\Driver\Manager($uri, $options);
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+===DONE===

--- a/tests/manager/manager-ctor-auth_mechanism-002.phpt
+++ b/tests/manager/manager-ctor-auth_mechanism-002.phpt
@@ -1,0 +1,29 @@
+--TEST--
+MongoDB\Driver\Manager::__construct(): authMechanismProperties option
+--FILE--
+<?php
+
+$tests = [
+    ['mongodb://127.0.0.1/?authMechanism=GSSAPI&authMechanismProperties=CANONICALIZE_HOST_NAME:true,SERVICE_NAME:foo,SERVICE_REALM:bar', []],
+    [null, ['authMechanism' => 'GSSAPI', 'authMechanismProperties' => ['CANONICALIZE_HOST_NAME' => 'true', 'SERVICE_NAME' => 'foo', 'SERVICE_REALM' => 'bar']]],
+    // Options are case-insensitive
+    ['mongodb://127.0.0.1/?authMechanism=GSSAPI&authMechanismProperties=canonicalize_host_name:TRUE,service_name:foo,service_realm:bar', []],
+    [null, ['authMechanism' => 'GSSAPI', 'authMechanismProperties' => ['canonicalize_host_name' => 'TRUE', 'service_name' => 'foo', 'service_realm' => 'bar']]],
+    // Boolean true "CANONICALIZE_HOST_NAME" value is converted to "true"
+    [null, ['authMechanism' => 'GSSAPI', 'authMechanismProperties' => ['canonicalize_host_name' => true]]],
+];
+
+foreach ($tests as $test) {
+    list($uri, $options) = $test;
+
+    /* Note: the Manager's debug information does not include the auth mechanism
+     * so we are merely testing that no exception is thrown and that option
+     * processing does not leak memory. */
+    $manager = new MongoDB\Driver\Manager($uri, $options);
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-772
https://jira.mongodb.org/browse/PHPC-953
https://jira.mongodb.org/browse/PHPC-957

Note: we don't have functional tests for GSSAPI (Kerberos), so I am only testing that parsing of the array options does not throw an exception or leak memory. Leak testing is relevant because non-string values for "CANONICALIZE_HOST_NAME" are evaluated as a boolean and converted to the string "true" if true. As noted in [PHPC-772](https://jira.mongodb.org/browse/PHPC-772), functional testing can wait for [PHPC-886](https://jira.mongodb.org/browse/PHPC-866).