### PR TITLE
PHPC-640: Create interfaces for BSON types classes

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -155,19 +155,28 @@ if test "$MONGODB" != "no"; then
     src/bson.c \
     src/bson-encode.c \
     src/BSON/Binary.c \
+    src/BSON/BinaryInterface.c \
     src/BSON/Decimal128.c \
+    src/BSON/Decimal128Interface.c \
     src/BSON/Javascript.c \
+    src/BSON/JavascriptInterface.c \
     src/BSON/MaxKey.c \
+    src/BSON/MaxKeyInterface.c \
     src/BSON/MinKey.c \
+    src/BSON/MinKeyInterface.c \
     src/BSON/ObjectID.c \
+    src/BSON/ObjectIDInterface.c \
     src/BSON/Persistable.c \
     src/BSON/Regex.c \
+    src/BSON/RegexInterface.c \
     src/BSON/Serializable.c \
     src/BSON/Timestamp.c \
+    src/BSON/TimestampInterface.c \
     src/BSON/Type.c \
     src/BSON/TypeWrapper.c \
     src/BSON/Unserializable.c \
     src/BSON/UTCDateTime.c \
+    src/BSON/UTCDateTimeInterface.c \
     src/BSON/functions.c \
     src/MongoDB/BulkWrite.c \
     src/MongoDB/Command.c \

