### PR TITLE
[backport] PHPC-1005: Use convert_to_object() to create stdClass from array

### DIFF
--- a/src/bson.c
+++ b/src/bson.c
@@ -807,7 +807,7 @@ bool php_phongo_bson_visit_document(const bson_iter_t *iter ARG_UNUSED, const ch
 				case PHONGO_TYPEMAP_NATIVE_OBJECT:
 				default:
 #if PHP_VERSION_ID >= 70000
-					object_and_properties_init(&state.zchild, zend_standard_class_def, Z_ARRVAL(state.zchild));
+					convert_to_object(&state.zchild);
 					if (((php_phongo_bson_state *)data)->is_visiting_array) {
 						add_next_index_zval(retval, &state.zchild);
 					} else {
@@ -815,7 +815,7 @@ bool php_phongo_bson_visit_document(const bson_iter_t *iter ARG_UNUSED, const ch
 					}
 					Z_SET_REFCOUNT(state.zchild, 1);
 #else
-					object_and_properties_init(state.zchild, zend_standard_class_def, Z_ARRVAL_P(state.zchild));
+					convert_to_object(state.zchild);
 					if (((php_phongo_bson_state *)data)->is_visiting_array) {
 						add_next_index_zval(retval, state.zchild);
 					} else {
@@ -898,7 +898,7 @@ bool php_phongo_bson_visit_array(const bson_iter_t *iter ARG_UNUSED, const char 
 
 				case PHONGO_TYPEMAP_NATIVE_OBJECT:
 #if PHP_VERSION_ID >= 70000
-					object_and_properties_init(&state.zchild, zend_standard_class_def, Z_ARRVAL(state.zchild));
+					convert_to_object(&state.zchild);
 					if (((php_phongo_bson_state *)data)->is_visiting_array) {
 						add_next_index_zval(retval, &state.zchild);
 					} else {
@@ -906,7 +906,7 @@ bool php_phongo_bson_visit_array(const bson_iter_t *iter ARG_UNUSED, const char 
 					}
 					Z_SET_REFCOUNT(state.zchild, 1);
 #else
-					object_and_properties_init(state.zchild, zend_standard_class_def, Z_ARRVAL_P(state.zchild));
+					convert_to_object(state.zchild);
 					if (((php_phongo_bson_state *)data)->is_visiting_array) {
 						add_next_index_zval(retval, state.zchild);
 					} else {
@@ -1587,9 +1587,9 @@ int phongo_bson_to_zval_ex(const unsigned char *data, int data_len, php_phongo_b
 		case PHONGO_TYPEMAP_NATIVE_OBJECT:
 		default:
 #if PHP_VERSION_ID >= 70000
-			object_and_properties_init(&state->zchild, zend_standard_class_def, Z_ARRVAL(state->zchild));
+			convert_to_object(&state->zchild);
 #else
-			object_and_properties_init(state->zchild, zend_standard_class_def, Z_ARRVAL_P(state->zchild));
+			convert_to_object(state->zchild);
 #endif
 	}
 

--- a/tests/bson/bson-encode-004.phpt
+++ b/tests/bson/bson-encode-004.phpt
@@ -94,7 +94,7 @@ Test { "0" : { "__pclass" : { "$binary" : "UGVyc29u", "$type" : "80" }, "name" :
    110 : 00 04 66 72 69 65 6e 64 73 00 05 00 00 00 00 00  [..friends.......]
    120 : 00 00 00                                         [...]
 object(stdClass)#%d (1) {
-  [0]=>
+  [%r(0|"0")%r]=>
   object(Person)#%d (5) {
     ["name":protected]=>
     string(6) "Hannes"

--- a/tests/bson/bson-toPHP-004.phpt
+++ b/tests/bson/bson-toPHP-004.phpt
@@ -67,7 +67,7 @@ object(stdClass)#%d (1) {
 object(stdClass)#%d (1) {
   ["x"]=>
   object(stdClass)#%d (1) {
-    [0]=>
+    [%r(0|"0")%r]=>
     NULL
   }
 }
@@ -93,7 +93,7 @@ object(stdClass)#%d (1) {
 object(stdClass)#%d (1) {
   ["x"]=>
   object(stdClass)#%d (1) {
-    [0]=>
+    [%r(0|"0")%r]=>
     bool(true)
   }
 }
@@ -119,7 +119,7 @@ object(stdClass)#%d (1) {
 object(stdClass)#%d (1) {
   ["x"]=>
   object(stdClass)#%d (1) {
-    [0]=>
+    [%r(0|"0")%r]=>
     int(1)
   }
 }
@@ -145,7 +145,7 @@ object(stdClass)#%d (1) {
 object(stdClass)#%d (1) {
   ["x"]=>
   object(stdClass)#%d (1) {
-    [0]=>
+    [%r(0|"0")%r]=>
     float(3.14)
   }
 }
