### PR TITLE
Test against PHP 7.2 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
 php:
+  - 7.2
   - 7.1
   - 7.0
   - 5.6


### PR DESCRIPTION
Cherry-picked from https://github.com/mongodb/mongo-php-driver/pull/652

We can also use this PR as an indicator for when https://github.com/mongodb/mongo-php-driver/issues/649 might be resolved after Travis CI upgrades to PHP 7.2 RC1.