### PR TITLE
PHPC-628: Throw InvalidArgumentException when executing empty BulkWrite

### DIFF
--- a/php_phongo.c
+++ b/php_phongo.c
@@ -501,7 +501,8 @@ bool phongo_execute_write(mongoc_client_t *client, const char *namespace, php_ph
 
 	/* The Write failed */
 	if (!success) {
-		if (error.domain == MONGOC_ERROR_COMMAND || error.domain == MONGOC_ERROR_WRITE_CONCERN) {
+		if ((error.domain == MONGOC_ERROR_COMMAND && error.code != MONGOC_ERROR_COMMAND_INVALID_ARG) ||
+		    error.domain == MONGOC_ERROR_WRITE_CONCERN) {
 			phongo_throw_exception(PHONGO_ERROR_WRITE_FAILED TSRMLS_CC, "%s", error.message);
 			phongo_add_exception_prop(ZEND_STRL("writeResult"), return_value TSRMLS_CC);
 		} else {

--- a/tests/manager/manager-executeBulkWrite_error-008.phpt
+++ b/tests/manager/manager-executeBulkWrite_error-008.phpt
@@ -1,0 +1,22 @@
+--TEST--
+MongoDB\Driver\Manager::executeBulkWrite() with empty BulkWrite
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('STANDALONE'); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(STANDALONE);
+
+echo throws(function() use ($manager) {
+    $manager->executeBulkWrite(NS, new MongoDB\Driver\BulkWrite);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Cannot do an empty bulk write
+===DONE===

--- a/tests/server/server-executeBulkWrite_error-001.phpt
+++ b/tests/server/server-executeBulkWrite_error-001.phpt
@@ -1,0 +1,23 @@
+--TEST--
+MongoDB\Driver\Server::executeBulkWrite() with empty BulkWrite
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('STANDALONE'); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(STANDALONE);
+$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY));
+
+echo throws(function() use ($server) {
+    $server->executeBulkWrite(NS, new MongoDB\Driver\BulkWrite);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Cannot do an empty bulk write
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-628