### PR TITLE
PHPC-996: Bump min PHP requirement in package.xml to 5.5

### DIFF
--- a/bin/package.xml.in
+++ b/bin/package.xml.in
@@ -46,7 +46,7 @@ necessary to build a fully-functional MongoDB driver.
  <dependencies>
   <required>
    <php>
-    <min>5.4.0</min>
+    <min>5.5.0</min>
     <max>7.99.99</max>
    </php>
    <pearinstaller>


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-996

Noticed that the 1.3.0beta2 still allowed PHP 5.4 in `package.xml`.