--- a/config.w32
+++ b/config.w32
@@ -84,7 +84,7 @@ if (PHP_MONGODB != "no") {
 
   EXTENSION("mongodb", "php_phongo.c phongo_compat.c", null, PHP_MONGODB_CFLAGS);
   ADD_SOURCES(configure_module_dirname + "/src", "bson.c bson-encode.c", "mongodb");
-  ADD_SOURCES(configure_module_dirname + "/src/BSON", "Binary.c Decimal128.c Javascript.c MaxKey.c MinKey.c ObjectID.c Persistable.c Regex.c Serializable.c Timestamp.c Type.c TypeWrapper.c Unserializable.c UTCDateTime.c functions.c", "mongodb");
+  ADD_SOURCES(configure_module_dirname + "/src/BSON", "Binary.c BinaryInterface.c Decimal128.c Decimal128Interface.c Javascript.c JavascriptInterface.c MaxKey.c MaxKeyInterface.c MinKey.c MinKeyInterface.c ObjectID.c ObjectIDInterface.c Persistable.c Regex.c RegexInterface.c Serializable.c Timestamp.c TimestampInterface.c Type.c TypeWrapper.c Unserializable.c UTCDateTime.c UTCDateTimeInterface.c functions.c", "mongodb");
   ADD_SOURCES(configure_module_dirname + "/src/MongoDB", "BulkWrite.c Command.c Cursor.c CursorId.c Manager.c Query.c ReadConcern.c ReadPreference.c Server.c WriteConcern.c WriteConcernError.c WriteError.c WriteResult.c", "mongodb");
   ADD_SOURCES(configure_module_dirname + "/src/MongoDB/Exception", "AuthenticationException.c BulkWriteException.c ConnectionException.c ConnectionTimeoutException.c Exception.c ExecutionTimeoutException.c InvalidArgumentException.c LogicException.c RuntimeException.c SSLConnectionException.c UnexpectedValueException.c WriteException.c", "mongodb");
   ADD_SOURCES(configure_module_dirname + "/src/MongoDB/Monitoring", "CommandFailedEvent.c CommandStartedEvent.c CommandSubscriber.c CommandSucceededEvent.c Subscriber.c functions.c", "mongodb");

--- a/php_phongo.c
+++ b/php_phongo.c
@@ -2200,6 +2200,16 @@ PHP_MINIT_FUNCTION(mongodb)
 	php_phongo_serializable_init_ce(INIT_FUNC_ARGS_PASSTHRU);
 	php_phongo_unserializable_init_ce(INIT_FUNC_ARGS_PASSTHRU);
 
+	php_phongo_binary_interface_init_ce(INIT_FUNC_ARGS_PASSTHRU);
+	php_phongo_decimal128_interface_init_ce(INIT_FUNC_ARGS_PASSTHRU);
+	php_phongo_javascript_interface_init_ce(INIT_FUNC_ARGS_PASSTHRU);
+	php_phongo_maxkey_interface_init_ce(INIT_FUNC_ARGS_PASSTHRU);
+	php_phongo_minkey_interface_init_ce(INIT_FUNC_ARGS_PASSTHRU);
+	php_phongo_objectid_interface_init_ce(INIT_FUNC_ARGS_PASSTHRU);
+	php_phongo_regex_interface_init_ce(INIT_FUNC_ARGS_PASSTHRU);
+	php_phongo_timestamp_interface_init_ce(INIT_FUNC_ARGS_PASSTHRU);
+	php_phongo_utcdatetime_interface_init_ce(INIT_FUNC_ARGS_PASSTHRU);
+
 	php_phongo_binary_init_ce(INIT_FUNC_ARGS_PASSTHRU);
 	php_phongo_decimal128_init_ce(INIT_FUNC_ARGS_PASSTHRU);
 	php_phongo_javascript_init_ce(INIT_FUNC_ARGS_PASSTHRU);

--- a/php_phongo_classes.h
+++ b/php_phongo_classes.h
@@ -257,6 +257,16 @@ extern zend_class_entry *php_phongo_regex_ce;
 extern zend_class_entry *php_phongo_timestamp_ce;
 extern zend_class_entry *php_phongo_utcdatetime_ce;
 
+extern zend_class_entry *php_phongo_binary_interface_ce;
+extern zend_class_entry *php_phongo_decimal128_interface_ce;
+extern zend_class_entry *php_phongo_javascript_interface_ce;
+extern zend_class_entry *php_phongo_maxkey_interface_ce;
+extern zend_class_entry *php_phongo_minkey_interface_ce;
+extern zend_class_entry *php_phongo_objectid_interface_ce;
+extern zend_class_entry *php_phongo_regex_interface_ce;
+extern zend_class_entry *php_phongo_timestamp_interface_ce;
+extern zend_class_entry *php_phongo_utcdatetime_interface_ce;
+
 extern zend_class_entry *php_phongo_commandfailedevent_ce;
 extern zend_class_entry *php_phongo_commandstartedevent_ce;
 extern zend_class_entry *php_phongo_commandsubscriber_ce;
@@ -277,6 +287,16 @@ extern void php_phongo_type_init_ce(INIT_FUNC_ARGS);
 extern void php_phongo_typewrapper_init_ce(INIT_FUNC_ARGS);
 extern void php_phongo_utcdatetime_init_ce(INIT_FUNC_ARGS);
 extern void php_phongo_unserializable_init_ce(INIT_FUNC_ARGS);
+
+extern void php_phongo_binary_interface_init_ce(INIT_FUNC_ARGS);
+extern void php_phongo_decimal128_interface_init_ce(INIT_FUNC_ARGS);
+extern void php_phongo_javascript_interface_init_ce(INIT_FUNC_ARGS);
+extern void php_phongo_maxkey_interface_init_ce(INIT_FUNC_ARGS);
+extern void php_phongo_minkey_interface_init_ce(INIT_FUNC_ARGS);
+extern void php_phongo_objectid_interface_init_ce(INIT_FUNC_ARGS);
+extern void php_phongo_regex_interface_init_ce(INIT_FUNC_ARGS);
+extern void php_phongo_timestamp_interface_init_ce(INIT_FUNC_ARGS);
+extern void php_phongo_utcdatetime_interface_init_ce(INIT_FUNC_ARGS);
 
 extern void php_phongo_bulkwrite_init_ce(INIT_FUNC_ARGS);
 extern void php_phongo_command_init_ce(INIT_FUNC_ARGS);

--- a/src/BSON/Binary.c
+++ b/src/BSON/Binary.c
@@ -459,6 +459,7 @@ void php_phongo_binary_init_ce(INIT_FUNC_ARGS) /* {{{ */
 	php_phongo_binary_ce->create_object = php_phongo_binary_create_object;
 	PHONGO_CE_FINAL(php_phongo_binary_ce);
 
+	zend_class_implements(php_phongo_binary_ce TSRMLS_CC, 1, php_phongo_binary_interface_ce);
 	zend_class_implements(php_phongo_binary_ce TSRMLS_CC, 1, php_phongo_json_serializable_ce);
 	zend_class_implements(php_phongo_binary_ce TSRMLS_CC, 1, php_phongo_type_ce);
 	zend_class_implements(php_phongo_binary_ce TSRMLS_CC, 1, zend_ce_serializable);

--- a/src/BSON/BinaryInterface.c
+++ b/src/BSON/BinaryInterface.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include <php.h> 
+
+#include "phongo_compat.h"
+#include "php_phongo.h"
+
+zend_class_entry *php_phongo_binary_interface_ce;
+
+/* {{{ MongoDB\BSON\BinaryInterface function entries */
+ZEND_BEGIN_ARG_INFO_EX(ai_BinaryInterface_void, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+static zend_function_entry php_phongo_binary_interface_me[] = {
+	ZEND_ABSTRACT_ME(BinaryInterface, getData, ai_BinaryInterface_void)
+	ZEND_ABSTRACT_ME(BinaryInterface, getType, ai_BinaryInterface_void)
+	ZEND_ABSTRACT_ME(BinaryInterface, __toString, ai_BinaryInterface_void)
+	PHP_FE_END
+};
+/* }}} */
+
+void php_phongo_binary_interface_init_ce(INIT_FUNC_ARGS) /* {{{ */
+{
+	zend_class_entry ce;
+
+	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "BinaryInterface", php_phongo_binary_interface_me);
+	php_phongo_binary_interface_ce = zend_register_internal_interface(&ce TSRMLS_CC);
+} /* }}} */
+
+/*
+ * Local variables:
+ * tab-width: 4
+ * c-basic-offset: 4
+ * End:
+ * vim600: noet sw=4 ts=4 fdm=marker
+ * vim<600: noet sw=4 ts=4
+ */

--- a/src/BSON/Decimal128.c
+++ b/src/BSON/Decimal128.c
@@ -368,6 +368,7 @@ void php_phongo_decimal128_init_ce(INIT_FUNC_ARGS) /* {{{ */
 	php_phongo_decimal128_ce->create_object = php_phongo_decimal128_create_object;
 	PHONGO_CE_FINAL(php_phongo_decimal128_ce);
 
+	zend_class_implements(php_phongo_decimal128_ce TSRMLS_CC, 1, php_phongo_decimal128_interface_ce);
 	zend_class_implements(php_phongo_decimal128_ce TSRMLS_CC, 1, php_phongo_json_serializable_ce);
 	zend_class_implements(php_phongo_decimal128_ce TSRMLS_CC, 1, php_phongo_type_ce);
 	zend_class_implements(php_phongo_decimal128_ce TSRMLS_CC, 1, zend_ce_serializable);

--- a/src/BSON/Decimal128Interface.c
+++ b/src/BSON/Decimal128Interface.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include <php.h> 
+
+#include "phongo_compat.h"
+#include "php_phongo.h"
+
+zend_class_entry *php_phongo_decimal128_interface_ce;
+
+/* {{{ MongoDB\BSON\Decimal128Interface function entries */
+ZEND_BEGIN_ARG_INFO_EX(ai_Decimal128Interface_void, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+static zend_function_entry php_phongo_decimal128_interface_me[] = {
+	ZEND_ABSTRACT_ME(Decimal128Interface, __toString, ai_Decimal128Interface_void)
+	PHP_FE_END
+};
+/* }}} */
+
+void php_phongo_decimal128_interface_init_ce(INIT_FUNC_ARGS) /* {{{ */
+{
+	zend_class_entry ce;
+
+	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "Decimal128Interface", php_phongo_decimal128_interface_me);
+	php_phongo_decimal128_interface_ce = zend_register_internal_interface(&ce TSRMLS_CC);
+} /* }}} */
+
+/*
+ * Local variables:
+ * tab-width: 4
+ * c-basic-offset: 4
+ * End:
+ * vim600: noet sw=4 ts=4 fdm=marker
+ * vim<600: noet sw=4 ts=4
+ */

--- a/src/BSON/Javascript.c
+++ b/src/BSON/Javascript.c
@@ -532,6 +532,7 @@ void php_phongo_javascript_init_ce(INIT_FUNC_ARGS) /* {{{ */
 	php_phongo_javascript_ce->create_object = php_phongo_javascript_create_object;
 	PHONGO_CE_FINAL(php_phongo_javascript_ce);
 
+	zend_class_implements(php_phongo_javascript_ce TSRMLS_CC, 1, php_phongo_javascript_interface_ce);
 	zend_class_implements(php_phongo_javascript_ce TSRMLS_CC, 1, php_phongo_json_serializable_ce);
 	zend_class_implements(php_phongo_javascript_ce TSRMLS_CC, 1, php_phongo_type_ce);
 	zend_class_implements(php_phongo_javascript_ce TSRMLS_CC, 1, zend_ce_serializable);

--- a/src/BSON/JavascriptInterface.c
+++ b/src/BSON/JavascriptInterface.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include <php.h> 
+
+#include "phongo_compat.h"
+#include "php_phongo.h"
+
+zend_class_entry *php_phongo_javascript_interface_ce;
+
+/* {{{ MongoDB\BSON\JavascriptInterface function entries */
+ZEND_BEGIN_ARG_INFO_EX(ai_JavascriptInterface_void, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+static zend_function_entry php_phongo_javascript_interface_me[] = {
+	ZEND_ABSTRACT_ME(JavascriptInterface, getCode, ai_JavascriptInterface_void)
+	ZEND_ABSTRACT_ME(JavascriptInterface, getScope, ai_JavascriptInterface_void)
+	ZEND_ABSTRACT_ME(JavascriptInterface, __toString, ai_JavascriptInterface_void)
+	PHP_FE_END
+};
+/* }}} */
+
+void php_phongo_javascript_interface_init_ce(INIT_FUNC_ARGS) /* {{{ */
+{
+	zend_class_entry ce;
+
+	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "JavascriptInterface", php_phongo_javascript_interface_me);
+	php_phongo_javascript_interface_ce = zend_register_internal_interface(&ce TSRMLS_CC);
+} /* }}} */
+
+/*
+ * Local variables:
+ * tab-width: 4
+ * c-basic-offset: 4
+ * End:
+ * vim600: noet sw=4 ts=4 fdm=marker
+ * vim<600: noet sw=4 ts=4
+ */

--- a/src/BSON/MaxKey.c
+++ b/src/BSON/MaxKey.c
@@ -149,6 +149,7 @@ void php_phongo_maxkey_init_ce(INIT_FUNC_ARGS) /* {{{ */
 	php_phongo_maxkey_ce->create_object = php_phongo_maxkey_create_object;
 	PHONGO_CE_FINAL(php_phongo_maxkey_ce);
 
+	zend_class_implements(php_phongo_maxkey_ce TSRMLS_CC, 1, php_phongo_maxkey_interface_ce);
 	zend_class_implements(php_phongo_maxkey_ce TSRMLS_CC, 1, php_phongo_json_serializable_ce);
 	zend_class_implements(php_phongo_maxkey_ce TSRMLS_CC, 1, php_phongo_type_ce);
 	zend_class_implements(php_phongo_maxkey_ce TSRMLS_CC, 1, zend_ce_serializable);

--- a/src/BSON/MaxKeyInterface.c
+++ b/src/BSON/MaxKeyInterface.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include <php.h> 
+
+#include "phongo_compat.h"
+#include "php_phongo.h"
+
+zend_class_entry *php_phongo_maxkey_interface_ce;
+
+/* {{{ MongoDB\BSON\MaxKeyInterface function entries */
+static zend_function_entry php_phongo_maxkey_interface_me[] = {
+	PHP_FE_END
+};
+/* }}} */
+
+void php_phongo_maxkey_interface_init_ce(INIT_FUNC_ARGS) /* {{{ */
+{
+	zend_class_entry ce;
+
+	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "MaxKeyInterface", php_phongo_maxkey_interface_me);
+	php_phongo_maxkey_interface_ce = zend_register_internal_interface(&ce TSRMLS_CC);
+} /* }}} */
+
+/*
+ * Local variables:
+ * tab-width: 4
+ * c-basic-offset: 4
+ * End:
+ * vim600: noet sw=4 ts=4 fdm=marker
+ * vim<600: noet sw=4 ts=4
+ */

--- a/src/BSON/MinKey.c
+++ b/src/BSON/MinKey.c
@@ -150,6 +150,7 @@ void php_phongo_minkey_init_ce(INIT_FUNC_ARGS) /* {{{ */
 	php_phongo_minkey_ce->create_object = php_phongo_minkey_create_object;
 	PHONGO_CE_FINAL(php_phongo_minkey_ce);
 
