### PR TITLE
[WAIT] PHPC-1017: Add pecl option prompt for `--with-openssl-dir`

### DIFF
--- a/bin/package.xml.in
+++ b/bin/package.xml.in
@@ -55,5 +55,7 @@ necessary to build a fully-functional MongoDB driver.
   </required>
  </dependencies>
  <providesextension>mongodb</providesextension>
- <extsrcrelease/>
+ <extsrcrelease>
+  <configureoption name="with-openssl-dir" default="no" prompt="openssl directory"/>
+ </extsrcrelease>
 </package>


### PR DESCRIPTION
This option is necessary for building on systems that may have outdated system openssl packages (macOS).