### PR TITLE
Implement new feature to ping connection to a given URI

### DIFF
--- a/php_phongo.c
+++ b/php_phongo.c
@@ -481,6 +481,23 @@ mongoc_bulk_operation_t *phongo_bulkwrite_init(zend_bool ordered) { /* {{{ */
 	return mongoc_bulk_operation_new(ordered);
 } /* }}} */
 
+bool php_phongo_ping_connection(zval *manager)
+{
+    mongoc_client_t *client;
+    bson_t *command, reply;
+    bson_error_t error;
+
+    client = Z_MANAGER_OBJ_P(manager)->client;
+
+    command = BCON_NEW ("ping", BCON_INT32(1));
+
+    if (!mongoc_client_command_simple(client, "testing", command, NULL, &reply, &error)) {
+        return false;
+    }
+
+    return true;
+}
+
 bool phongo_execute_write(zval *manager, const char *namespace, php_phongo_bulkwrite_t  *bulk_write, const mongoc_write_concern_t *write_concern, int server_id, zval *return_value, int return_value_used TSRMLS_DC) /* {{{ */
 {
 	mongoc_client_t *client;

--- a/php_phongo.c
+++ b/php_phongo.c
@@ -492,9 +492,13 @@ bool php_phongo_ping_connection(zval *manager)
     command = BCON_NEW ("ping", BCON_INT32(1));
 
     if (!mongoc_client_command_simple(client, "testing", command, NULL, &reply, &error)) {
+        bson_destroy(command);
+        bson_destroy(&reply);
         return false;
     }
 
+    bson_destroy(command);
+    bson_destroy(&reply);
     return true;
 }
 

--- a/php_phongo.h
+++ b/php_phongo.h
@@ -126,6 +126,7 @@ void                     phongo_readconcern_init     (zval *return_value, const 
 void                     phongo_readpreference_init  (zval *return_value, const mongoc_read_prefs_t *read_prefs TSRMLS_DC);
 void                     phongo_writeconcern_init    (zval *return_value, const mongoc_write_concern_t *write_concern TSRMLS_DC);
 mongoc_bulk_operation_t* phongo_bulkwrite_init       (zend_bool ordered);
+bool                     php_phongo_ping_connection  (zval *manager);
 bool                     phongo_execute_write        (zval *manager, const char *namespace, php_phongo_bulkwrite_t  *bulk_write, const mongoc_write_concern_t *write_concern, int server_id, zval *return_value, int return_value_used TSRMLS_DC);
 int                      phongo_execute_command      (zval *manager, const char *db, zval *zcommand, zval *zreadPreference, int server_id, zval *return_value, int return_value_used TSRMLS_DC);
 int                      phongo_execute_query        (zval *manager, const char *namespace, zval *zquery, zval *zreadPreference, int server_id, zval *return_value, int return_value_used TSRMLS_DC);

--- a/src/MongoDB/Manager.c
+++ b/src/MongoDB/Manager.c
@@ -205,7 +205,7 @@ PHP_METHOD(Manager, pingConnection)
     }
 
     if (!php_phongo_ping_connection(getThis())) {
-        phongo_throw_exception(PHONGO_ERROR_CONNECTION_FAILED, "Failed to create Manager from URI");
+        phongo_throw_exception(PHONGO_ERROR_CONNECTION_FAILED TSRMLS_CC, "Failed to create Manager from URI");
     }
 }
 

--- a/src/MongoDB/Manager.c
+++ b/src/MongoDB/Manager.c
@@ -196,6 +196,19 @@ PHP_METHOD(Manager, __construct)
 }
 /* }}} */
 
+/* {{{ proto MongoDB\Driver\Cursor Manager::pingConnection()
+   Ping a connection against given URI */
+PHP_METHOD(Manager, pingConnection)
+{
+    if (zend_parse_parameters_none() == FAILURE) {
+        return;
+    }
+
+    if (!php_phongo_ping_connection(getThis())) {
+        phongo_throw_exception(PHONGO_ERROR_CONNECTION_FAILED TSRMLS_CC, "Failed to create Manager from URI");
+    }
+}
+
 /* {{{ proto MongoDB\Driver\Cursor Manager::executeCommand(string $db, MongoDB\Driver\Command $command[, MongoDB\Driver\ReadPreference $readPreference = null])
    Execute a Command */
 PHP_METHOD(Manager, executeCommand)
@@ -449,6 +462,7 @@ ZEND_END_ARG_INFO()
 
 static zend_function_entry php_phongo_manager_me[] = {
 	PHP_ME(Manager, __construct, ai_Manager___construct, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+    PHP_ME(Manager, pingConnection, ai_Manager_void, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	PHP_ME(Manager, executeCommand, ai_Manager_executeCommand, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	PHP_ME(Manager, executeQuery, ai_Manager_executeQuery, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	PHP_ME(Manager, executeBulkWrite, ai_Manager_executeBulkWrite, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)

--- a/src/MongoDB/Manager.c
+++ b/src/MongoDB/Manager.c
@@ -205,7 +205,7 @@ PHP_METHOD(Manager, pingConnection)
     }
 
     if (!php_phongo_ping_connection(getThis())) {
-        phongo_throw_exception(PHONGO_ERROR_CONNECTION_FAILED TSRMLS_CC, "Failed to create Manager from URI");
+        phongo_throw_exception(PHONGO_ERROR_CONNECTION_FAILED, "Failed to create Manager from URI");
     }
 }
 

--- a/tests/connect/standalone-bad_uri-001.phpt
+++ b/tests/connect/standalone-bad_uri-001.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Test connection to MongoDB.
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$adminmanager = new MongoDB\Driver\Manager("mongodb://localhost:27017");
+
+try {
+    $adminmanager->pingConnection();
+    echo "Connection Established\n";
+} catch (\MongoDB\Driver\Exception\ConnectionException $e) {
+    echo $e->getMessage() . "\n";
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+Connection Established
+===DONE===
+

--- a/tests/connect/standalone-bad_uri-002.phpt
+++ b/tests/connect/standalone-bad_uri-002.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Test connection to MongoDB.
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$adminmanager = new MongoDB\Driver\Manager("mongodb://localhosta:27017");
+
+try {
+    $adminmanager->pingConnection();
+    echo "Connection Established\n";
+} catch (\MongoDB\Driver\Exception\ConnectionException $e) {
+    echo $e->getMessage() . "\n";
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+Failed to create Manager from URI
+===DONE===
+

--- a/tests/connect/standalone-bad_uri-003.phpt
+++ b/tests/connect/standalone-bad_uri-003.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Test connection to MongoDB.
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$adminmanager = new MongoDB\Driver\Manager("mongodb://localhost:27007");
+
+try {
+    $adminmanager->pingConnection();
+    echo "Connection Established\n";
+} catch (\MongoDB\Driver\Exception\ConnectionException $e) {
+    echo $e->getMessage() . "\n";
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+Failed to create Manager from URI
+===DONE===
+


### PR DESCRIPTION
Inspired by this [issue @ SO](https://stackoverflow.com/questions/43977509/is-there-a-way-to-test-mongodb-connection-in-php) , we need a simple way to test connection to a given URI , Also like the [C++ driver](http://api.mongodb.com/csharp/1.8/html/4df96e2d-3273-1075-23df-6baea97942c3.htm).

there was two implementations to do this,
1) Automatically check within the `\Manager::__construct();` but that will enforce to add an additional operation to check that connection
2) Create a separated method to check/ping connection to a given URI.

I went with the second choice to make it optional for the developer to whether check his connection or not

@jmikola @derickr 