+	zend_class_implements(php_phongo_minkey_ce TSRMLS_CC, 1, php_phongo_minkey_interface_ce);
 	zend_class_implements(php_phongo_minkey_ce TSRMLS_CC, 1, php_phongo_json_serializable_ce);
 	zend_class_implements(php_phongo_minkey_ce TSRMLS_CC, 1, php_phongo_type_ce);
 	zend_class_implements(php_phongo_minkey_ce TSRMLS_CC, 1, zend_ce_serializable);

--- a/src/BSON/MinKeyInterface.c
+++ b/src/BSON/MinKeyInterface.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include <php.h> 
+
+#include "phongo_compat.h"
+#include "php_phongo.h"
+
+zend_class_entry *php_phongo_minkey_interface_ce;
+
+/* {{{ MongoDB\BSON\MinKeyInterface function entries */
+static zend_function_entry php_phongo_minkey_interface_me[] = {
+	PHP_FE_END
+};
+/* }}} */
+
+void php_phongo_minkey_interface_init_ce(INIT_FUNC_ARGS) /* {{{ */
+{
+	zend_class_entry ce;
+
+	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "MinKeyInterface", php_phongo_minkey_interface_me);
+	php_phongo_minkey_interface_ce = zend_register_internal_interface(&ce TSRMLS_CC);
+} /* }}} */
+
+/*
+ * Local variables:
+ * tab-width: 4
+ * c-basic-offset: 4
+ * End:
+ * vim600: noet sw=4 ts=4 fdm=marker
+ * vim<600: noet sw=4 ts=4
+ */

--- a/src/BSON/ObjectID.c
+++ b/src/BSON/ObjectID.c
@@ -414,6 +414,7 @@ void php_phongo_objectid_init_ce(INIT_FUNC_ARGS) /* {{{ */
 	php_phongo_objectid_ce->create_object = php_phongo_objectid_create_object;
 	PHONGO_CE_FINAL(php_phongo_objectid_ce);
 
+	zend_class_implements(php_phongo_objectid_ce TSRMLS_CC, 1, php_phongo_objectid_interface_ce);
 	zend_class_implements(php_phongo_objectid_ce TSRMLS_CC, 1, php_phongo_json_serializable_ce);
 	zend_class_implements(php_phongo_objectid_ce TSRMLS_CC, 1, php_phongo_type_ce);
 	zend_class_implements(php_phongo_objectid_ce TSRMLS_CC, 1, zend_ce_serializable);

--- a/src/BSON/ObjectIDInterface.c
+++ b/src/BSON/ObjectIDInterface.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include <php.h> 
+
+#include "phongo_compat.h"
+#include "php_phongo.h"
+
+zend_class_entry *php_phongo_objectid_interface_ce;
+
+/* {{{ MongoDB\BSON\ObjectIDInterface function entries */
+ZEND_BEGIN_ARG_INFO_EX(ai_ObjectIDInterface_void, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+static zend_function_entry php_phongo_objectid_interface_me[] = {
+	ZEND_ABSTRACT_ME(ObjectIDInterface, getTimestamp, ai_ObjectIDInterface_void)
+	ZEND_ABSTRACT_ME(ObjectIDInterface, __toString, ai_ObjectIDInterface_void)
+	PHP_FE_END
+};
+/* }}} */
+
+void php_phongo_objectid_interface_init_ce(INIT_FUNC_ARGS) /* {{{ */
+{
+	zend_class_entry ce;
+
+	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "ObjectIDInterface", php_phongo_objectid_interface_me);
+	php_phongo_objectid_interface_ce = zend_register_internal_interface(&ce TSRMLS_CC);
+} /* }}} */
+
+/*
+ * Local variables:
+ * tab-width: 4
+ * c-basic-offset: 4
+ * End:
+ * vim600: noet sw=4 ts=4 fdm=marker
+ * vim<600: noet sw=4 ts=4
+ */

--- a/src/BSON/Regex.c
+++ b/src/BSON/Regex.c
@@ -465,6 +465,7 @@ void php_phongo_regex_init_ce(INIT_FUNC_ARGS) /* {{{ */
 	php_phongo_regex_ce->create_object = php_phongo_regex_create_object;
 	PHONGO_CE_FINAL(php_phongo_regex_ce);
 
+	zend_class_implements(php_phongo_regex_ce TSRMLS_CC, 1, php_phongo_regex_interface_ce);
 	zend_class_implements(php_phongo_regex_ce TSRMLS_CC, 1, php_phongo_type_ce);
 	zend_class_implements(php_phongo_regex_ce TSRMLS_CC, 1, zend_ce_serializable);
 	zend_class_implements(php_phongo_regex_ce TSRMLS_CC, 1, php_phongo_json_serializable_ce);

--- a/src/BSON/RegexInterface.c
+++ b/src/BSON/RegexInterface.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include <php.h> 
+
+#include "phongo_compat.h"
+#include "php_phongo.h"
+
+zend_class_entry *php_phongo_regex_interface_ce;
+
+/* {{{ MongoDB\BSON\RegexInterface function entries */
+ZEND_BEGIN_ARG_INFO_EX(ai_RegexInterface_void, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+static zend_function_entry php_phongo_regex_interface_me[] = {
+	ZEND_ABSTRACT_ME(RegexInterface, getFlags, ai_RegexInterface_void)
+	ZEND_ABSTRACT_ME(RegexInterface, getPattern, ai_RegexInterface_void)
+	ZEND_ABSTRACT_ME(RegexInterface, __toString, ai_RegexInterface_void)
+	PHP_FE_END
+};
+/* }}} */
+
+void php_phongo_regex_interface_init_ce(INIT_FUNC_ARGS) /* {{{ */
+{
+	zend_class_entry ce;
+
+	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "RegexInterface", php_phongo_regex_interface_me);
+	php_phongo_regex_interface_ce = zend_register_internal_interface(&ce TSRMLS_CC);
+} /* }}} */
+
+/*
+ * Local variables:
+ * tab-width: 4
+ * c-basic-offset: 4
+ * End:
+ * vim600: noet sw=4 ts=4 fdm=marker
+ * vim<600: noet sw=4 ts=4
+ */

--- a/src/BSON/Timestamp.c
+++ b/src/BSON/Timestamp.c
@@ -531,6 +531,7 @@ void php_phongo_timestamp_init_ce(INIT_FUNC_ARGS) /* {{{ */
 	php_phongo_timestamp_ce->create_object = php_phongo_timestamp_create_object;
 	PHONGO_CE_FINAL(php_phongo_timestamp_ce);
 
+	zend_class_implements(php_phongo_timestamp_ce TSRMLS_CC, 1, php_phongo_timestamp_interface_ce);
 	zend_class_implements(php_phongo_timestamp_ce TSRMLS_CC, 1, php_phongo_json_serializable_ce);
 	zend_class_implements(php_phongo_timestamp_ce TSRMLS_CC, 1, php_phongo_type_ce);
 	zend_class_implements(php_phongo_timestamp_ce TSRMLS_CC, 1, zend_ce_serializable);

--- a/src/BSON/TimestampInterface.c
+++ b/src/BSON/TimestampInterface.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include <php.h> 
+
+#include "phongo_compat.h"
+#include "php_phongo.h"
+
+zend_class_entry *php_phongo_timestamp_interface_ce;
+
+/* {{{ MongoDB\BSON\TimestampInterface function entries */
+ZEND_BEGIN_ARG_INFO_EX(ai_TimestampInterface_void, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+static zend_function_entry php_phongo_timestamp_interface_me[] = {
+	ZEND_ABSTRACT_ME(TimestampInterface, getIncrement, ai_TimestampInterface_void)
+	ZEND_ABSTRACT_ME(TimestampInterface, getTimestamp, ai_TimestampInterface_void)
+	ZEND_ABSTRACT_ME(TimestampInterface, __toString, ai_TimestampInterface_void)
+	PHP_FE_END
+};
+/* }}} */
+
+void php_phongo_timestamp_interface_init_ce(INIT_FUNC_ARGS) /* {{{ */
+{
+	zend_class_entry ce;
+
+	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "TimestampInterface", php_phongo_timestamp_interface_me);
+	php_phongo_timestamp_interface_ce = zend_register_internal_interface(&ce TSRMLS_CC);
+} /* }}} */
+
+/*
+ * Local variables:
+ * tab-width: 4
+ * c-basic-offset: 4
+ * End:
+ * vim600: noet sw=4 ts=4 fdm=marker
+ * vim<600: noet sw=4 ts=4
+ */