@@ -171,7 +171,7 @@ object(stdClass)#%d (1) {
 object(stdClass)#%d (1) {
   ["x"]=>
   object(stdClass)#%d (1) {
-    [0]=>
+    [%r(0|"0")%r]=>
     string(3) "foo"
   }
 }
@@ -198,7 +198,7 @@ object(stdClass)#%d (1) {
 object(stdClass)#%d (1) {
   ["x"]=>
   object(stdClass)#%d (1) {
-    [0]=>
+    [%r(0|"0")%r]=>
     object(stdClass)#%d (0) {
     }
   }
@@ -230,7 +230,7 @@ object(stdClass)#%d (1) {
 object(stdClass)#%d (1) {
   ["x"]=>
   object(stdClass)#%d (1) {
-    [0]=>
+    [%r(0|"0")%r]=>
     object(stdClass)#%d (0) {
     }
   }
@@ -263,7 +263,7 @@ object(stdClass)#%d (1) {
 object(stdClass)#%d (1) {
   ["x"]=>
   object(stdClass)#%d (1) {
-    [0]=>
+    [%r(0|"0")%r]=>
     object(MongoDB\BSON\Binary)#%d (2) {
       ["data"]=>
       string(3) "foo"
@@ -302,7 +302,7 @@ object(stdClass)#%d (1) {
 object(stdClass)#%d (1) {
   ["x"]=>
   object(stdClass)#%d (1) {
-    [0]=>
+    [%r(0|"0")%r]=>
     object(MongoDB\BSON\Decimal128)#%d (1) {
       ["dec"]=>
       string(4) "3.14"
@@ -339,7 +339,7 @@ object(stdClass)#%d (1) {
 object(stdClass)#%d (1) {
   ["x"]=>
   object(stdClass)#%d (1) {
-    [0]=>
+    [%r(0|"0")%r]=>
     object(MongoDB\BSON\Javascript)#%d (2) {
       ["code"]=>
       string(12) "function(){}"
@@ -376,7 +376,7 @@ object(stdClass)#%d (1) {
 object(stdClass)#%d (1) {
   ["x"]=>
   object(stdClass)#%d (1) {
-    [0]=>
+    [%r(0|"0")%r]=>
     object(MongoDB\BSON\MaxKey)#%d (0) {
     }
   }
@@ -405,7 +405,7 @@ object(stdClass)#%d (1) {
 object(stdClass)#%d (1) {
   ["x"]=>
   object(stdClass)#%d (1) {
-    [0]=>
+    [%r(0|"0")%r]=>
     object(MongoDB\BSON\MinKey)#%d (0) {
     }
   }
@@ -436,7 +436,7 @@ object(stdClass)#%d (1) {
 object(stdClass)#%d (1) {
   ["x"]=>
   object(stdClass)#%d (1) {
-    [0]=>
+    [%r(0|"0")%r]=>
     object(MongoDB\BSON\ObjectID)#%d (1) {
       ["oid"]=>
       string(24) "586c18d86118fd6c9012dec1"
@@ -473,7 +473,7 @@ object(stdClass)#%d (1) {
 object(stdClass)#%d (1) {
   ["x"]=>
   object(stdClass)#%d (1) {
-    [0]=>
+    [%r(0|"0")%r]=>
     object(MongoDB\BSON\Regex)#%d (2) {
       ["pattern"]=>
       string(3) "foo"
@@ -514,7 +514,7 @@ object(stdClass)#%d (1) {
 object(stdClass)#%d (1) {
   ["x"]=>
   object(stdClass)#%d (1) {
-    [0]=>
+    [%r(0|"0")%r]=>
     object(MongoDB\BSON\Timestamp)#%d (2) {
       ["increment"]=>
       string(4) "1234"
@@ -553,7 +553,7 @@ object(stdClass)#%d (1) {
 object(stdClass)#%d (1) {
   ["x"]=>
   object(stdClass)#%d (1) {
-    [0]=>
+    [%r(0|"0")%r]=>
     object(MongoDB\BSON\UTCDateTime)#%d (1) {
       ["milliseconds"]=>
       string(13) "1483479256924"

--- a/tests/functional/query-sort-004.phpt
+++ b/tests/functional/query-sort-004.phpt
@@ -48,7 +48,7 @@ object(MongoDB\Driver\Query)#%d (%d) {
   object(stdClass)#%d (%d) {
     ["sort"]=>
     object(stdClass)#%d (%d) {
-      [0]=>
+      [%r(0|"0")%r]=>
       int(1)
     }
   }


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1005

This will ensure that the array symtable is properly converted to an object proptable in PHP 7.2 (e.g. integer key 0 converts to string key "0").

This is a backport of #642 to the v1.2 branch.