### PR TITLE
PHPC-1046: Use authSource URI option to specify $external

### DIFF
--- a/tests/connect/standalone-plain-0001.phpt
+++ b/tests/connect/standalone-plain-0001.phpt
@@ -33,7 +33,7 @@ $username = "bugs";
 $password = "password";
 $database = '$external';
 
-$dsn = sprintf("mongodb://%s:%s@%s:%d/%s?authMechanism=PLAIN", $username, $password, $parsed["host"], $parsed["port"], $database);
+$dsn = sprintf("mongodb://%s:%s@%s:%d/?authSource=%s&authMechanism=PLAIN", $username, $password, $parsed["host"], $parsed["port"], $database);
 $manager = new MongoDB\Driver\Manager($dsn);
 
 $bulk = new MongoDB\Driver\BulkWrite();

--- a/tests/connect/standalone-plain-0002.phpt
+++ b/tests/connect/standalone-plain-0002.phpt
@@ -33,7 +33,7 @@ $username = "bugs";
 $password = "wrong-password";
 $database = '$external';
 
-$dsn = sprintf("mongodb://%s:%s@%s:%d/%s?authMechanism=PLAIN", $username, $password, $parsed["host"], $parsed["port"], $database);
+$dsn = sprintf("mongodb://%s:%s@%s:%d/?authSource=%s&authMechanism=PLAIN", $username, $password, $parsed["host"], $parsed["port"], $database);
 $manager = new MongoDB\Driver\Manager($dsn);
 
 $bulk = new MongoDB\Driver\BulkWrite();


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1046

@derickr: This is the same change I had you add in https://github.com/mongodb/mongo-php-driver/pull/672. I noticed this was failing since PHPC 1.3.0 when we bumped to libmongoc 1.8.0. The relevant change was [CDRIVER-2190](https://jira.mongodb.org/browse/CDRIVER-2190) from libmongoc 1.7.0 (which we never bundled with directly).

I'd like to fix it in 1.3.x as I noticed the failure after bumping the 1.8.2 in https://github.com/mongodb/mongo-php-driver/pull/674.