--- a/src/BSON/UTCDateTime.c
+++ b/src/BSON/UTCDateTime.c
@@ -537,6 +537,7 @@ void php_phongo_utcdatetime_init_ce(INIT_FUNC_ARGS) /* {{{ */
 	php_phongo_utcdatetime_ce->create_object = php_phongo_utcdatetime_create_object;
 	PHONGO_CE_FINAL(php_phongo_utcdatetime_ce);
 
+	zend_class_implements(php_phongo_utcdatetime_ce TSRMLS_CC, 1, php_phongo_utcdatetime_interface_ce);
 	zend_class_implements(php_phongo_utcdatetime_ce TSRMLS_CC, 1, php_phongo_json_serializable_ce);
 	zend_class_implements(php_phongo_utcdatetime_ce TSRMLS_CC, 1, php_phongo_type_ce);
 	zend_class_implements(php_phongo_utcdatetime_ce TSRMLS_CC, 1, zend_ce_serializable);

--- a/src/BSON/UTCDateTimeInterface.c
+++ b/src/BSON/UTCDateTimeInterface.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include <php.h> 
+
+#include "phongo_compat.h"
+#include "php_phongo.h"
+
+zend_class_entry *php_phongo_utcdatetime_interface_ce;
+
+/* {{{ MongoDB\BSON\UTCDateTimeInterface function entries */
+ZEND_BEGIN_ARG_INFO_EX(ai_UTCDateTimeInterface_void, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+static zend_function_entry php_phongo_utcdatetime_interface_me[] = {
+	ZEND_ABSTRACT_ME(UTCDateTimeInterface, toDateTime, ai_UTCDateTimeInterface_void)
+	ZEND_ABSTRACT_ME(UTCDateTimeInterface, __toString, ai_UTCDateTimeInterface_void)
+	PHP_FE_END
+};
+/* }}} */
+
+void php_phongo_utcdatetime_interface_init_ce(INIT_FUNC_ARGS) /* {{{ */
+{
+	zend_class_entry ce;
+
+	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "UTCDateTimeInterface", php_phongo_utcdatetime_interface_me);
+	php_phongo_utcdatetime_interface_ce = zend_register_internal_interface(&ce TSRMLS_CC);
+} /* }}} */
+
+/*
+ * Local variables:
+ * tab-width: 4
+ * c-basic-offset: 4
+ * End:
+ * vim600: noet sw=4 ts=4 fdm=marker
+ * vim<600: noet sw=4 ts=4
+ */

--- a/src/bson.c
+++ b/src/bson.c
@@ -47,6 +47,9 @@
 		zval zwrapper; \
 		zend_call_method_with_1_params(NULL, wrapper_ce, NULL, "createfrombsontype", &zwrapper, &(zchild)); \
 		zval_ptr_dtor(&(zchild)); \
+		if (EG(exception)) { \
+			return false; \
+		} \
 		ZVAL_COPY_VALUE(&(zchild), &zwrapper); \
 	}
 #else
@@ -55,6 +58,9 @@
 		zval *zwrapper; \
 		zend_call_method_with_1_params(NULL, wrapper_ce, NULL, "createfrombsontype", &zwrapper, (zchild)); \
 		zval_ptr_dtor(&(zchild)); \
+		if (EG(exception)) { \
+			return false; \
+		} \
 		zchild = zwrapper; \
 	}
 #endif

--- a/tests/bson/bson-binaryinterface-001.phpt
+++ b/tests/bson/bson-binaryinterface-001.phpt
@@ -1,0 +1,14 @@
+--TEST--
+MongoDB\BSON\BinaryInterface is implemented by MongoDB\BSON\Binary
+--FILE--
+<?php
+
+$binary = new MongoDB\BSON\Binary('foo', MongoDB\BSON\Binary::TYPE_GENERIC);
+var_dump($binary instanceof MongoDB\BSON\BinaryInterface);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+bool(true)
+===DONE===

--- a/tests/bson/bson-binaryinterface-002.phpt
+++ b/tests/bson/bson-binaryinterface-002.phpt
@@ -1,0 +1,117 @@
+--TEST--
+MongoDB\BSON\BinaryInterface example with MongoDB\BSON\TypeWrapper
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/tools.php';
+
+class MyBinary implements MongoDB\BSON\TypeWrapper, MongoDB\BSON\BinaryInterface
+{
+    private $binary;
+
+    public function __construct($data, $type)
+    {
+        $this->binary = new MongoDB\BSON\Binary($data, $type);
+    }
+
+    public static function createFromBSONType(MongoDB\BSON\Type $type)
+    {
+        if ( ! $type instanceof MongoDB\BSON\Binary) {
+            throw new InvalidArgumentException('Cannot create MyBinary from ' . get_class($type));
+        }
+
+        return new self($type->getData(), $type->getType());
+    }
+
+    public function toBSONType()
+    {
+        return $this->binary;
+    }
+
+    public function getData()
+    {
+        return $this->binary->getData();
+    }
+
+    public function getType()
+    {
+        return $this->binary->getType();
+    }
+
+    public function __toString()
+    {
+        return (string) $this->binary;
+    }
+}
+
+$binary = new MongoDB\BSON\Binary('foo', MongoDB\BSON\Binary::TYPE_GENERIC);
+$myBinary = new MyBinary('foo', MongoDB\BSON\Binary::TYPE_GENERIC);
+
+echo "\nTesting MyBinary and Binary are equivalent\n";
+var_dump($binary->getData() === $myBinary->getData());
+var_dump($binary->getType() === $myBinary->getType());
+var_dump((string) $binary === (string) $myBinary);
+
+echo "\nTesting MyBinary and Binary produce the same BSON\n";
+var_dump(fromPHP(['x' => $binary]) === fromPHP(['x' => $myBinary]));
+
+echo "\nTesting Binary to BSON to MyBinary\n";
+var_dump(toPHP(fromPHP(['x' => $binary]), ['types' => ['Binary' => 'MyBinary']])->x);
+
+echo "\nTesting MyBinary to BSON to MyBinary\n";
+var_dump(toPHP(fromPHP(['x' => $myBinary]), ['types' => ['Binary' => 'MyBinary']])->x);
+
+echo "\nTesting MyBinary to BSON to Binary\n";
+var_dump(toPHP(fromPHP(['x' => $myBinary]))->x);
+
+echo "\nTesting MyBinary::createFromBSONType() expects Binary\n";
+echo throws(function() {
+    toPHP(fromPHP(['x' => new MongoDB\BSON\MinKey]), ['types' => ['MinKey' => 'MyBinary']]);
+}, 'InvalidArgumentException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+Testing MyBinary and Binary are equivalent
+bool(true)
+bool(true)
+bool(true)
+
+Testing MyBinary and Binary produce the same BSON
+bool(true)
+
+Testing Binary to BSON to MyBinary
+object(MyBinary)#%d (%d) {
+  ["binary":"MyBinary":private]=>
+  object(MongoDB\BSON\Binary)#%d (%d) {
+    ["data"]=>
+    string(3) "foo"
+    ["type"]=>
+    int(0)
+  }
+}
+
+Testing MyBinary to BSON to MyBinary
+object(MyBinary)#%d (%d) {
+  ["binary":"MyBinary":private]=>
+  object(MongoDB\BSON\Binary)#%d (%d) {
+    ["data"]=>
+    string(3) "foo"
+    ["type"]=>
+    int(0)
+  }
+}
+
+Testing MyBinary to BSON to Binary
+object(MongoDB\BSON\Binary)#%d (%d) {
+  ["data"]=>
+  string(3) "foo"
+  ["type"]=>
+  int(0)
+}
+
+Testing MyBinary::createFromBSONType() expects Binary
+OK: Got InvalidArgumentException
+Cannot create MyBinary from MongoDB\BSON\MinKey
+===DONE===

--- a/tests/bson/bson-decimal128interface-001.phpt
+++ b/tests/bson/bson-decimal128interface-001.phpt
@@ -1,0 +1,14 @@
+--TEST--
+MongoDB\BSON\Decimal128Interface is implemented by MongoDB\BSON\Decimal128
+--FILE--
+<?php
+
+$decimal = new MongoDB\BSON\Decimal128('1234.5678');
+var_dump($decimal instanceof MongoDB\BSON\Decimal128Interface);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+bool(true)
+===DONE===

