### PR TITLE
PHPC-846: Throw if maxStalenessSeconds URI option is out of range

### DIFF
--- a/tests/manager/manager-ctor-read_preference-error-002.phpt
+++ b/tests/manager/manager-ctor-read_preference-error-002.phpt
@@ -14,6 +14,10 @@ echo throws(function() {
 }, "MongoDB\Driver\Exception\InvalidArgumentException"), "\n";
 
 echo throws(function() {
+    $manager = new MongoDB\Driver\Manager('mongodb://127.0.0.1/?readPreference=secondary&maxStalenessSeconds=2147483648');
+}, "MongoDB\Driver\Exception\InvalidArgumentException"), "\n";
+
+echo throws(function() {
     $manager = new MongoDB\Driver\Manager(null, ['maxstalenessseconds' => 1231]);
 }, "MongoDB\Driver\Exception\InvalidArgumentException"), "\n";
 
@@ -41,6 +45,8 @@ OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Failed to parse MongoDB URI: 'mongodb://127.0.0.1/?maxstalenessseconds=1231'. Invalid readPreferences.
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Failed to parse MongoDB URI: 'mongodb://127.0.0.1/?maxStalenessSeconds=1231'. Invalid readPreferences.
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Failed to parse MongoDB URI: 'mongodb://127.0.0.1/?readPreference=secondary&maxStalenessSeconds=2147483648'. Unknown option or value for 'maxStalenessSeconds=2147483648'.
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Primary read preference mode conflicts with maxStalenessSeconds
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException

--- a/tests/manager/manager-ctor-read_preference-error-004.phpt
+++ b/tests/manager/manager-ctor-read_preference-error-004.phpt
@@ -1,0 +1,20 @@
+--TEST--
+MongoDB\Driver\Manager::__construct(): invalid read preference (maxStalenessSeconds range)
+--SKIPIF--
+<?php if (8 !== PHP_INT_SIZE) { die('skip Only for 64-bit platform'); } ?>
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/tools.php';
+
+echo throws(function() {
+    $manager = new MongoDB\Driver\Manager(null, ['readPreference' => 'secondary', 'maxStalenessSeconds' => 2147483648]);
+}, "MongoDB\Driver\Exception\InvalidArgumentException"), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected maxStalenessSeconds to be <= 2147483647, 2147483648 given
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-846

Note: Resolution of [CDRIVER-2232](https://jira.mongodb.org/browse/CDRIVER-2232) will decide if 64-bit integers are actually valid for `maxStalenessSeconds` (they appear to already be supported my libmongoc's read preference API, while the URI parsing restricts it to 32-bit values). We currently document the ReadPreference constructor argument as a "signed 32-bit integer".

If 64-bit integers are approved for `maxStalenessSeconds`, I will repurpose this issue to add support in both our URI options array and ReadPreference constructor.