### PR TITLE
PHPC-1001: Report field name for invalid UTF-8 and unsupported zval types

### DIFF
--- a/src/bson-encode.c
+++ b/src/bson-encode.c
@@ -321,7 +321,7 @@ try_again:
 			if (bson_utf8_validate(Z_STRVAL_P(entry), Z_STRLEN_P(entry), true)) {
 				bson_append_utf8(bson, key, key_len, Z_STRVAL_P(entry), Z_STRLEN_P(entry));
 			} else {
-				phongo_throw_exception(PHONGO_ERROR_UNEXPECTED_VALUE TSRMLS_CC, "Got invalid UTF-8 value serializing '%s'", Z_STRVAL_P(entry));
+				phongo_throw_exception(PHONGO_ERROR_UNEXPECTED_VALUE TSRMLS_CC, "Detected invalid UTF-8 for fieldname \"%s\": %s", key, Z_STRVAL_P(entry));
 			}
 			break;
 
@@ -380,7 +380,7 @@ try_again:
 #endif
 
 		default:
-			phongo_throw_exception(PHONGO_ERROR_UNEXPECTED_VALUE TSRMLS_CC, "Got unsupported type %d '%s'", Z_TYPE_P(entry), zend_get_type_by_const(Z_TYPE_P(entry)));
+			phongo_throw_exception(PHONGO_ERROR_UNEXPECTED_VALUE TSRMLS_CC, "Detected unsupported PHP type for fieldname \"%s\": %d (%s)", key, Z_TYPE_P(entry), zend_get_type_by_const(Z_TYPE_P(entry)));
 	}
 } /* }}} */
 

--- a/tests/bulk/bulkwrite-delete_error-002.phpt
+++ b/tests/bulk/bulkwrite-delete_error-002.phpt
@@ -20,8 +20,8 @@ echo throws(function() use ($bulk) {
 <?php exit(0); ?>
 --EXPECTF--
 OK: Got MongoDB\Driver\Exception\UnexpectedValueException
-Got invalid UTF-8 value serializing '%s'
+Detected invalid UTF-8 for fieldname "x": %s
 
 OK: Got MongoDB\Driver\Exception\UnexpectedValueException
-Got invalid UTF-8 value serializing '%s'
+Detected invalid UTF-8 for fieldname "locale": %s
 ===DONE===

--- a/tests/bulk/bulkwrite-insert_error-002.phpt
+++ b/tests/bulk/bulkwrite-insert_error-002.phpt
@@ -16,5 +16,5 @@ echo throws(function() use ($bulk) {
 <?php exit(0); ?>
 --EXPECTF--
 OK: Got MongoDB\Driver\Exception\UnexpectedValueException
-Got invalid UTF-8 value serializing '%s'
+Detected invalid UTF-8 for fieldname "x": %s
 ===DONE===

--- a/tests/bulk/bulkwrite-update_error-004.phpt
+++ b/tests/bulk/bulkwrite-update_error-004.phpt
@@ -28,14 +28,14 @@ echo throws(function() use ($bulk) {
 <?php exit(0); ?>
 --EXPECTF--
 OK: Got MongoDB\Driver\Exception\UnexpectedValueException
-Got invalid UTF-8 value serializing '%s'
+Detected invalid UTF-8 for fieldname "x": %s
 
 OK: Got MongoDB\Driver\Exception\UnexpectedValueException
-Got invalid UTF-8 value serializing '%s'
+Detected invalid UTF-8 for fieldname "x": %s
 
 OK: Got MongoDB\Driver\Exception\UnexpectedValueException
-Got invalid UTF-8 value serializing '%s'
+Detected invalid UTF-8 for fieldname "x": %s
 
 OK: Got MongoDB\Driver\Exception\UnexpectedValueException
-Got invalid UTF-8 value serializing '%s'
+Detected invalid UTF-8 for fieldname "locale": %s
 ===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1001

See: https://github.com/mongodb/mongo-php-driver/issues/635#issuecomment-323367576