### PR TITLE
PHPC-980: Sessions API

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -190,6 +190,7 @@ if test "$MONGODB" != "no"; then
     src/MongoDB/ReadConcern.c \
     src/MongoDB/ReadPreference.c \
     src/MongoDB/Server.c \
+    src/MongoDB/Session.c \
     src/MongoDB/WriteConcern.c \
     src/MongoDB/WriteConcernError.c \
     src/MongoDB/WriteError.c \

--- a/config.w32
+++ b/config.w32
@@ -85,7 +85,7 @@ if (PHP_MONGODB != "no") {
   EXTENSION("mongodb", "php_phongo.c phongo_compat.c", null, PHP_MONGODB_CFLAGS);
   ADD_SOURCES(configure_module_dirname + "/src", "bson.c bson-encode.c", "mongodb");
   ADD_SOURCES(configure_module_dirname + "/src/BSON", "Binary.c BinaryInterface.c DBPointer.c Decimal128.c Decimal128Interface.c Javascript.c JavascriptInterface.c MaxKey.c MaxKeyInterface.c MinKey.c MinKeyInterface.c ObjectId.c ObjectIdInterface.c Persistable.c Regex.c RegexInterface.c Serializable.c Symbol.c Timestamp.c TimestampInterface.c Type.c Undefined.c Unserializable.c UTCDateTime.c UTCDateTimeInterface.c functions.c", "mongodb");
-  ADD_SOURCES(configure_module_dirname + "/src/MongoDB", "BulkWrite.c Command.c Cursor.c CursorId.c Manager.c Query.c ReadConcern.c ReadPreference.c Server.c WriteConcern.c WriteConcernError.c WriteError.c WriteResult.c", "mongodb");
+  ADD_SOURCES(configure_module_dirname + "/src/MongoDB", "BulkWrite.c Command.c Cursor.c CursorId.c Manager.c Query.c ReadConcern.c ReadPreference.c Server.c Session.c WriteConcern.c WriteConcernError.c WriteError.c WriteResult.c", "mongodb");
   ADD_SOURCES(configure_module_dirname + "/src/MongoDB/Exception", "AuthenticationException.c BulkWriteException.c ConnectionException.c ConnectionTimeoutException.c Exception.c ExecutionTimeoutException.c InvalidArgumentException.c LogicException.c RuntimeException.c SSLConnectionException.c UnexpectedValueException.c WriteException.c", "mongodb");
   ADD_SOURCES(configure_module_dirname + "/src/MongoDB/Monitoring", "CommandFailedEvent.c CommandStartedEvent.c CommandSubscriber.c CommandSucceededEvent.c Subscriber.c functions.c", "mongodb");
   ADD_SOURCES(configure_module_dirname + "/src/libbson/src/bson", PHP_MONGODB_BSON_SOURCES, "mongodb");

--- a/php_phongo.h
+++ b/php_phongo.h
@@ -126,6 +126,7 @@ typedef enum {
 zend_object_handlers *phongo_get_std_object_handlers(void);
 
 void                     phongo_server_init          (zval *return_value, mongoc_client_t *client, int server_id TSRMLS_DC);
+void                     phongo_session_init         (zval *return_value, mongoc_client_session_t *client_session TSRMLS_DC);
 void                     phongo_readconcern_init     (zval *return_value, const mongoc_read_concern_t *read_concern TSRMLS_DC);
 void                     phongo_readpreference_init  (zval *return_value, const mongoc_read_prefs_t *read_prefs TSRMLS_DC);
 void                     phongo_writeconcern_init    (zval *return_value, const mongoc_write_concern_t *write_concern TSRMLS_DC);

--- a/php_phongo_classes.h
+++ b/php_phongo_classes.h
@@ -52,6 +52,9 @@ static inline php_phongo_readpreference_t* php_readpreference_fetch_object(zend_
 static inline php_phongo_server_t* php_server_fetch_object(zend_object *obj) {
     return (php_phongo_server_t *)((char *)obj - XtOffsetOf(php_phongo_server_t, std));
 }
+static inline php_phongo_session_t* php_session_fetch_object(zend_object *obj) {
+    return (php_phongo_session_t *)((char *)obj - XtOffsetOf(php_phongo_session_t, std));
+}
 static inline php_phongo_writeconcern_t* php_writeconcern_fetch_object(zend_object *obj) {
     return (php_phongo_writeconcern_t *)((char *)obj - XtOffsetOf(php_phongo_writeconcern_t, std));
 }
@@ -118,6 +121,7 @@ static inline php_phongo_commandsucceededevent_t* php_commandsucceededevent_fetc
 # define Z_READCONCERN_OBJ_P(zv)       (php_readconcern_fetch_object(Z_OBJ_P(zv)))
 # define Z_READPREFERENCE_OBJ_P(zv)    (php_readpreference_fetch_object(Z_OBJ_P(zv)))
 # define Z_SERVER_OBJ_P(zv)            (php_server_fetch_object(Z_OBJ_P(zv)))
+# define Z_SESSION_OBJ_P(zv)           (php_session_fetch_object(Z_OBJ_P(zv)))
 # define Z_BULKWRITE_OBJ_P(zv)         (php_bulkwrite_fetch_object(Z_OBJ_P(zv)))
 # define Z_WRITECONCERN_OBJ_P(zv)      (php_writeconcern_fetch_object(Z_OBJ_P(zv)))
 # define Z_WRITECONCERNERROR_OBJ_P(zv) (php_writeconcernerror_fetch_object(Z_OBJ_P(zv)))
@@ -147,6 +151,7 @@ static inline php_phongo_commandsucceededevent_t* php_commandsucceededevent_fetc
 # define Z_OBJ_READCONCERN(zo)         (php_readconcern_fetch_object(zo))
 # define Z_OBJ_READPREFERENCE(zo)      (php_readpreference_fetch_object(zo))
 # define Z_OBJ_SERVER(zo)              (php_server_fetch_object(zo))
+# define Z_OBJ_SESSION(zo)             (php_session_fetch_object(zo))
 # define Z_OBJ_BULKWRITE(zo)           (php_bulkwrite_fetch_object(zo))
 # define Z_OBJ_WRITECONCERN(zo)        (php_writeconcern_fetch_object(zo))
 # define Z_OBJ_WRITECONCERNERROR(zo)   (php_writeconcernerror_fetch_object(zo))
@@ -178,6 +183,7 @@ static inline php_phongo_commandsucceededevent_t* php_commandsucceededevent_fetc
 # define Z_READCONCERN_OBJ_P(zv)       ((php_phongo_readconcern_t *)zend_object_store_get_object(zv TSRMLS_CC))
 # define Z_READPREFERENCE_OBJ_P(zv)    ((php_phongo_readpreference_t *)zend_object_store_get_object(zv TSRMLS_CC))
 # define Z_SERVER_OBJ_P(zv)            ((php_phongo_server_t *)zend_object_store_get_object(zv TSRMLS_CC))
+# define Z_SESSION_OBJ_P(zv)           ((php_phongo_session_t *)zend_object_store_get_object(zv TSRMLS_CC))
 # define Z_BULKWRITE_OBJ_P(zv)         ((php_phongo_bulkwrite_t *)zend_object_store_get_object(zv TSRMLS_CC))
 # define Z_WRITECONCERN_OBJ_P(zv)      ((php_phongo_writeconcern_t *)zend_object_store_get_object(zv TSRMLS_CC))
 # define Z_WRITECONCERNERROR_OBJ_P(zv) ((php_phongo_writeconcernerror_t *)zend_object_store_get_object(zv TSRMLS_CC))
@@ -207,6 +213,7 @@ static inline php_phongo_commandsucceededevent_t* php_commandsucceededevent_fetc
 # define Z_OBJ_READCONCERN(zo)         ((php_phongo_readconcern_t *)zo)
 # define Z_OBJ_READPREFERENCE(zo)      ((php_phongo_readpreference_t *)zo)
 # define Z_OBJ_SERVER(zo)              ((php_phongo_server_t *)zo)
+# define Z_OBJ_SESSION(zo)             ((php_phongo_session_t *)zo)
 # define Z_OBJ_BULKWRITE(zo)           ((php_phongo_bulkwrite_t *)zo)
 # define Z_OBJ_WRITECONCERN(zo)        ((php_phongo_writeconcern_t *)zo)
 # define Z_OBJ_WRITECONCERNERROR(zo)   ((php_phongo_writeconcernerror_t *)zo)
@@ -244,6 +251,7 @@ extern zend_class_entry *php_phongo_query_ce;
 extern zend_class_entry *php_phongo_readconcern_ce;
 extern zend_class_entry *php_phongo_readpreference_ce;
 extern zend_class_entry *php_phongo_server_ce;
+extern zend_class_entry *php_phongo_session_ce;
 extern zend_class_entry *php_phongo_bulkwrite_ce;
 extern zend_class_entry *php_phongo_writeconcern_ce;
 extern zend_class_entry *php_phongo_writeconcernerror_ce;
@@ -332,6 +340,7 @@ extern void php_phongo_query_init_ce(INIT_FUNC_ARGS);
 extern void php_phongo_readconcern_init_ce(INIT_FUNC_ARGS);
 extern void php_phongo_readpreference_init_ce(INIT_FUNC_ARGS);
 extern void php_phongo_server_init_ce(INIT_FUNC_ARGS);
+extern void php_phongo_session_init_ce(INIT_FUNC_ARGS);
 extern void php_phongo_writeconcern_init_ce(INIT_FUNC_ARGS);
 extern void php_phongo_writeconcernerror_init_ce(INIT_FUNC_ARGS);
 extern void php_phongo_writeerror_init_ce(INIT_FUNC_ARGS);

--- a/php_phongo_structs.h
+++ b/php_phongo_structs.h
@@ -108,6 +108,12 @@ typedef struct {
 
 typedef struct {
 	PHONGO_ZEND_OBJECT_PRE
+	mongoc_client_session_t *client_session;
+	PHONGO_ZEND_OBJECT_POST
+} php_phongo_session_t;
+
+typedef struct {
+	PHONGO_ZEND_OBJECT_PRE
 	mongoc_write_concern_t *write_concern;
 	PHONGO_ZEND_OBJECT_POST
 } php_phongo_writeconcern_t;

--- a/src/MongoDB/Session.c
+++ b/src/MongoDB/Session.c
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2014-2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include <php.h>
+#include <Zend/zend_interfaces.h>
+
+#include "phongo_compat.h"
+#include "php_phongo.h"
+#include "php_bson.h"
+
+zend_class_entry *php_phongo_session_ce;
+
+/* {{{ proto void MongoDB\Driver\Session::advanceClusterTime(array|object $clusterTime)
+   Advances the cluster time for this Session */
+static PHP_METHOD(Session, advanceClusterTime)
+{
+	php_phongo_session_t *intern;
+	zval                 *zcluster_time;
+	bson_t                cluster_time = BSON_INITIALIZER;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
+
+
+	intern = Z_SESSION_OBJ_P(getThis());
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "A", &zcluster_time) == FAILURE) {
+		return;
+	}
+
+	php_phongo_zval_to_bson(zcluster_time, PHONGO_BSON_NONE, &cluster_time, NULL TSRMLS_CC);
+
+	/* An exception may be thrown during BSON conversion */
+	if (EG(exception)) {
+		goto cleanup;
+	}
+
+	mongoc_client_session_advance_cluster_time(intern->client_session, &cluster_time);
+
+cleanup:
+	bson_destroy(&cluster_time);
+} /* }}} */
+
+/* {{{ proto object|null MongoDB\Driver\Session::getClusterTime()
+   Returns the cluster time for this Session */
+static PHP_METHOD(Session, getClusterTime)
+{
+	php_phongo_session_t  *intern;
+	const bson_t          *cluster_time;
+	php_phongo_bson_state  state = PHONGO_BSON_STATE_INITIALIZER;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
+
+
+	intern = Z_SESSION_OBJ_P(getThis());
+
+	if (zend_parse_parameters_none() == FAILURE) {
+		return;
+	}
+
+	cluster_time = mongoc_client_session_get_cluster_time(intern->client_session);
+
+	if (!cluster_time) {
+		RETURN_NULL();
+	}
+
+	if (!php_phongo_bson_to_zval_ex(bson_get_data(cluster_time), cluster_time->len, &state)) {
+		/* Exception should already have been thrown */
+		zval_ptr_dtor(&state.zchild);
+		return;
+	}
+
+#if PHP_VERSION_ID >= 70000
+	RETURN_ZVAL(&state.zchild, 0, 1);
+#else
+	RETURN_ZVAL(state.zchild, 0, 1);
+#endif
+} /* }}} */
+
+/* {{{ proto object MongoDB\Driver\Session::getLogicalSessionId()
+   Returns the logical session ID for this Session */
+static PHP_METHOD(Session, getLogicalSessionId)
+{
+	php_phongo_session_t  *intern;
+	const bson_t          *lsid;
+	php_phongo_bson_state  state = PHONGO_BSON_STATE_INITIALIZER;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
+
+
+	intern = Z_SESSION_OBJ_P(getThis());
+
+	if (zend_parse_parameters_none() == FAILURE) {
+		return;
+	}
+
+	lsid = mongoc_client_session_get_lsid(intern->client_session);
+
+
+	if (!php_phongo_bson_to_zval_ex(bson_get_data(lsid), lsid->len, &state)) {
+		/* Exception should already have been thrown */
+		zval_ptr_dtor(&state.zchild);
+		return;
+	}
+
+#if PHP_VERSION_ID >= 70000
+	RETURN_ZVAL(&state.zchild, 0, 1);
+#else
+	RETURN_ZVAL(state.zchild, 0, 1);
+#endif
+} /* }}} */
+
+/* {{{ MongoDB\Driver\Session function entries */
+ZEND_BEGIN_ARG_INFO_EX(ai_Session_advanceClusterTime, 0, 0, 1)
+	ZEND_ARG_INFO(0, clusterTime)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(ai_Session_void, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+static zend_function_entry php_phongo_session_me[] = {
+	PHP_ME(Session, advanceClusterTime, ai_Session_advanceClusterTime, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+	PHP_ME(Session, getClusterTime, ai_Session_void, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+	PHP_ME(Session, getLogicalSessionId, ai_Session_void, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+	ZEND_NAMED_ME(__construct, PHP_FN(MongoDB_disabled___construct), ai_Session_void, ZEND_ACC_PRIVATE|ZEND_ACC_FINAL)
+	ZEND_NAMED_ME(__wakeup, PHP_FN(MongoDB_disabled___wakeup), ai_Session_void, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+	PHP_FE_END
+};
+/* }}} */
+
+/* {{{ MongoDB\Driver\Session object handlers */
+static zend_object_handlers php_phongo_handler_session;
+
+static void php_phongo_session_free_object(phongo_free_object_arg *object TSRMLS_DC) /* {{{ */
+{
+	php_phongo_session_t *intern = Z_OBJ_SESSION(object);
+
+	zend_object_std_dtor(&intern->std TSRMLS_CC);
+
+	if (intern->client_session) {
+		mongoc_client_session_destroy(intern->client_session);
+	}
+
+#if PHP_VERSION_ID < 70000
+	efree(intern);
+#endif
+} /* }}} */
+
+static phongo_create_object_retval php_phongo_session_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
+{
+	php_phongo_session_t *intern = NULL;
+
+	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_session_t, class_type);
+
+	zend_object_std_init(&intern->std, class_type TSRMLS_CC);
+	object_properties_init(&intern->std, class_type);
+
+#if PHP_VERSION_ID >= 70000
+	intern->std.handlers = &php_phongo_handler_session;
+
+	return &intern->std;
+#else
+	{
+		zend_object_value retval;
+		retval.handle = zend_objects_store_put(intern, (zend_objects_store_dtor_t) zend_objects_destroy_object, php_phongo_session_free_object, NULL TSRMLS_CC);
+		retval.handlers = &php_phongo_handler_session;
+
+		return retval;
+	}
+#endif
+} /* }}} */
+
+static HashTable *php_phongo_session_get_debug_info(zval *object, int *is_temp TSRMLS_DC) /* {{{ */
+{
+	php_phongo_session_t       *intern = NULL;
+	const mongoc_session_opt_t *cs_opts;
+#if PHP_VERSION_ID >= 70000
+	zval                        retval;
+#else
+	zval                        retval = zval_used_for_init;
+#endif
+
+	*is_temp = 1;
+	intern = Z_SESSION_OBJ_P(object);
+
+	array_init(&retval);
+
+	{
+		const bson_t *lsid;
+
+		php_phongo_bson_state state = PHONGO_BSON_STATE_INITIALIZER;
+		/* Use native arrays for debugging output */
+		state.map.root_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
+		state.map.document_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
+
+		lsid = mongoc_client_session_get_lsid(intern->client_session);
+
+		php_phongo_bson_to_zval_ex(bson_get_data(lsid), lsid->len, &state);
+
+#if PHP_VERSION_ID >= 70000
+		ADD_ASSOC_ZVAL_EX(&retval, "logicalSessionId", &state.zchild);
+#else
+		ADD_ASSOC_ZVAL_EX(&retval, "logicalSessionId", state.zchild);
+#endif
+	}
+
+	{
+		const bson_t *cluster_time;
+
+		php_phongo_bson_state state = PHONGO_BSON_STATE_INITIALIZER;
+		/* Use native arrays for debugging output */
+		state.map.root_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
+		state.map.document_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
+
+		cluster_time = mongoc_client_session_get_cluster_time(intern->client_session);
+
+		if (cluster_time) {
+			php_phongo_bson_to_zval_ex(bson_get_data(cluster_time), cluster_time->len, &state);
+
+#if PHP_VERSION_ID >= 70000
+			ADD_ASSOC_ZVAL_EX(&retval, "clusterTime", &state.zchild);
+#else
+			ADD_ASSOC_ZVAL_EX(&retval, "clusterTime", state.zchild);
+#endif
+		} else {
+			ADD_ASSOC_NULL_EX(&retval, "clusterTime");
+		}
+	}
+
+	cs_opts = mongoc_client_session_get_opts(intern->client_session);
+	ADD_ASSOC_BOOL_EX(&retval, "causalConsistency", mongoc_session_opts_get_causal_consistency(cs_opts));
+
+	return Z_ARRVAL(retval);
+} /* }}} */
+/* }}} */
+
+void php_phongo_session_init_ce(INIT_FUNC_ARGS) /* {{{ */
+{
+	zend_class_entry ce;
+
+	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver", "Session", php_phongo_session_me);
+	php_phongo_session_ce = zend_register_internal_class(&ce TSRMLS_CC);
+	php_phongo_session_ce->create_object = php_phongo_session_create_object;
+	PHONGO_CE_FINAL(php_phongo_session_ce);
+	PHONGO_CE_DISABLE_SERIALIZATION(php_phongo_session_ce);
+
+	memcpy(&php_phongo_handler_session, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
+	php_phongo_handler_session.get_debug_info = php_phongo_session_get_debug_info;
+#if PHP_VERSION_ID >= 70000
+	php_phongo_handler_session.free_obj = php_phongo_session_free_object;
+	php_phongo_handler_session.offset = XtOffsetOf(php_phongo_session_t, std);
+#endif
+} /* }}} */
+
+/*
+ * Local variables:
+ * tab-width: 4
+ * c-basic-offset: 4
+ * End:
+ * vim600: noet sw=4 ts=4 fdm=marker
+ * vim<600: noet sw=4 ts=4
+ */

--- a/tests/session/session-001.phpt
+++ b/tests/session/session-001.phpt
@@ -1,0 +1,28 @@
+--TEST--
+MongoDB\Driver\Session spec test: Pool is LIFO
+--SKIPIF--
+<?php if (getenv("TRAVIS")) exit("skip This currently fails on Travis because it doesn't run 3.6 yet"); ?>
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('STANDALONE'); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(STANDALONE);
+
+$firstSession = $manager->startSession();
+$firstSessionId = $firstSession->getLogicalSessionId();
+
+unset($firstSession);
+
+$secondSession = $manager->startSession();
+$secondSessionId = $secondSession->getLogicalSessionId();
+
+var_dump($firstSessionId == $secondSessionId);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+bool(true)
+===DONE===

--- a/tests/session/session-002.phpt
+++ b/tests/session/session-002.phpt
@@ -1,0 +1,170 @@
+--TEST--
+MongoDB\Driver\Session spec test: $clusterTime in commands
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('REPLICASET'); CLEANUP(REPLICASET); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+class Test implements MongoDB\Driver\Monitoring\CommandSubscriber
+{
+    private $lastSeenClusterTime;
+
+    public function aggregate()
+    {
+        $this->lastSeenClusterTime = null;
+
+        MongoDB\Driver\Monitoring\addSubscriber($this);
+
+        $manager = new MongoDB\Driver\Manager(REPLICASET);
+        $session = $manager->startSession();
+
+        $command = new MongoDB\Driver\Command([
+            'aggregate' => COLLECTION_NAME,
+            'pipeline' => [],
+            'cursor' => new stdClass(),
+        ]);
+        $manager->executeReadWriteCommand(DATABASE_NAME, $command, ['session' => $session]);
+        $manager->executeReadWriteCommand(DATABASE_NAME, $command, ['session' => $session]);
+
+        printf("Session reports last seen \$clusterTime: %s\n", ($session->getClusterTime() == $this->lastSeenClusterTime) ? 'yes' : 'no');
+
+        MongoDB\Driver\Monitoring\removeSubscriber($this);
+    }
+
+    public function find()
+    {
+        $this->lastSeenClusterTime = null;
+
+        MongoDB\Driver\Monitoring\addSubscriber($this);
+
+        $manager = new MongoDB\Driver\Manager(REPLICASET);
+        $session = $manager->startSession();
+
+        $query = new MongoDB\Driver\Query([]);
+        $manager->executeQuery(NS, $query, ['session' => $session]);
+        $manager->executeQuery(NS, $query, ['session' => $session]);
+
+        printf("Session reports last seen \$clusterTime: %s\n", ($session->getClusterTime() == $this->lastSeenClusterTime) ? 'yes' : 'no');
+
+        MongoDB\Driver\Monitoring\removeSubscriber($this);
+    }
+
+    public function insert()
+    {
+        $this->lastSeenClusterTime = null;
+
+        MongoDB\Driver\Monitoring\addSubscriber($this);
+
+        $manager = new MongoDB\Driver\Manager(REPLICASET);
+        $session = $manager->startSession();
+
+        $bulk = new MongoDB\Driver\BulkWrite();
+        $bulk->insert(['x' => 1]);
+        $manager->executeBulkWrite(NS, $bulk, ['session' => $session]);
+
+        $bulk = new MongoDB\Driver\BulkWrite();
+        $bulk->insert(['x' => 2]);
+        $manager->executeBulkWrite(NS, $bulk, ['session' => $session]);
+
+        printf("Session reports last seen \$clusterTime: %s\n", ($session->getClusterTime() == $this->lastSeenClusterTime) ? 'yes' : 'no');
+
+        MongoDB\Driver\Monitoring\removeSubscriber($this);
+    }
+
+    public function ping()
+    {
+        $this->lastSeenClusterTime = null;
+
+        MongoDB\Driver\Monitoring\addSubscriber($this);
+
+        $manager = new MongoDB\Driver\Manager(REPLICASET);
+        $session = $manager->startSession();
+
+        $command = new MongoDB\Driver\Command(['ping' => 1]);
+        $manager->executeCommand(DATABASE_NAME, $command, ['session' => $session]);
+        $manager->executeCommand(DATABASE_NAME, $command, ['session' => $session]);
+
+        printf("Session reports last seen \$clusterTime: %s\n", ($session->getClusterTime() == $this->lastSeenClusterTime) ? 'yes' : 'no');
+
+        MongoDB\Driver\Monitoring\removeSubscriber($this);
+    }
+
+    public function commandStarted(MongoDB\Driver\Monitoring\CommandStartedEvent $event)
+    {
+        $command = $event->getCommand();
+        $hasClusterTime = isset($command->{'$clusterTime'});
+
+        printf("%s command includes \$clusterTime: %s\n", $event->getCommandName(), $hasClusterTime ? 'yes' : 'no');
+
+        if ($hasClusterTime && $this->lastSeenClusterTime !== null) {
+            printf("%s command uses last seen \$clusterTime: %s\n", $event->getCommandName(), ($command->{'$clusterTime'} == $this->lastSeenClusterTime) ? 'yes' : 'no');
+        }
+    }
+
+    public function commandSucceeded(MongoDB\Driver\Monitoring\CommandSucceededEvent $event)
+    {
+        $reply = $event->getReply();
+        $hasClusterTime = isset($reply->{'$clusterTime'});
+
+        printf("%s command reply includes \$clusterTime: %s\n", $event->getCommandName(), $hasClusterTime ? 'yes' : 'no');
+
+        if ($hasClusterTime) {
+            $this->lastSeenClusterTime = $reply->{'$clusterTime'};
+        }
+    }
+
+    public function commandFailed(MongoDB\Driver\Monitoring\CommandFailedEvent $event)
+    {
+    }
+}
+
+echo "\nTesting aggregate command\n";
+(new Test)->aggregate();
+
+echo "\nTesting find command\n";
+(new Test)->find();
+
+echo "\nTesting insert command\n";
+(new Test)->insert();
+
+echo "\nTesting ping command\n";
+(new Test)->ping();
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+Testing aggregate command
+aggregate command includes $clusterTime: yes
+aggregate command reply includes $clusterTime: yes
+aggregate command includes $clusterTime: yes
+aggregate command uses last seen $clusterTime: yes
+aggregate command reply includes $clusterTime: yes
+Session reports last seen $clusterTime: yes
+
+Testing find command
+find command includes $clusterTime: yes
+find command reply includes $clusterTime: yes
+find command includes $clusterTime: yes
+find command uses last seen $clusterTime: yes
+find command reply includes $clusterTime: yes
+Session reports last seen $clusterTime: yes
+
+Testing insert command
+insert command includes $clusterTime: yes
+insert command reply includes $clusterTime: yes
+insert command includes $clusterTime: yes
+insert command uses last seen $clusterTime: yes
+insert command reply includes $clusterTime: yes
+Session reports last seen $clusterTime: yes
+
+Testing ping command
+ping command includes $clusterTime: yes
+ping command reply includes $clusterTime: yes
+ping command includes $clusterTime: yes
+ping command uses last seen $clusterTime: yes
+ping command reply includes $clusterTime: yes
+Session reports last seen $clusterTime: yes
+===DONE===

--- a/tests/session/session-003.phpt
+++ b/tests/session/session-003.phpt
@@ -1,0 +1,51 @@
+--TEST--
+MongoDB\Driver\Session spec test: session cannot be used for different clients
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('STANDALONE'); CLEANUP(REPLICASET); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+// Vary heartbeatFrequencyMS to ensure each Manager gets a different client
+$manager = new MongoDB\Driver\Manager(STANDALONE, ['heartbeatFrequencyMS' => 60000]);
+$otherManager = new MongoDB\Driver\Manager(STANDALONE, ['heartbeatFrequencyMS' => 90000]);
+
+// Create a session with the second Manager (associated with different client)
+$session = $otherManager->startSession();
+
+echo "\nTesting executeBulkWrite()\n";
+echo throws(function() use ($manager, $session) {
+    $bulk = new MongoDB\Driver\BulkWrite();
+    $bulk->insert(['x' => 1]);
+    $manager->executeBulkWrite(NS, $bulk, ['session' => $session]);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo "\nTesting executeCommand()\n";
+echo throws(function() use ($manager, $session) {
+    $command = new MongoDB\Driver\Command(['ping' => 1]);
+    $manager->executeCommand(DATABASE_NAME, $command, ['session' => $session]);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo "\nTesting executeQuery()\n";
+echo throws(function() use ($manager, $session) {
+    $query = new MongoDB\Driver\Query([]);
+    $manager->executeQuery(NS, $query, ['session' => $session]);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+Testing executeBulkWrite()
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Cannot use Session started from a different Manager
+
+Testing executeCommand()
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Cannot use Session started from a different Manager
+
+Testing executeQuery()
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Cannot use Session started from a different Manager
+===DONE===

--- a/tests/session/session-advanceClusterTime-001.phpt
+++ b/tests/session/session-advanceClusterTime-001.phpt
@@ -1,0 +1,50 @@
+--TEST--
+MongoDB\Driver\Session::advanceClusterTime()
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('REPLICASET'); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(REPLICASET);
+$sessionA = $manager->startSession();
+$sessionB = $manager->startSession();
+
+$command = new MongoDB\Driver\Command(['ping' => 1]);
+$manager->executeCommand(DATABASE_NAME, $command, ['session' => $sessionA]);
+
+echo "Initial cluster time of session B:\n";
+var_dump($sessionB->getClusterTime());
+
+$sessionB->advanceClusterTime($sessionA->getClusterTime());
+
+echo "\nCluster time after advancing session B:\n";
+var_dump($sessionB->getClusterTime());
+
+echo "\nSessions A and B have equivalent cluster times:\n";
+var_dump($sessionA->getClusterTime() == $sessionB->getClusterTime());
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+Initial cluster time of session B:
+NULL
+
+Cluster time after advancing session B:
+object(stdClass)#%d (%d) {
+  ["clusterTime"]=>
+  object(MongoDB\BSON\Timestamp)#%d (%d) {
+    ["increment"]=>
+    string(%d) "%d"
+    ["timestamp"]=>
+    string(%d) "%d"
+  }
+  ["signature"]=>
+  %a
+}
+
+Sessions A and B have equivalent cluster times:
+bool(true)
+===DONE===

--- a/tests/session/session-debug-001.phpt
+++ b/tests/session/session-debug-001.phpt
@@ -1,0 +1,36 @@
+--TEST--
+MongoDB\Driver\Session debug output (before processing $clusterTime)
+--SKIPIF--
+<?php if (getenv("TRAVIS")) exit("skip This currently fails on Travis because it doesn't run 3.6 yet"); ?>
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('STANDALONE'); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(STANDALONE);
+$session = $manager->startSession();
+
+var_dump($session);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+object(MongoDB\Driver\Session)#%d (%d) {
+  ["logicalSessionId"]=>
+  array(1) {
+    ["id"]=>
+    object(MongoDB\BSON\Binary)#%d (%d) {
+      ["data"]=>
+      string(16) "%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c"
+      ["type"]=>
+      int(4)
+    }
+  }
+  ["clusterTime"]=>
+  NULL
+  ["causalConsistency"]=>
+  bool(true)
+}
+===DONE===

--- a/tests/session/session-debug-002.phpt
+++ b/tests/session/session-debug-002.phpt
@@ -1,0 +1,48 @@
+--TEST--
+MongoDB\Driver\Session debug output (after processing $clusterTime)
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('REPLICASET'); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(REPLICASET);
+$session = $manager->startSession();
+
+$command = new MongoDB\Driver\Command(['ping' => 1]);
+$manager->executeCommand(DATABASE_NAME, $command, ['session' => $session]);
+
+var_dump($session);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+object(MongoDB\Driver\Session)#%d (%d) {
+  ["logicalSessionId"]=>
+  array(1) {
+    ["id"]=>
+    object(MongoDB\BSON\Binary)#%d (%d) {
+      ["data"]=>
+      string(16) "%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c"
+      ["type"]=>
+      int(4)
+    }
+  }
+  ["clusterTime"]=>
+  array(2) {
+    ["clusterTime"]=>
+    object(MongoDB\BSON\Timestamp)#%d (%d) {
+      ["increment"]=>
+      string(%d) "%d"
+      ["timestamp"]=>
+      string(%d) "%d"
+    }
+    ["signature"]=>
+    %a
+  }
+  ["causalConsistency"]=>
+  bool(true)
+}
+===DONE===

--- a/tests/session/session-debug-003.phpt
+++ b/tests/session/session-debug-003.phpt
@@ -1,0 +1,36 @@
+--TEST--
+MongoDB\Driver\Session debug output (causalConsistency=false)
+--SKIPIF--
+<?php if (getenv("TRAVIS")) exit("skip This currently fails on Travis because it doesn't run 3.6 yet"); ?>
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('STANDALONE'); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(STANDALONE);
+$session = $manager->startSession(['causalConsistency' => false]);
+
+var_dump($session);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+object(MongoDB\Driver\Session)#%d (%d) {
+  ["logicalSessionId"]=>
+  array(1) {
+    ["id"]=>
+    object(MongoDB\BSON\Binary)#%d (%d) {
+      ["data"]=>
+      string(16) "%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c"
+      ["type"]=>
+      int(4)
+    }
+  }
+  ["clusterTime"]=>
+  NULL
+  ["causalConsistency"]=>
+  bool(false)
+}
+===DONE===

--- a/tests/session/session-getClusterTime-001.phpt
+++ b/tests/session/session-getClusterTime-001.phpt
@@ -1,0 +1,41 @@
+--TEST--
+MongoDB\Driver\Session::getClusterTime()
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('REPLICASET'); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(REPLICASET);
+$session = $manager->startSession();
+
+echo "Initial cluster time:\n";
+var_dump($session->getClusterTime());
+
+$command = new MongoDB\Driver\Command(['ping' => 1]);
+$manager->executeCommand(DATABASE_NAME, $command, ['session' => $session]);
+
+echo "\nCluster time after command:\n";
+var_dump($session->getClusterTime());
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+Initial cluster time:
+NULL
+
+Cluster time after command:
+object(stdClass)#%d (%d) {
+  ["clusterTime"]=>
+  object(MongoDB\BSON\Timestamp)#%d (%d) {
+    ["increment"]=>
+    string(%d) "%d"
+    ["timestamp"]=>
+    string(%d) "%d"
+  }
+  ["signature"]=>
+  %a
+}
+===DONE===

--- a/tests/session/session-getLogicalSessionId-001.phpt
+++ b/tests/session/session-getLogicalSessionId-001.phpt
@@ -1,0 +1,29 @@
+--TEST--
+MongoDB\Driver\Session::getLogicalSessionId()
+--SKIPIF--
+<?php if (getenv("TRAVIS")) exit("skip This currently fails on Travis because it doesn't run 3.6 yet"); ?>
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('STANDALONE'); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(STANDALONE);
+$session = $manager->startSession();
+
+var_dump($session->getLogicalSessionId());
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+object(stdClass)#%d (%d) {
+  ["id"]=>
+  object(MongoDB\BSON\Binary)#%d (%d) {
+    ["data"]=>
+    string(16) "%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c"
+    ["type"]=>
+    int(4)
+  }
+}
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-980

I reached a road block supporting options for `phongo_execute_query()` and ended up continuing that work in #707 while refactoring the option parsing for execute methods for [PHPC-1057](https://jira.mongodb.org/browse/PHPC-1057).

This PR is limited just to relevant session commits. All included spec tests should be passing.