### PR TITLE
PHPC-586: Regression tests for tailable cursor iteration

### DIFF
--- a/tests/cursor/cursor-tailable-001.phpt
+++ b/tests/cursor/cursor-tailable-001.phpt
@@ -1,0 +1,86 @@
+--TEST--
+MongoDB\Driver\Cursor tailable iteration
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('STANDALONE'); CLEANUP(STANDALONE); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+function insert(MongoDB\Driver\Manager $manager, $from, $to = null)
+{
+    if ($to === null) {
+        $to = $from;
+    }
+
+    $bulkWrite = new MongoDB\Driver\BulkWrite;
+
+    for ($i = $from; $i <= $to; $i++) {
+        $bulkWrite->insert(['_id' => $i]);
+    }
+
+    $writeResult = $manager->executeBulkWrite(NS, $bulkWrite);
+
+    printf("Inserted %d document(s): %s\n", $writeResult->getInsertedCount(), implode(range($from, $to), ', '));
+}
+
+$manager = new MongoDB\Driver\Manager(STANDALONE);
+
+$manager->executeCommand(DATABASE_NAME, new MongoDB\Driver\Command([
+    'create' => COLLECTION_NAME,
+    'capped' => true,
+    'size' => 1048576,
+]));
+
+insert($manager, 1, 3);
+
+$cursor = $manager->executeQuery(NS, new MongoDB\Driver\Query([], ['tailable' => true]));
+$it = new IteratorIterator($cursor);
+
+$numAwaitAttempts = 0;
+$maxAwaitAttempts = 7;
+
+for ($it->rewind(); $numAwaitAttempts < $maxAwaitAttempts; $it->next()) {
+    $document = $it->current();
+
+    if ($document !== null) {
+        printf("{_id: %d}\n", $document->_id);
+        continue;
+    }
+
+    if ($numAwaitAttempts === 2) {
+        insert($manager, 4, 6);
+    }
+
+    if ($numAwaitAttempts === 5) {
+        insert($manager, 7, 9);
+    }
+
+    echo "Awaiting results...\n";
+    $numAwaitAttempts += 1;
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+Inserted 3 document(s): 1, 2, 3
+{_id: 1}
+{_id: 2}
+{_id: 3}
+Awaiting results...
+Awaiting results...
+Inserted 3 document(s): 4, 5, 6
+Awaiting results...
+{_id: 4}
+{_id: 5}
+{_id: 6}
+Awaiting results...
+Awaiting results...
+Inserted 3 document(s): 7, 8, 9
+Awaiting results...
+{_id: 7}
+{_id: 8}
+{_id: 9}
+Awaiting results...
+===DONE===

--- a/tests/cursor/cursor-tailable-002.phpt
+++ b/tests/cursor/cursor-tailable-002.phpt
@@ -1,0 +1,86 @@
+--TEST--
+MongoDB\Driver\Cursor tailable iteration with awaitData option
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php SLOW(); NEEDS('STANDALONE'); CLEANUP(STANDALONE); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+function insert(MongoDB\Driver\Manager $manager, $from, $to = null)
+{
+    if ($to === null) {
+        $to = $from;
+    }
+
+    $bulkWrite = new MongoDB\Driver\BulkWrite;
+
+    for ($i = $from; $i <= $to; $i++) {
+        $bulkWrite->insert(['_id' => $i]);
+    }
+
+    $writeResult = $manager->executeBulkWrite(NS, $bulkWrite);
+
+    printf("Inserted %d document(s): %s\n", $writeResult->getInsertedCount(), implode(range($from, $to), ', '));
+}
+
+$manager = new MongoDB\Driver\Manager(STANDALONE);
+
+$manager->executeCommand(DATABASE_NAME, new MongoDB\Driver\Command([
+    'create' => COLLECTION_NAME,
+    'capped' => true,
+    'size' => 1048576,
+]));
+
+insert($manager, 1, 3);
+
+$cursor = $manager->executeQuery(NS, new MongoDB\Driver\Query([], ['tailable' => true, 'awaitData' => true]));
+$it = new IteratorIterator($cursor);
+
+$numAwaitAttempts = 0;
+$maxAwaitAttempts = 7;
+
+for ($it->rewind(); $numAwaitAttempts < $maxAwaitAttempts; $it->next()) {
+    $document = $it->current();
+
+    if ($document !== null) {
+        printf("{_id: %d}\n", $document->_id);
+        continue;
+    }
+
+    if ($numAwaitAttempts === 2) {
+        insert($manager, 4, 6);
+    }
+
+    if ($numAwaitAttempts === 5) {
+        insert($manager, 7, 9);
+    }
+
+    echo "Awaiting results...\n";
+    $numAwaitAttempts += 1;
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+Inserted 3 document(s): 1, 2, 3
+{_id: 1}
+{_id: 2}
+{_id: 3}
+Awaiting results...
+Awaiting results...
+Inserted 3 document(s): 4, 5, 6
+Awaiting results...
+{_id: 4}
+{_id: 5}
+{_id: 6}
+Awaiting results...
+Awaiting results...
+Inserted 3 document(s): 7, 8, 9
+Awaiting results...
+{_id: 7}
+{_id: 8}
+{_id: 9}
+Awaiting results...
+===DONE===

--- a/tests/cursor/cursor-tailable_error-001.phpt
+++ b/tests/cursor/cursor-tailable_error-001.phpt
@@ -1,0 +1,85 @@
+--TEST--
+MongoDB\Driver\Cursor collection dropped during tailable iteration
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('STANDALONE'); CLEANUP(STANDALONE); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+function insert(MongoDB\Driver\Manager $manager, $from, $to = null)
+{
+    if ($to === null) {
+        $to = $from;
+    }
+
+    $bulkWrite = new MongoDB\Driver\BulkWrite;
+
+    for ($i = $from; $i <= $to; $i++) {
+        $bulkWrite->insert(['_id' => $i]);
+    }
+
+    $writeResult = $manager->executeBulkWrite(NS, $bulkWrite);
+
+    printf("Inserted %d document(s): %s\n", $writeResult->getInsertedCount(), implode(range($from, $to), ', '));
+}
+
+$manager = new MongoDB\Driver\Manager(STANDALONE);
+
+$manager->executeCommand(DATABASE_NAME, new MongoDB\Driver\Command([
+    'create' => COLLECTION_NAME,
+    'capped' => true,
+    'size' => 1048576,
+]));
+
+insert($manager, 1, 3);
+
+echo throws(function() use ($manager) {
+    $cursor = $manager->executeQuery(NS, new MongoDB\Driver\Query([], ['tailable' => true]));
+    $it = new IteratorIterator($cursor);
+
+    $numAwaitAttempts = 0;
+    $maxAwaitAttempts = 7;
+
+    for ($it->rewind(); $numAwaitAttempts < $maxAwaitAttempts; $it->next()) {
+        $document = $it->current();
+
+        if ($document !== null) {
+            printf("{_id: %d}\n", $document->_id);
+            continue;
+        }
+
+        if ($numAwaitAttempts === 2) {
+            insert($manager, 4, 6);
+        }
+
+        if ($numAwaitAttempts === 5) {
+            $manager->executeCommand(DATABASE_NAME, new MongoDB\Driver\Command(['drop' => COLLECTION_NAME]));
+        }
+
+        echo "Awaiting results...\n";
+        $numAwaitAttempts += 1;
+    }
+}, 'MongoDB\Driver\Exception\RuntimeException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+Inserted 3 document(s): 1, 2, 3
+{_id: 1}
+{_id: 2}
+{_id: 3}
+Awaiting results...
+Awaiting results...
+Inserted 3 document(s): 4, 5, 6
+Awaiting results...
+{_id: 4}
+{_id: 5}
+{_id: 6}
+Awaiting results...
+Awaiting results...
+Awaiting results...
+OK: Got MongoDB\Driver\Exception\RuntimeException
+collection dropped between getMore calls
+===DONE===

--- a/tests/cursor/cursor-tailable_error-002.phpt
+++ b/tests/cursor/cursor-tailable_error-002.phpt
@@ -1,0 +1,88 @@
+--TEST--
+MongoDB\Driver\Cursor cursor killed during tailable iteration
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('STANDALONE'); CLEANUP(STANDALONE); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+function insert(MongoDB\Driver\Manager $manager, $from, $to = null)
+{
+    if ($to === null) {
+        $to = $from;
+    }
+
+    $bulkWrite = new MongoDB\Driver\BulkWrite;
+
+    for ($i = $from; $i <= $to; $i++) {
+        $bulkWrite->insert(['_id' => $i]);
+    }
+
+    $writeResult = $manager->executeBulkWrite(NS, $bulkWrite);
+
+    printf("Inserted %d document(s): %s\n", $writeResult->getInsertedCount(), implode(range($from, $to), ', '));
+}
+
+$manager = new MongoDB\Driver\Manager(STANDALONE);
+
+$manager->executeCommand(DATABASE_NAME, new MongoDB\Driver\Command([
+    'create' => COLLECTION_NAME,
+    'capped' => true,
+    'size' => 1048576,
+]));
+
+insert($manager, 1, 3);
+
+echo throws(function() use ($manager) {
+    $cursor = $manager->executeQuery(NS, new MongoDB\Driver\Query([], ['tailable' => true]));
+    $it = new IteratorIterator($cursor);
+
+    $numAwaitAttempts = 0;
+    $maxAwaitAttempts = 7;
+
+    for ($it->rewind(); $numAwaitAttempts < $maxAwaitAttempts; $it->next()) {
+        $document = $it->current();
+
+        if ($document !== null) {
+            printf("{_id: %d}\n", $document->_id);
+            continue;
+        }
+
+        if ($numAwaitAttempts === 2) {
+            insert($manager, 4, 6);
+        }
+
+        if ($numAwaitAttempts === 5) {
+            $manager->executeCommand(DATABASE_NAME, new MongoDB\Driver\Command([
+                'killCursors' => COLLECTION_NAME,
+                'cursors' => [ $cursor->getId() ],
+            ]));
+        }
+
+        echo "Awaiting results...\n";
+        $numAwaitAttempts += 1;
+    }
+}, 'MongoDB\Driver\Exception\RuntimeException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+Inserted 3 document(s): 1, 2, 3
+{_id: 1}
+{_id: 2}
+{_id: 3}
+Awaiting results...
+Awaiting results...
+Inserted 3 document(s): 4, 5, 6
+Awaiting results...
+{_id: 4}
+{_id: 5}
+{_id: 6}
+Awaiting results...
+Awaiting results...
+Awaiting results...
+OK: Got MongoDB\Driver\Exception\RuntimeException
+Cursor not found, cursor id: %d
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-586

Note: iterating a tailable cursor with `foreach` is not possible because [`php_phongo_cursor_iterator_valid()`](https://github.com/mongodb/mongo-php-driver/blob/0c683809881ee9633fd61383855ff6b4ebf977d7/src/MongoDB/Cursor.c#L58) returns `false` if the current element is undefined. When [`php_phongo_cursor_iterator_move_forward()`](https://github.com/mongodb/mongo-php-driver/blob/0c683809881ee9633fd61383855ff6b4ebf977d7/src/MongoDB/Cursor.c#L102) advances the cursor, it clears the current element by calling [`php_phongo_cursor_free_current()`](https://github.com/mongodb/mongo-php-driver/blob/0c683809881ee9633fd61383855ff6b4ebf977d7/src/MongoDB/Cursor.c#L31) and will leave it undefined unless `mongoc_cursor_next()` returns `true` and we have a BSON document to convert to the current element. This means that `foreach` is only able to iterate as long as the server returns documents in result batches and will not allow the driver to issue a `getMore` and tail the collection for more results.