--- a/tests/bson/bson-decimal128interface-002.phpt
+++ b/tests/bson/bson-decimal128interface-002.phpt
@@ -1,0 +1,97 @@
+--TEST--
+MongoDB\BSON\Decimal128Interface example with MongoDB\BSON\TypeWrapper
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/tools.php';
+
+class MyDecimal128 implements MongoDB\BSON\TypeWrapper, MongoDB\BSON\Decimal128Interface
+{
+    private $decimal;
+
+    public function __construct($value)
+    {
+        $this->decimal = new MongoDB\BSON\Decimal128($value);
+    }
+
+    public static function createFromBSONType(MongoDB\BSON\Type $type)
+    {
+        if ( ! $type instanceof MongoDB\BSON\Decimal128) {
+            throw new InvalidArgumentException('Cannot create MyDecimal128 from ' . get_class($type));
+        }
+
+        return new self($type);
+    }
+
+    public function toBSONType()
+    {
+        return $this->decimal;
+    }
+
+    public function __toString()
+    {
+        return (string) $this->decimal;
+    }
+}
+
+$decimal = new MongoDB\BSON\Decimal128('1234.5678');
+$myDecimal = new MyDecimal128('1234.5678');
+
+echo "\nTesting MyDecimal128 and Decimal128 are equivalent\n";
+var_dump((string) $decimal === (string) $myDecimal);
+
+echo "\nTesting MyDecimal128 and Decimal128 produce the same BSON\n";
+var_dump(fromPHP(['x' => $decimal]) === fromPHP(['x' => $myDecimal]));
+
+echo "\nTesting Decimal128 to BSON to MyDecimal128\n";
+var_dump(toPHP(fromPHP(['x' => $decimal]), ['types' => ['Decimal128' => 'MyDecimal128']])->x);
+
+echo "\nTesting MyDecimal128 to BSON to MyDecimal128\n";
+var_dump(toPHP(fromPHP(['x' => $myDecimal]), ['types' => ['Decimal128' => 'MyDecimal128']])->x);
+
+echo "\nTesting MyDecimal128 to BSON to Decimal128\n";
+var_dump(toPHP(fromPHP(['x' => $myDecimal]))->x);
+
+echo "\nTesting MyDecimal128::createFromBSONType() expects Decimal128\n";
+echo throws(function() {
+    toPHP(fromPHP(['x' => new MongoDB\BSON\MinKey]), ['types' => ['MinKey' => 'MyDecimal128']]);
+}, 'InvalidArgumentException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+Testing MyDecimal128 and Decimal128 are equivalent
+bool(true)
+
+Testing MyDecimal128 and Decimal128 produce the same BSON
+bool(true)
+
+Testing Decimal128 to BSON to MyDecimal128
+object(MyDecimal128)#%d (%d) {
+  ["decimal":"MyDecimal128":private]=>
+  object(MongoDB\BSON\Decimal128)#%d (%d) {
+    ["dec"]=>
+    string(9) "1234.5678"
+  }
+}
+
+Testing MyDecimal128 to BSON to MyDecimal128
+object(MyDecimal128)#%d (%d) {
+  ["decimal":"MyDecimal128":private]=>
+  object(MongoDB\BSON\Decimal128)#%d (%d) {
+    ["dec"]=>
+    string(9) "1234.5678"
+  }
+}
+
+Testing MyDecimal128 to BSON to Decimal128
+object(MongoDB\BSON\Decimal128)#%d (%d) {
+  ["dec"]=>
+  string(9) "1234.5678"
+}
+
+Testing MyDecimal128::createFromBSONType() expects Decimal128
+OK: Got InvalidArgumentException
+Cannot create MyDecimal128 from MongoDB\BSON\MinKey
+===DONE===

--- a/tests/bson/bson-javascriptinterface-001.phpt
+++ b/tests/bson/bson-javascriptinterface-001.phpt
@@ -1,0 +1,14 @@
+--TEST--
+MongoDB\BSON\JavascriptInterface is implemented by MongoDB\BSON\Javascript
+--FILE--
+<?php
+
+$javascript = new MongoDB\BSON\Javascript('function foo() { return bar; }', ['bar' => 1]);
+var_dump($javascript instanceof MongoDB\BSON\JavascriptInterface);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+bool(true)
+===DONE===

--- a/tests/bson/bson-javascriptinterface-002.phpt
+++ b/tests/bson/bson-javascriptinterface-002.phpt
@@ -1,0 +1,127 @@
+--TEST--
+MongoDB\BSON\JavascriptInterface example with MongoDB\BSON\TypeWrapper
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/tools.php';
+
+class MyJavascript implements MongoDB\BSON\TypeWrapper, MongoDB\BSON\JavascriptInterface
+{
+    private $javascript;
+
+    public function __construct($code, $scope)
+    {
+        $this->javascript = new MongoDB\BSON\Javascript($code, $scope);
+    }
+
+    public static function createFromBSONType(MongoDB\BSON\Type $type)
+    {
+        if ( ! $type instanceof MongoDB\BSON\Javascript) {
+            throw new InvalidArgumentException('Cannot create MyJavascript from ' . get_class($type));
+        }
+
+        return new self($type->getCode(), $type->getScope());
+    }
+
+    public function toBSONType()
+    {
+        return $this->javascript;
+    }
+
+    public function getCode()
+    {
+        return $this->javascript->getCode();
+    }
+
+    public function getScope()
+    {
+        return $this->javascript->getScope();
+    }
+
+    public function __toString()
+    {
+        return (string) $this->javascript;
+    }
+}
+
+$javascript = new MongoDB\BSON\Javascript('function foo() { return bar; }', ['bar' => 1]);
+$myJavascript = new MyJavascript('function foo() { return bar; }', ['bar' => 1]);
+
+echo "\nTesting MyJavascript and Javascript are equivalent\n";
+var_dump($javascript->getCode() === $myJavascript->getCode());
+// Do not use "===" since each scope is a different stdClass instance
+var_dump($javascript->getScope() == $myJavascript->getScope());
+var_dump((string) $javascript === (string) $myJavascript);
+
+echo "\nTesting MyJavascript and Javascript produce the same BSON\n";
+var_dump(fromPHP(['x' => $javascript]) === fromPHP(['x' => $myJavascript]));
+
+echo "\nTesting Javascript to BSON to MyJavascript\n";
+var_dump(toPHP(fromPHP(['x' => $javascript]), ['types' => ['Javascript' => 'MyJavascript']])->x);
+
+echo "\nTesting MyJavascript to BSON to MyJavascript\n";
+var_dump(toPHP(fromPHP(['x' => $myJavascript]), ['types' => ['Javascript' => 'MyJavascript']])->x);
+
+echo "\nTesting MyJavascript to BSON to Javascript\n";
+var_dump(toPHP(fromPHP(['x' => $myJavascript]))->x);
+
+echo "\nTesting MyJavascript::createFromBSONType() expects Javascript\n";
+echo throws(function() {
+    toPHP(fromPHP(['x' => new MongoDB\BSON\MinKey]), ['types' => ['MinKey' => 'MyJavascript']]);
+}, 'InvalidArgumentException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+Testing MyJavascript and Javascript are equivalent
+bool(true)
+bool(true)
+bool(true)
+
+Testing MyJavascript and Javascript produce the same BSON
+bool(true)
+
+Testing Javascript to BSON to MyJavascript
+object(MyJavascript)#%d (%d) {
+  ["javascript":"MyJavascript":private]=>
+  object(MongoDB\BSON\Javascript)#%d (%d) {
+    ["code"]=>
+    string(30) "function foo() { return bar; }"
+    ["scope"]=>
+    object(stdClass)#%d (%d) {
+      ["bar"]=>
+      int(1)
+    }
+  }
+}
+
+Testing MyJavascript to BSON to MyJavascript
+object(MyJavascript)#%d (%d) {
+  ["javascript":"MyJavascript":private]=>
+  object(MongoDB\BSON\Javascript)#%d (%d) {
+    ["code"]=>
+    string(30) "function foo() { return bar; }"
+    ["scope"]=>
+    object(stdClass)#%d (%d) {
+      ["bar"]=>
+      int(1)
+    }
+  }
+}
+
+Testing MyJavascript to BSON to Javascript
+object(MongoDB\BSON\Javascript)#%d (%d) {
+  ["code"]=>
+  string(30) "function foo() { return bar; }"
+  ["scope"]=>
+  object(stdClass)#%d (%d) {
+    ["bar"]=>
+    int(1)
+  }
+}
+
+Testing MyJavascript::createFromBSONType() expects Javascript
+OK: Got InvalidArgumentException
+Cannot create MyJavascript from MongoDB\BSON\MinKey
+===DONE===

