### PR TITLE
Reload VM and restart MO in make test-bootstrap

### DIFF
--- a/Makefile.frag
+++ b/Makefile.frag
@@ -59,6 +59,9 @@ list-servers:
 	php scripts/list-servers.php
 
 test-bootstrap:
+	vagrant reload mo
+	vagrant ssh mo -c 'sudo rm -f /home/vagrant/server.pid'
+	vagrant ssh mo -c 'sudo mongo-orchestration -f mongo-orchestration-config.json -b 192.168.112.10 --enable-majority-read-concern start'
 	php scripts/start-servers.php
 
 distcheck: package test-virtual


### PR DESCRIPTION
@derickr: This is adopted from my shell script. I removed a line that deletes `/tmp/PHONGO-SERVERS.json` since `start-servers.php` overwrites the file anyway. The functional difference is that if you run tests with a bad `PHONGO-SERVERS.json` you'll likely get failures, while tests would otherwise be skipped if `PHONGO-SERVERS.json` is missing.