### PR TITLE
PHPC-994: Assume socklen_t is defined on Windows

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -149,11 +149,11 @@ if (PHP_MONGODB != "no") {
     MONGOC_ENABLE_SASL_SSPI: 0,
     MONGOC_HAVE_ASN1_STRING_GET0_DATA: 0,
     MONGOC_HAVE_SASL_CLIENT_DONE: 0,
-    MONGOC_HAVE_SOCKLEN: 0,
+    MONGOC_HAVE_SOCKLEN: 1,
     MONGOC_HAVE_WEAK_SYMBOLS: 0,
     MONGOC_NO_AUTOMATIC_GLOBALS: 1,
     MONGOC_SOCKET_ARG2: "struct sockaddr",
-    MONGOC_SOCKET_ARG3: "int",
+    MONGOC_SOCKET_ARG3: "socklen_t",
     MONGOC_CC: "",
     MONGOC_USER_SET_CFLAGS: "",
     MONGOC_USER_SET_LDFLAGS: ""
@@ -188,10 +188,6 @@ if (PHP_MONGODB != "no") {
     }
   } else {
     WARNING("mongodb libsasl support not enabled, libs not found");
-  }
-
-  if (CHECK_FUNC_IN_HEADER("ws2tcpip.h", "socklen_t")) {
-    mongoc_opts.MONGOC_HAVE_SOCKLEN = 1;
   }
 
   if (typeof COMPILER_NAME === 'string') {


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-994

This fixes macro redefinition warnings for HAVE_SOCKLEN_T, which were caused by CHECK_FUNC_IN_HEADER() injecting a definition. We can safely assume that Windows builds environments for PHP have socklen_t defined (as does libmongoc in its cmake config).

Fixes https://github.com/mongodb/mongo-php-driver/issues/629.