### PR TITLE
PHPC-895: Require 16-byte data length for Binary UUID subtypes 0x03 and 0x04

### DIFF
--- a/src/BSON/Binary.c
+++ b/src/BSON/Binary.c
@@ -32,6 +32,8 @@
 #include "phongo_compat.h"
 #include "php_phongo.h"
 
+#define PHONGO_BINARY_UUID_SIZE 16
+
 zend_class_entry *php_phongo_binary_ce;
 
 /* Initialize the object and return whether it was successful. An exception will
@@ -40,6 +42,11 @@ static bool php_phongo_binary_init(php_phongo_binary_t *intern, const char *data
 {
 	if (type < 0 || type > UINT8_MAX) {
 		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Expected type to be an unsigned 8-bit integer, %" PHONGO_LONG_FORMAT " given", type);
+		return false;
+	}
+
+	if ((type == BSON_SUBTYPE_UUID_DEPRECATED || type == BSON_SUBTYPE_UUID) && data_len != PHONGO_BINARY_UUID_SIZE) {
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Expected UUID length to be %d bytes, %d given", PHONGO_BINARY_UUID_SIZE, data_len);
 		return false;
 	}
 

--- a/tests/bson/bson-binary-001.phpt
+++ b/tests/bson/bson-binary-001.phpt
@@ -17,8 +17,9 @@ $types = array(
 );
 $tests = array();
 foreach($types as $type) {
-    $binary = new MongoDB\BSON\Binary("random binary data", $type);
-    var_dump($binary->getData() == "random binary data");
+    // Use 16-byte data to satisfy UUID requirements
+    $binary = new MongoDB\BSON\Binary('randomBinaryData', $type);
+    var_dump($binary->getData() === 'randomBinaryData');
     var_dump($binary->getType() == $type);
     $tests[] = array("binary" => $binary);
 }
@@ -51,36 +52,36 @@ bool(true)
 bool(true)
 bool(true)
 bool(true)
-Test#0 { "binary" : { "$binary" : "cmFuZG9tIGJpbmFyeSBkYXRh", "$type" : "00" } }
-string(73) "{ "binary" : { "$binary" : "cmFuZG9tIGJpbmFyeSBkYXRh", "$type" : "00" } }"
-string(73) "{ "binary" : { "$binary" : "cmFuZG9tIGJpbmFyeSBkYXRh", "$type" : "00" } }"
+Test#0 { "binary" : { "$binary" : "cmFuZG9tQmluYXJ5RGF0YQ==", "$type" : "00" } }
+string(73) "{ "binary" : { "$binary" : "cmFuZG9tQmluYXJ5RGF0YQ==", "$type" : "00" } }"
+string(73) "{ "binary" : { "$binary" : "cmFuZG9tQmluYXJ5RGF0YQ==", "$type" : "00" } }"
 bool(true)
-Test#1 { "binary" : { "$binary" : "cmFuZG9tIGJpbmFyeSBkYXRh", "$type" : "01" } }
-string(73) "{ "binary" : { "$binary" : "cmFuZG9tIGJpbmFyeSBkYXRh", "$type" : "01" } }"
-string(73) "{ "binary" : { "$binary" : "cmFuZG9tIGJpbmFyeSBkYXRh", "$type" : "01" } }"
+Test#1 { "binary" : { "$binary" : "cmFuZG9tQmluYXJ5RGF0YQ==", "$type" : "01" } }
+string(73) "{ "binary" : { "$binary" : "cmFuZG9tQmluYXJ5RGF0YQ==", "$type" : "01" } }"
+string(73) "{ "binary" : { "$binary" : "cmFuZG9tQmluYXJ5RGF0YQ==", "$type" : "01" } }"
 bool(true)
-Test#2 { "binary" : { "$binary" : "cmFuZG9tIGJpbmFyeSBkYXRh", "$type" : "02" } }
-string(73) "{ "binary" : { "$binary" : "cmFuZG9tIGJpbmFyeSBkYXRh", "$type" : "02" } }"
-string(73) "{ "binary" : { "$binary" : "cmFuZG9tIGJpbmFyeSBkYXRh", "$type" : "02" } }"
+Test#2 { "binary" : { "$binary" : "cmFuZG9tQmluYXJ5RGF0YQ==", "$type" : "02" } }
+string(73) "{ "binary" : { "$binary" : "cmFuZG9tQmluYXJ5RGF0YQ==", "$type" : "02" } }"
+string(73) "{ "binary" : { "$binary" : "cmFuZG9tQmluYXJ5RGF0YQ==", "$type" : "02" } }"
 bool(true)
-Test#3 { "binary" : { "$binary" : "cmFuZG9tIGJpbmFyeSBkYXRh", "$type" : "03" } }
-string(73) "{ "binary" : { "$binary" : "cmFuZG9tIGJpbmFyeSBkYXRh", "$type" : "03" } }"
-string(73) "{ "binary" : { "$binary" : "cmFuZG9tIGJpbmFyeSBkYXRh", "$type" : "03" } }"
+Test#3 { "binary" : { "$binary" : "cmFuZG9tQmluYXJ5RGF0YQ==", "$type" : "03" } }
+string(73) "{ "binary" : { "$binary" : "cmFuZG9tQmluYXJ5RGF0YQ==", "$type" : "03" } }"
+string(73) "{ "binary" : { "$binary" : "cmFuZG9tQmluYXJ5RGF0YQ==", "$type" : "03" } }"
 bool(true)
-Test#4 { "binary" : { "$binary" : "cmFuZG9tIGJpbmFyeSBkYXRh", "$type" : "04" } }
-string(73) "{ "binary" : { "$binary" : "cmFuZG9tIGJpbmFyeSBkYXRh", "$type" : "04" } }"
-string(73) "{ "binary" : { "$binary" : "cmFuZG9tIGJpbmFyeSBkYXRh", "$type" : "04" } }"
+Test#4 { "binary" : { "$binary" : "cmFuZG9tQmluYXJ5RGF0YQ==", "$type" : "04" } }
+string(73) "{ "binary" : { "$binary" : "cmFuZG9tQmluYXJ5RGF0YQ==", "$type" : "04" } }"
+string(73) "{ "binary" : { "$binary" : "cmFuZG9tQmluYXJ5RGF0YQ==", "$type" : "04" } }"
 bool(true)
-Test#5 { "binary" : { "$binary" : "cmFuZG9tIGJpbmFyeSBkYXRh", "$type" : "05" } }
-string(73) "{ "binary" : { "$binary" : "cmFuZG9tIGJpbmFyeSBkYXRh", "$type" : "05" } }"
-string(73) "{ "binary" : { "$binary" : "cmFuZG9tIGJpbmFyeSBkYXRh", "$type" : "05" } }"
+Test#5 { "binary" : { "$binary" : "cmFuZG9tQmluYXJ5RGF0YQ==", "$type" : "05" } }
+string(73) "{ "binary" : { "$binary" : "cmFuZG9tQmluYXJ5RGF0YQ==", "$type" : "05" } }"
+string(73) "{ "binary" : { "$binary" : "cmFuZG9tQmluYXJ5RGF0YQ==", "$type" : "05" } }"
 bool(true)
-Test#6 { "binary" : { "$binary" : "cmFuZG9tIGJpbmFyeSBkYXRh", "$type" : "80" } }
-string(73) "{ "binary" : { "$binary" : "cmFuZG9tIGJpbmFyeSBkYXRh", "$type" : "80" } }"
-string(73) "{ "binary" : { "$binary" : "cmFuZG9tIGJpbmFyeSBkYXRh", "$type" : "80" } }"
+Test#6 { "binary" : { "$binary" : "cmFuZG9tQmluYXJ5RGF0YQ==", "$type" : "80" } }
+string(73) "{ "binary" : { "$binary" : "cmFuZG9tQmluYXJ5RGF0YQ==", "$type" : "80" } }"
+string(73) "{ "binary" : { "$binary" : "cmFuZG9tQmluYXJ5RGF0YQ==", "$type" : "80" } }"
 bool(true)
-Test#7 { "binary" : { "$binary" : "cmFuZG9tIGJpbmFyeSBkYXRh", "$type" : "85" } }
-string(73) "{ "binary" : { "$binary" : "cmFuZG9tIGJpbmFyeSBkYXRh", "$type" : "85" } }"
-string(73) "{ "binary" : { "$binary" : "cmFuZG9tIGJpbmFyeSBkYXRh", "$type" : "85" } }"
+Test#7 { "binary" : { "$binary" : "cmFuZG9tQmluYXJ5RGF0YQ==", "$type" : "85" } }
+string(73) "{ "binary" : { "$binary" : "cmFuZG9tQmluYXJ5RGF0YQ==", "$type" : "85" } }"
+string(73) "{ "binary" : { "$binary" : "cmFuZG9tQmluYXJ5RGF0YQ==", "$type" : "85" } }"
 bool(true)
 ===DONE===

--- a/tests/bson/bson-binary-serialization_error-003.phpt
+++ b/tests/bson/bson-binary-serialization_error-003.phpt
@@ -1,0 +1,36 @@
+--TEST--
+MongoDB\BSON\Binary unserialization requires 16-byte data length for UUID types
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/tools.php';
+
+echo throws(function() {
+    unserialize('C:19:"MongoDB\BSON\Binary":55:{a:2:{s:4:"data";s:15:"0123456789abcde";s:4:"type";i:3;}}');
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() {
+    unserialize('C:19:"MongoDB\BSON\Binary":57:{a:2:{s:4:"data";s:17:"0123456789abcdefg";s:4:"type";i:3;}}');
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() {
+    unserialize('C:19:"MongoDB\BSON\Binary":55:{a:2:{s:4:"data";s:15:"0123456789abcde";s:4:"type";i:4;}}');
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() {
+    unserialize('C:19:"MongoDB\BSON\Binary":57:{a:2:{s:4:"data";s:17:"0123456789abcdefg";s:4:"type";i:4;}}');
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected UUID length to be 16 bytes, 15 given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected UUID length to be 16 bytes, 17 given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected UUID length to be 16 bytes, 15 given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected UUID length to be 16 bytes, 17 given
+===DONE===

--- a/tests/bson/bson-binary-set_state_error-003.phpt
+++ b/tests/bson/bson-binary-set_state_error-003.phpt
@@ -1,0 +1,36 @@
+--TEST--
+MongoDB\BSON\Binary::__set_state() requires 16-byte data length for UUID types
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/tools.php';
+
+echo throws(function() {
+    MongoDB\BSON\Binary::__set_state(['data' => '0123456789abcde', 'type' => MongoDB\BSON\Binary::TYPE_OLD_UUID]);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() {
+    MongoDB\BSON\Binary::__set_state(['data' => '0123456789abcdefg', 'type' => MongoDB\BSON\Binary::TYPE_OLD_UUID]);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() {
+    MongoDB\BSON\Binary::__set_state(['data' => '0123456789abcde', 'type' => MongoDB\BSON\Binary::TYPE_UUID]);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() {
+    MongoDB\BSON\Binary::__set_state(['data' => '0123456789abcdefg', 'type' => MongoDB\BSON\Binary::TYPE_UUID]);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected UUID length to be 16 bytes, 15 given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected UUID length to be 16 bytes, 17 given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected UUID length to be 16 bytes, 15 given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected UUID length to be 16 bytes, 17 given
+===DONE===

--- a/tests/bson/bson-binary_error-004.phpt
+++ b/tests/bson/bson-binary_error-004.phpt
@@ -1,0 +1,36 @@
+--TEST--
+MongoDB\BSON\Binary constructor requires 16-byte data length for UUID types
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/tools.php';
+
+echo throws(function() {
+    new MongoDB\BSON\Binary('0123456789abcde', MongoDB\BSON\Binary::TYPE_OLD_UUID);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() {
+    new MongoDB\BSON\Binary('0123456789abcdefg', MongoDB\BSON\Binary::TYPE_OLD_UUID);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() {
+    new MongoDB\BSON\Binary('0123456789abcde', MongoDB\BSON\Binary::TYPE_UUID);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() {
+    new MongoDB\BSON\Binary('0123456789abcdefg', MongoDB\BSON\Binary::TYPE_UUID);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected UUID length to be 16 bytes, 15 given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected UUID length to be 16 bytes, 17 given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected UUID length to be 16 bytes, 15 given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected UUID length to be 16 bytes, 17 given
+===DONE===

--- a/tests/bson/bson-toPHP-006.phpt
+++ b/tests/bson/bson-toPHP-006.phpt
@@ -1,0 +1,62 @@
+--TEST--
+MongoDB\BSON\toPHP(): Decodes Binary UUID types with any data length
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/tools.php';
+
+/* Note: PHPC-895 requires Binary UUID types to have 16-byte data lengths during
+ * construction and initialization from unserialize() and __set_state(), but the
+ * ability to decoding existing BSON documents should be preserved. */
+$tests = [
+    pack('VCa*xVCa*x', 30, 0x05, 'foo', 15, 0x03, '0123456789abcde'), // UUID type 0x03 with 15 bytes
+    pack('VCa*xVCa*x', 32, 0x05, 'foo', 17, 0x03, '0123456789abcdefg'), // UUID type 0x03 with 17 bytes
+    pack('VCa*xVCa*x', 30, 0x05, 'foo', 15, 0x04, '0123456789abcde'), // UUID type 0x04 with 15 bytes
+    pack('VCa*xVCa*x', 32, 0x05, 'foo', 17, 0x04, '0123456789abcdefg'), // UUID type 0x04 with 17 bytes
+];
+
+foreach ($tests as $bson) {
+    var_dump(toPHP($bson));
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+object(stdClass)#%d (%d) {
+  ["foo"]=>
+  object(MongoDB\BSON\Binary)#%d (%d) {
+    ["data"]=>
+    string(15) "0123456789abcde"
+    ["type"]=>
+    int(3)
+  }
+}
+object(stdClass)#%d (%d) {
+  ["foo"]=>
+  object(MongoDB\BSON\Binary)#%d (%d) {
+    ["data"]=>
+    string(17) "0123456789abcdefg"
+    ["type"]=>
+    int(3)
+  }
+}
+object(stdClass)#%d (%d) {
+  ["foo"]=>
+  object(MongoDB\BSON\Binary)#%d (%d) {
+    ["data"]=>
+    string(15) "0123456789abcde"
+    ["type"]=>
+    int(4)
+  }
+}
+object(stdClass)#%d (%d) {
+  ["foo"]=>
+  object(MongoDB\BSON\Binary)#%d (%d) {
+    ["data"]=>
+    string(17) "0123456789abcdefg"
+    ["type"]=>
+    int(4)
+  }
+}
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-895