--- a/tests/bson/bson-maxkeyinterface-001.phpt
+++ b/tests/bson/bson-maxkeyinterface-001.phpt
@@ -1,0 +1,14 @@
+--TEST--
+MongoDB\BSON\MaxKeyInterface is implemented by MongoDB\BSON\MaxKey
+--FILE--
+<?php
+
+$maxkey = new MongoDB\BSON\MaxKey;
+var_dump($maxkey instanceof MongoDB\BSON\MaxKeyInterface);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+bool(true)
+===DONE===

--- a/tests/bson/bson-maxkeyinterface-002.phpt
+++ b/tests/bson/bson-maxkeyinterface-002.phpt
@@ -1,0 +1,80 @@
+--TEST--
+MongoDB\BSON\MaxKeyInterface example with MongoDB\BSON\TypeWrapper
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/tools.php';
+
+class MyMaxKey implements MongoDB\BSON\TypeWrapper, MongoDB\BSON\MaxKeyInterface
+{
+    private $maxkey;
+
+    public function __construct()
+    {
+        $this->maxkey = new MongoDB\BSON\MaxKey;
+    }
+
+    public static function createFromBSONType(MongoDB\BSON\Type $type)
+    {
+        if ( ! $type instanceof MongoDB\BSON\MaxKey) {
+            throw new InvalidArgumentException('Cannot create MyMaxKey from ' . get_class($type));
+        }
+
+        return new self;
+    }
+
+    public function toBSONType()
+    {
+        return $this->maxkey;
+    }
+}
+
+$maxkey = new MongoDB\BSON\MaxKey;
+$myMaxkey = new MyMaxKey;
+
+echo "\nTesting MyMaxKey and MaxKey produce the same BSON\n";
+var_dump(fromPHP(['x' => $maxkey]) === fromPHP(['x' => $myMaxkey]));
+
+echo "\nTesting MaxKey to BSON to MyMaxKey\n";
+var_dump(toPHP(fromPHP(['x' => $maxkey]), ['types' => ['MaxKey' => 'MyMaxKey']])->x);
+
+echo "\nTesting MyMaxKey to BSON to MyMaxKey\n";
+var_dump(toPHP(fromPHP(['x' => $myMaxkey]), ['types' => ['MaxKey' => 'MyMaxKey']])->x);
+
+echo "\nTesting MyMaxKey to BSON to MaxKey\n";
+var_dump(toPHP(fromPHP(['x' => $myMaxkey]))->x);
+
+echo "\nTesting MyMaxKey::createFromBSONType() expects MaxKey\n";
+echo throws(function() {
+    toPHP(fromPHP(['x' => new MongoDB\BSON\MinKey]), ['types' => ['MinKey' => 'MyMaxKey']]);
+}, 'InvalidArgumentException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+Testing MyMaxKey and MaxKey produce the same BSON
+bool(true)
+
+Testing MaxKey to BSON to MyMaxKey
+object(MyMaxKey)#%d (%d) {
+  ["maxkey":"MyMaxKey":private]=>
+  object(MongoDB\BSON\MaxKey)#%d (%d) {
+  }
+}
+
+Testing MyMaxKey to BSON to MyMaxKey
+object(MyMaxKey)#%d (%d) {
+  ["maxkey":"MyMaxKey":private]=>
+  object(MongoDB\BSON\MaxKey)#%d (%d) {
+  }
+}
+
+Testing MyMaxKey to BSON to MaxKey
+object(MongoDB\BSON\MaxKey)#%d (%d) {
+}
+
+Testing MyMaxKey::createFromBSONType() expects MaxKey
+OK: Got InvalidArgumentException
+Cannot create MyMaxKey from MongoDB\BSON\MinKey
+===DONE===

--- a/tests/bson/bson-minkeyinterface-001.phpt
+++ b/tests/bson/bson-minkeyinterface-001.phpt
@@ -1,0 +1,14 @@
+--TEST--
+MongoDB\BSON\MinKeyInterface is implemented by MongoDB\BSON\MinKey
+--FILE--
+<?php
+
+$minkey = new MongoDB\BSON\MinKey;
+var_dump($minkey instanceof MongoDB\BSON\MinKeyInterface);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+bool(true)
+===DONE===

--- a/tests/bson/bson-minkeyinterface-002.phpt
+++ b/tests/bson/bson-minkeyinterface-002.phpt
@@ -1,0 +1,80 @@
+--TEST--
+MongoDB\BSON\MinKeyInterface example with MongoDB\BSON\TypeWrapper
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/tools.php';
+
+class MyMinKey implements MongoDB\BSON\TypeWrapper, MongoDB\BSON\MinKeyInterface
+{
+    private $minkey;
+
+    public function __construct()
+    {
+        $this->minkey = new MongoDB\BSON\MinKey;
+    }
+
+    public static function createFromBSONType(MongoDB\BSON\Type $type)
+    {
+        if ( ! $type instanceof MongoDB\BSON\MinKey) {
+            throw new InvalidArgumentException('Cannot create MyMinKey from ' . get_class($type));
+        }
+
+        return new self;
+    }
+
+    public function toBSONType()
+    {
+        return $this->minkey;
+    }
+}
+
+$minkey = new MongoDB\BSON\MinKey;
+$myMinkey = new MyMinKey;
+
+echo "\nTesting MyMinKey and MinKey produce the same BSON\n";
+var_dump(fromPHP(['x' => $minkey]) === fromPHP(['x' => $myMinkey]));
+
+echo "\nTesting MinKey to BSON to MyMinKey\n";
+var_dump(toPHP(fromPHP(['x' => $minkey]), ['types' => ['MinKey' => 'MyMinKey']])->x);
+
+echo "\nTesting MyMinKey to BSON to MyMinKey\n";
+var_dump(toPHP(fromPHP(['x' => $myMinkey]), ['types' => ['MinKey' => 'MyMinKey']])->x);
+
+echo "\nTesting MyMinKey to BSON to MinKey\n";
+var_dump(toPHP(fromPHP(['x' => $myMinkey]))->x);
+
+echo "\nTesting MyMinKey::createFromBSONType() expects MinKey\n";
+echo throws(function() {
+    toPHP(fromPHP(['x' => new MongoDB\BSON\MaxKey]), ['types' => ['MaxKey' => 'MyMinKey']]);
+}, 'InvalidArgumentException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+Testing MyMinKey and MinKey produce the same BSON
+bool(true)
+
+Testing MinKey to BSON to MyMinKey
+object(MyMinKey)#%d (%d) {
+  ["minkey":"MyMinKey":private]=>
+  object(MongoDB\BSON\MinKey)#%d (%d) {
+  }
+}
+
+Testing MyMinKey to BSON to MyMinKey
+object(MyMinKey)#%d (%d) {
+  ["minkey":"MyMinKey":private]=>
+  object(MongoDB\BSON\MinKey)#%d (%d) {
+  }
+}
+
+Testing MyMinKey to BSON to MinKey
+object(MongoDB\BSON\MinKey)#%d (%d) {
+}
+
+Testing MyMinKey::createFromBSONType() expects MinKey
+OK: Got InvalidArgumentException
+Cannot create MyMinKey from MongoDB\BSON\MaxKey
+===DONE===

--- a/tests/bson/bson-objectidinterface-001.phpt
+++ b/tests/bson/bson-objectidinterface-001.phpt
@@ -1,0 +1,14 @@
+--TEST--
+MongoDB\BSON\ObjectIDInterface is implemented by MongoDB\BSON\ObjectID
+--FILE--
+<?php
+
+$oid = new MongoDB\BSON\ObjectID;
+var_dump($oid instanceof MongoDB\BSON\ObjectIDInterface);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+bool(true)
+===DONE===

