### PR TITLE
Fix coveralls urllib dependency for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
     - secure: "pfGVPucvgcgcefhtzAVeejlpOtn4TnAqJSTM8mJkBl36KdU9P7hMuD3czQ4drWgzZ373/VT5UVhLu/HNsdbW0YBTeqPKJ4YNjqVVLytI8xT7y2Lw9l+I7o93j98TMgAoo8nVRmp/E4D6yutbKK1eddrcmf899R1iJbw8v8d1Ht8="
 
 before_install:
-  - sudo pip install cpp-coveralls
+  - sudo pip install --upgrade cpp-coveralls
   - sudo pip install ${MONGODB_ORCHESTRATION_REPO}
   - sudo apt-get update
   - sudo apt-get install gdb valgrind


### PR DESCRIPTION
Fix coveralls error
```
coveralls --exclude src/libbson --exclude src/libmongoc --exclude src/contrib --exclude lib --exclude tests
Traceback (most recent call last):
  File "/usr/local/bin/coveralls", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 3049, in <module>
    @_call_aside
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 3033, in _call_aside
    f(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 3062, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 658, in _build_master
    ws.require(__requires__)
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 972, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 866, in resolve
    new_requirements = dist.requires(req.extras)[::-1]
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2590, in requires
    "%s has no such extra feature %r" % (self, ext)
pkg_resources.UnknownExtra: urllib3 1.7.1 has no such extra feature 'secure'
make: *** [coveralls] Error 1
```

As already described at https://github.com/micropython/micropython/pull/3306#issuecomment-328342837, we should try to upgrade coveralls by specifying "--upgrade" to `pip install` and force pip to get the latest version of urllib3 as well.