### PR TITLE
PHPC-1015: Add test for DNS Initial Seedlist

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -375,7 +375,11 @@ if test "$MONGODB" != "no"; then
 
   m4_include(src/libmongoc/build/autotools/m4/ax_prototype.m4)
   m4_include(src/libmongoc/build/autotools/CheckCompiler.m4)
+
+  dnl We need to convince the libmongoc M4 file to actually run these checks for us
+  enable_srv=auto
   m4_include(src/libmongoc/build/autotools/FindResSearch.m4)
+
   m4_include(src/libmongoc/build/autotools/WeakSymbols.m4)
   m4_include(src/libmongoc/build/autotools/m4/ax_pthread.m4)
   AX_PTHREAD

--- a/scripts/presets/replicaset-dns.json
+++ b/scripts/presets/replicaset-dns.json
@@ -1,0 +1,65 @@
+{
+	"id": "REPLICASET_DNS",
+	"name": "mongod",
+	"members": [
+		{
+			"procParams": {
+				"dbpath": "/tmp/REPLICASET/27017/",
+				"ipv6": true,
+				"logappend": true,
+				"logpath": "/tmp/REPLICASET/27017/mongod.log",
+				"nohttpinterface": true,
+				"journal": true,
+				"noprealloc": true,
+				"nssize": 1,
+				"port": 27017,
+				"smallfiles": true,
+				"setParameter": {"enableTestCommands": 1}
+			},
+			"rsParams": {
+				"priority": 1
+			},
+			"server_id": "DNS-one"
+		},
+		{
+			"procParams": {
+				"dbpath": "/tmp/REPLICASET/27018/",
+				"ipv6": true,
+				"logappend": true,
+				"logpath": "/tmp/REPLICASET/27018/mongod.log",
+				"nohttpinterface": true,
+				"journal": true,
+				"noprealloc": true,
+				"nssize": 1,
+				"port": 27018,
+				"smallfiles": true,
+				"setParameter": {"enableTestCommands": 1}
+			},
+			"rsParams": {
+				"priority": 1
+			},
+			"server_id": "DNS-two"
+		},
+		{
+			"procParams": {
+				"dbpath": "/tmp/REPLICASET/27019/",
+				"ipv6": true,
+				"logappend": true,
+				"logpath": "/tmp/REPLICASET/27019/mongod.log",
+				"nohttpinterface": true,
+				"journal": true,
+				"noprealloc": true,
+				"nssize": 1,
+				"port": 27019,
+				"smallfiles": true,
+				"setParameter": {"enableTestCommands": 1}
+			},
+			"rsParams": {
+				"priority": 1
+
+			},
+			"server_id": "DNS-three"
+		}
+	]
+}
+

--- a/scripts/start-servers.php
+++ b/scripts/start-servers.php
@@ -30,6 +30,7 @@ $PRESETS = [
         "scripts/presets/replicaset.json",
         "scripts/presets/replicaset-30.json",
         "scripts/presets/replicaset-36.json",
+        "scripts/presets/replicaset-dns.json",
     ],
 ];
 

--- a/tests/connect/bug1015.phpt
+++ b/tests/connect/bug1015.phpt
@@ -2,13 +2,22 @@
 PHPC-1015: Initial DNS Seedlist test
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php echo "skip Manual test, as it needs configuration\n"; ?>
 <?php NEEDS('REPLICASET_DNS'); ?>
 --FILE--
 <?php
-
+/**
+ * This test requires additional configuration, and hence is not enabled by
+ * default. In order for this test to succeed, you need the following line in
+ * /etc/hosts:
+ *
+ * 192.168.112.10  localhost.test.build.10gen.cc
+ *
+ * The IP address needs to match the IP address that your vagrant environment
+ * has created. The IP address is shown when you run "make start-servers".
+ */
 require_once __DIR__ . "/../utils/basic.inc";
 
-// STANDALONE does not support auth, but that is not necessary for the test
 $m = new MongoDB\Driver\Manager("mongodb+srv://test1.test.build.10gen.cc/");
 $s = $m->selectServer( new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_NEAREST ) );
 $servers = $m->getServers();

--- a/tests/connect/bug1015.phpt
+++ b/tests/connect/bug1015.phpt
@@ -1,0 +1,27 @@
+--TEST--
+PHPC-1015: Initial DNS Seedlist test
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('REPLICASET_DNS'); ?>
+--FILE--
+<?php
+
+require_once __DIR__ . "/../utils/basic.inc";
+
+// STANDALONE does not support auth, but that is not necessary for the test
+$m = new MongoDB\Driver\Manager("mongodb+srv://test1.test.build.10gen.cc/");
+$s = $m->selectServer( new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_NEAREST ) );
+$servers = $m->getServers();
+
+foreach ( $servers as $server )
+{
+	echo $server->getHost(), ':', $server->getPort(), "\n";
+}
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+%d.%d.%d.%d:27017
+%d.%d.%d.%d:27018
+%d.%d.%d.%d:27019
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1015

We'll need to decide whether we want to always run this. Starting up a whole
replicaset for one test is a waste of resources really. It also requires that we add a line in our /etc/hosts files (with the IP address of the Vagrant host) for this to work.