--- a/tests/bson/bson-objectidinterface-002.phpt
+++ b/tests/bson/bson-objectidinterface-002.phpt
@@ -1,0 +1,104 @@
+--TEST--
+MongoDB\BSON\ObjectIDInterface example with MongoDB\BSON\TypeWrapper
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/tools.php';
+
+class MyObjectID implements MongoDB\BSON\TypeWrapper, MongoDB\BSON\ObjectIDInterface
+{
+    private $oid;
+
+    public function __construct($value = null)
+    {
+        $this->oid = new MongoDB\BSON\ObjectID($value);
+    }
+
+    public static function createFromBSONType(MongoDB\BSON\Type $type)
+    {
+        if ( ! $type instanceof MongoDB\BSON\ObjectID) {
+            throw new InvalidArgumentException('Cannot create MyObjectID from ' . get_class($type));
+        }
+
+        return new self($type);
+    }
+
+    public function toBSONType()
+    {
+        return $this->oid;
+    }
+
+    public function getTimestamp()
+    {
+        return $this->oid->getTimestamp();
+    }
+
+    public function __toString()
+    {
+        return (string) $this->oid;
+    }
+}
+
+$oid = new MongoDB\BSON\ObjectID('59823d5c98ed91f9d815743c');
+$myOid = new MyObjectID('59823d5c98ed91f9d815743c');
+
+echo "\nTesting MyObjectID and ObjectID are equivalent\n";
+var_dump($oid->getTimestamp() === $myOid->getTimestamp());
+var_dump((string) $oid === (string) $myOid);
+
+echo "\nTesting MyObjectID and ObjectID produce the same BSON\n";
+var_dump(fromPHP(['x' => $oid]) === fromPHP(['x' => $myOid]));
+
+echo "\nTesting ObjectID to BSON to MyObjectID\n";
+var_dump(toPHP(fromPHP(['x' => $oid]), ['types' => ['ObjectID' => 'MyObjectID']])->x);
+
+echo "\nTesting MyObjectID to BSON to MyObjectID\n";
+var_dump(toPHP(fromPHP(['x' => $myOid]), ['types' => ['ObjectID' => 'MyObjectID']])->x);
+
+echo "\nTesting MyObjectID to BSON to ObjectID\n";
+var_dump(toPHP(fromPHP(['x' => $myOid]))->x);
+
+echo "\nTesting MyObjectID::createFromBSONType() expects ObjectID\n";
+echo throws(function() {
+    toPHP(fromPHP(['x' => new MongoDB\BSON\MinKey]), ['types' => ['MinKey' => 'MyObjectID']]);
+}, 'InvalidArgumentException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+Testing MyObjectID and ObjectID are equivalent
+bool(true)
+bool(true)
+
+Testing MyObjectID and ObjectID produce the same BSON
+bool(true)
+
+Testing ObjectID to BSON to MyObjectID
+object(MyObjectID)#%d (%d) {
+  ["oid":"MyObjectID":private]=>
+  object(MongoDB\BSON\ObjectID)#%d (%d) {
+    ["oid"]=>
+    string(24) "59823d5c98ed91f9d815743c"
+  }
+}
+
+Testing MyObjectID to BSON to MyObjectID
+object(MyObjectID)#%d (%d) {
+  ["oid":"MyObjectID":private]=>
+  object(MongoDB\BSON\ObjectID)#%d (%d) {
+    ["oid"]=>
+    string(24) "59823d5c98ed91f9d815743c"
+  }
+}
+
+Testing MyObjectID to BSON to ObjectID
+object(MongoDB\BSON\ObjectID)#%d (%d) {
+  ["oid"]=>
+  string(24) "59823d5c98ed91f9d815743c"
+}
+
+Testing MyObjectID::createFromBSONType() expects ObjectID
+OK: Got InvalidArgumentException
+Cannot create MyObjectID from MongoDB\BSON\MinKey
+===DONE===

--- a/tests/bson/bson-regexinterface-001.phpt
+++ b/tests/bson/bson-regexinterface-001.phpt
@@ -1,0 +1,14 @@
+--TEST--
+MongoDB\BSON\RegexInterface is implemented by MongoDB\BSON\Regex
+--FILE--
+<?php
+
+$regex = new MongoDB\BSON\Regex('pattern', 'i');
+var_dump($regex instanceof MongoDB\BSON\RegexInterface);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+bool(true)
+===DONE===

--- a/tests/bson/bson-regexinterface-002.phpt
+++ b/tests/bson/bson-regexinterface-002.phpt
@@ -1,0 +1,117 @@
+--TEST--
+MongoDB\BSON\RegexInterface example with MongoDB\BSON\TypeWrapper
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/tools.php';
+
+class MyRegex implements MongoDB\BSON\TypeWrapper, MongoDB\BSON\RegexInterface
+{
+    private $regex;
+
+    public function __construct($pattern, $flags)
+    {
+        $this->regex = new MongoDB\BSON\Regex($pattern, $flags);
+    }
+
+    public static function createFromBSONType(MongoDB\BSON\Type $type)
+    {
+        if ( ! $type instanceof MongoDB\BSON\Regex) {
+            throw new InvalidArgumentException('Cannot create MyRegex from ' . get_class($type));
+        }
+
+        return new self($type->getPattern(), $type->getFlags());
+    }
+
+    public function toBSONType()
+    {
+        return $this->regex;
+    }
+
+    public function getPattern()
+    {
+        return $this->regex->getPattern();
+    }
+
+    public function getFlags()
+    {
+        return $this->regex->getFlags();
+    }
+
+    public function __toString()
+    {
+        return (string) $this->regex;
+    }
+}
+
+$regex = new MongoDB\BSON\Regex('pattern', 'i');
+$myRegex = new MyRegex('pattern', 'i');
+
+echo "\nTesting MyRegex and Regex are equivalent\n";
+var_dump($regex->getPattern() === $myRegex->getPattern());
+var_dump($regex->getFlags() === $myRegex->getFlags());
+var_dump((string) $regex === (string) $myRegex);
+
+echo "\nTesting MyRegex and Regex produce the same BSON\n";
+var_dump(fromPHP(['x' => $regex]) === fromPHP(['x' => $myRegex]));
+
+echo "\nTesting Regex to BSON to MyRegex\n";
+var_dump(toPHP(fromPHP(['x' => $regex]), ['types' => ['Regex' => 'MyRegex']])->x);
+
+echo "\nTesting MyRegex to BSON to MyRegex\n";
+var_dump(toPHP(fromPHP(['x' => $myRegex]), ['types' => ['Regex' => 'MyRegex']])->x);
+
+echo "\nTesting MyRegex to BSON to Regex\n";
+var_dump(toPHP(fromPHP(['x' => $myRegex]))->x);
+
+echo "\nTesting MyRegex::createFromBSONType() expects Regex\n";
+echo throws(function() {
+    toPHP(fromPHP(['x' => new MongoDB\BSON\MinKey]), ['types' => ['MinKey' => 'MyRegex']]);
+}, 'InvalidArgumentException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+Testing MyRegex and Regex are equivalent
+bool(true)
+bool(true)
+bool(true)
+
+Testing MyRegex and Regex produce the same BSON
+bool(true)
+
+Testing Regex to BSON to MyRegex
+object(MyRegex)#%d (%d) {
+  ["regex":"MyRegex":private]=>
+  object(MongoDB\BSON\Regex)#%d (%d) {
+    ["pattern"]=>
+    string(7) "pattern"
+    ["flags"]=>
+    string(1) "i"
+  }
+}
+
+Testing MyRegex to BSON to MyRegex
+object(MyRegex)#%d (%d) {
+  ["regex":"MyRegex":private]=>
+  object(MongoDB\BSON\Regex)#%d (%d) {
+    ["pattern"]=>
+    string(7) "pattern"
+    ["flags"]=>
+    string(1) "i"
+  }
+}
+
+Testing MyRegex to BSON to Regex
+object(MongoDB\BSON\Regex)#%d (%d) {
+  ["pattern"]=>
+  string(7) "pattern"
+  ["flags"]=>
+  string(1) "i"
+}
+
+Testing MyRegex::createFromBSONType() expects Regex
+OK: Got InvalidArgumentException
+Cannot create MyRegex from MongoDB\BSON\MinKey
+===DONE===

--- a/tests/bson/bson-timestampinterface-001.phpt
+++ b/tests/bson/bson-timestampinterface-001.phpt
@@ -1,0 +1,14 @@
+--TEST--
+MongoDB\BSON\TimestampInterface is implemented by MongoDB\BSON\Timestamp
+--FILE--
+<?php
+
+$timestamp = new MongoDB\BSON\Timestamp(1234, 5678);
+var_dump($timestamp instanceof MongoDB\BSON\TimestampInterface);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+bool(true)
+===DONE===

--- a/tests/bson/bson-timestampinterface-002.phpt
+++ b/tests/bson/bson-timestampinterface-002.phpt
@@ -1,0 +1,117 @@
+--TEST--
+MongoDB\BSON\TimestampInterface example with MongoDB\BSON\TypeWrapper
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/tools.php';
+
+class MyTimestamp implements MongoDB\BSON\TypeWrapper, MongoDB\BSON\TimestampInterface
+{
+    private $timestamp;
+
+    public function __construct($increment, $timestamp)
+    {
+        $this->timestamp = new MongoDB\BSON\Timestamp($increment, $timestamp);
+    }
+
+    public static function createFromBSONType(MongoDB\BSON\Type $type)
+    {
+        if ( ! $type instanceof MongoDB\BSON\Timestamp) {
+            throw new InvalidArgumentException('Cannot create MyTimestamp from ' . get_class($type));
+        }
+
+        return new self($type->getIncrement(), $type->getTimestamp());
+    }
+
+    public function toBSONType()
+    {
+        return $this->timestamp;
+    }
+
+    public function getIncrement()
+    {
+        return $this->timestamp->getIncrement();
+    }
+
+    public function getTimestamp()
+    {
+        return $this->timestamp->getTimestamp();
+    }
+
+    public function __toString()
+    {
+        return (string) $this->timestamp;
+    }
+}
+
+$timestamp = new MongoDB\BSON\Timestamp(1234, 5678);
+$myTimestamp = new MyTimestamp(1234, 5678);
+
+echo "\nTesting MyTimestamp and Timestamp are equivalent\n";
+var_dump($timestamp->getIncrement() === $myTimestamp->getIncrement());
+var_dump($timestamp->getTimestamp() === $myTimestamp->getTimestamp());
+var_dump((string) $timestamp === (string) $myTimestamp);
+
+echo "\nTesting MyTimestamp and Timestamp produce the same BSON\n";
+var_dump(fromPHP(['x' => $timestamp]) === fromPHP(['x' => $myTimestamp]));
+
+echo "\nTesting Timestamp to BSON to MyTimestamp\n";
+var_dump(toPHP(fromPHP(['x' => $timestamp]), ['types' => ['Timestamp' => 'MyTimestamp']])->x);
+
+echo "\nTesting MyTimestamp to BSON to MyTimestamp\n";
+var_dump(toPHP(fromPHP(['x' => $myTimestamp]), ['types' => ['Timestamp' => 'MyTimestamp']])->x);
+
+echo "\nTesting MyTimestamp to BSON to Timestamp\n";
+var_dump(toPHP(fromPHP(['x' => $myTimestamp]))->x);
+
+echo "\nTesting MyTimestamp::createFromBSONType() expects Timestamp\n";
+echo throws(function() {
+    toPHP(fromPHP(['x' => new MongoDB\BSON\MinKey]), ['types' => ['MinKey' => 'MyTimestamp']]);
+}, 'InvalidArgumentException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+Testing MyTimestamp and Timestamp are equivalent
+bool(true)
+bool(true)
+bool(true)
+
+Testing MyTimestamp and Timestamp produce the same BSON
+bool(true)
+
+Testing Timestamp to BSON to MyTimestamp
+object(MyTimestamp)#%d (%d) {
+  ["timestamp":"MyTimestamp":private]=>
+  object(MongoDB\BSON\Timestamp)#%d (%d) {
+    ["increment"]=>
+    string(4) "1234"
+    ["timestamp"]=>
+    string(4) "5678"
+  }
+}
+
+Testing MyTimestamp to BSON to MyTimestamp
+object(MyTimestamp)#%d (%d) {
+  ["timestamp":"MyTimestamp":private]=>
+  object(MongoDB\BSON\Timestamp)#%d (%d) {
+    ["increment"]=>
+    string(4) "1234"
+    ["timestamp"]=>
+    string(4) "5678"
+  }
+}
+
+Testing MyTimestamp to BSON to Timestamp
+object(MongoDB\BSON\Timestamp)#%d (%d) {
+  ["increment"]=>
+  string(4) "1234"
+  ["timestamp"]=>
+  string(4) "5678"
+}
+
+Testing MyTimestamp::createFromBSONType() expects Timestamp
+OK: Got InvalidArgumentException
+Cannot create MyTimestamp from MongoDB\BSON\MinKey
+===DONE===

--- a/tests/bson/bson-utcdatetimeinterface-001.phpt
+++ b/tests/bson/bson-utcdatetimeinterface-001.phpt
@@ -1,0 +1,14 @@
+--TEST--
+MongoDB\BSON\UTCDateTimeInterface is implemented by MongoDB\BSON\UTCDateTime
+--FILE--
+<?php
+
+$date = new MongoDB\BSON\UTCDateTime('1416445411987');
+var_dump($date instanceof MongoDB\BSON\UTCDateTimeInterface);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+bool(true)
+===DONE===

--- a/tests/bson/bson-utcdatetimeinterface-002.phpt
+++ b/tests/bson/bson-utcdatetimeinterface-002.phpt
@@ -1,0 +1,105 @@
+--TEST--
+MongoDB\BSON\UTCDateTimeInterface example with MongoDB\BSON\TypeWrapper
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/tools.php';
+
+class MyUTCDateTime implements MongoDB\BSON\TypeWrapper, MongoDB\BSON\UTCDateTimeInterface
+{
+    private $date;
+
+    public function __construct($milliseconds)
+    {
+        $this->date = new MongoDB\BSON\UTCDateTime($milliseconds);
+    }
+
+    public static function createFromBSONType(MongoDB\BSON\Type $type)
+    {
+        if ( ! $type instanceof MongoDB\BSON\UTCDateTime) {
+            throw new InvalidArgumentException('Cannot create MyUTCDateTime from ' . get_class($type));
+        }
+
+        return new self((string) $type);
+    }
+
+    public function toBSONType()
+    {
+        return $this->date;
+    }
+
+    public function toDateTime()
+    {
+        return $this->date->toDateTime();
+    }
+
+    public function __toString()
+    {
+        return (string) $this->date;
+    }
+}
+
+$date = new MongoDB\BSON\UTCDateTime('1416445411987');
+$myDate = new MyUTCDateTime('1416445411987');
+
+echo "\nTesting MyUTCDateTime and UTCDateTime are equivalent\n";
+// Do not use "===" since each scope is a different DateTime instance
+var_dump($date->toDateTime() == $myDate->toDateTime());
+var_dump((string) $date === (string) $myDate);
+
+echo "\nTesting MyUTCDateTime and UTCDateTime produce the same BSON\n";
+var_dump(fromPHP(['x' => $date]) === fromPHP(['x' => $myDate]));
+
+echo "\nTesting UTCDateTime to BSON to MyUTCDateTime\n";
+var_dump(toPHP(fromPHP(['x' => $date]), ['types' => ['UTCDateTime' => 'MyUTCDateTime']])->x);
+
+echo "\nTesting MyUTCDateTime to BSON to MyUTCDateTime\n";
+var_dump(toPHP(fromPHP(['x' => $myDate]), ['types' => ['UTCDateTime' => 'MyUTCDateTime']])->x);
+
+echo "\nTesting MyUTCDateTime to BSON to UTCDateTime\n";
+var_dump(toPHP(fromPHP(['x' => $myDate]))->x);
+
+echo "\nTesting MyUTCDateTime::createFromBSONType() expects UTCDateTime\n";
+echo throws(function() {
+    toPHP(fromPHP(['x' => new MongoDB\BSON\MinKey]), ['types' => ['MinKey' => 'MyUTCDateTime']]);
+}, 'InvalidArgumentException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+Testing MyUTCDateTime and UTCDateTime are equivalent
+bool(true)
+bool(true)
+
+Testing MyUTCDateTime and UTCDateTime produce the same BSON
+bool(true)
+
+Testing UTCDateTime to BSON to MyUTCDateTime
+object(MyUTCDateTime)#%d (%d) {
+  ["date":"MyUTCDateTime":private]=>
+  object(MongoDB\BSON\UTCDateTime)#%d (%d) {
+    ["milliseconds"]=>
+    string(13) "1416445411987"
+  }
+}
+
+Testing MyUTCDateTime to BSON to MyUTCDateTime
+object(MyUTCDateTime)#%d (%d) {
+  ["date":"MyUTCDateTime":private]=>
+  object(MongoDB\BSON\UTCDateTime)#%d (%d) {
+    ["milliseconds"]=>
+    string(13) "1416445411987"
+  }
+}
+
+Testing MyUTCDateTime to BSON to UTCDateTime
+object(MongoDB\BSON\UTCDateTime)#%d (%d) {
+  ["milliseconds"]=>
+  string(13) "1416445411987"
+}
+
+Testing MyUTCDateTime::createFromBSONType() expects UTCDateTime
+OK: Got InvalidArgumentException
+Cannot create MyUTCDateTime from MongoDB\BSON\MinKey
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-640
https://jira.mongodb.org/browse/PHPC-988

These interfaces are implemented by the corresponding BSON classes and intended to be used by TypeWrapper implementations.

TODO:

 * [x] Tests to ensure that each BSON type class implements the appropriate interface
 * [x] Tests to demonstrate how we expect TypeWrapper implementations to use these interfaces