### PR TITLE
PHPC-1070 and PHPC-1071: Report class name for unexpected object values

### DIFF
--- a/php_phongo.c
+++ b/php_phongo.c
@@ -469,7 +469,7 @@ static bool process_read_concern(zval *option, bson_t *mongoc_opts TSRMLS_DC)
 		phongo_throw_exception(
 			PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC,
 			"Expected 'readConcern' option to be 'MongoDB\\Driver\\ReadConcern', %s given",
-			zend_get_type_by_const(Z_TYPE_P(option))
+			PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(option)
 		);
 		return false;
 	}
@@ -520,7 +520,7 @@ static bool process_read_preference(zval *option, bson_t *mongoc_opts, zval **zr
 		phongo_throw_exception(
 			PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC,
 			"Expected 'readPreference' option to be 'MongoDB\\Driver\\ReadPreference', %s given",
-			zend_get_type_by_const(Z_TYPE_P(option))
+			PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(option)
 		);
 		return false;
 	}
@@ -543,7 +543,7 @@ static bool process_write_concern(zval *option, bson_t *mongoc_opts, zval **zwri
 		phongo_throw_exception(
 			PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC,
 			"Expected 'writeConcern' option to be 'MongoDB\\Driver\\WriteConcern', %s given",
-			zend_get_type_by_const(Z_TYPE_P(option))
+			PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(option)
 		);
 		return false;
 	}

--- a/php_phongo.h
+++ b/php_phongo.h
@@ -21,6 +21,9 @@
 #include "bson.h"
 #include "mongoc.h"
 
+#include "phongo_compat.h"
+#include "php_phongo_classes.h"
+
 #define phpext_mongodb_ptr &mongodb_module_entry
 extern zend_module_entry mongodb_module_entry;
 
@@ -60,8 +63,6 @@ ZEND_TSRMLS_CACHE_EXTERN()
 #endif
 
 #define PHONGO_WRITE_CONCERN_W_MAJORITY "majority"
-
-#include "php_phongo_classes.h"
 
 /* This enum is necessary since mongoc_server_description_type_t is private and
  * we need to translate strings returned by mongoc_server_description_type() to
@@ -193,6 +194,9 @@ zend_bool phongo_writeconcernerror_init(zval *return_value, bson_t *bson TSRMLS_
         (intern)->properties = (props);                                         \
     }                                                                           \
 } while(0);
+
+#define PHONGO_ZVAL_CLASS_OR_TYPE_NAME(zv) (Z_TYPE(zv) == IS_OBJECT ? ZSTR_VAL(Z_OBJCE(zv)->name) : zend_get_type_by_const(Z_TYPE(zv)))
+#define PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(zvp) PHONGO_ZVAL_CLASS_OR_TYPE_NAME(*(zvp))
 
 #endif /* PHONGO_H */
 

--- a/src/BSON/Timestamp.c
+++ b/src/BSON/Timestamp.c
@@ -147,7 +147,7 @@ static PHP_METHOD(Timestamp, __construct)
 	}
 
 	if (Z_TYPE_P(increment) != IS_STRING) {
-		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Expected increment to be an unsigned 32-bit integer or string, %s given", zend_get_type_by_const(Z_TYPE_P(increment)));
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Expected increment to be an unsigned 32-bit integer or string, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(increment));
 		return;
 	}
 
@@ -156,7 +156,7 @@ static PHP_METHOD(Timestamp, __construct)
 	}
 
 	if (Z_TYPE_P(timestamp) != IS_STRING) {
-		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Expected timestamp to be an unsigned 32-bit integer or string, %s given", zend_get_type_by_const(Z_TYPE_P(timestamp)));
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Expected timestamp to be an unsigned 32-bit integer or string, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(timestamp));
 		return;
 	}
 

--- a/src/BSON/UTCDateTime.c
+++ b/src/BSON/UTCDateTime.c
@@ -190,7 +190,7 @@ static PHP_METHOD(UTCDateTime, __construct)
 	}
 
 	if (Z_TYPE_P(milliseconds) != IS_STRING) {
-		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Expected integer or string, %s given", zend_get_type_by_const(Z_TYPE_P(milliseconds)));
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Expected integer or string, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(milliseconds));
 		return;
 	}
 

--- a/src/MongoDB/Query.c
+++ b/src/MongoDB/Query.c
@@ -35,7 +35,7 @@ static bool php_phongo_query_opts_append_string(bson_t *opts, const char *opts_k
 	zval *value = php_array_fetch(zarr, zarr_key);
 
 	if (Z_TYPE_P(value) != IS_STRING) {
-		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Expected \"%s\" %s to be string, %s given", zarr_key, zarr_key[0] == '$' ? "modifier" : "option", zend_get_type_by_const(Z_TYPE_P(value)));
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Expected \"%s\" %s to be string, %s given", zarr_key, zarr_key[0] == '$' ? "modifier" : "option", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(value));
 		return false;
 	}
 
@@ -55,7 +55,7 @@ static bool php_phongo_query_opts_append_document(bson_t *opts, const char *opts
 	bson_t b = BSON_INITIALIZER;
 
 	if (Z_TYPE_P(value) != IS_OBJECT && Z_TYPE_P(value) != IS_ARRAY) {
-		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Expected \"%s\" %s to be array or object, %s given", zarr_key, zarr_key[0] == '$' ? "modifier" : "option", zend_get_type_by_const(Z_TYPE_P(value)));
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Expected \"%s\" %s to be array or object, %s given", zarr_key, zarr_key[0] == '$' ? "modifier" : "option", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(value));
 		return false;
 	}
 
@@ -195,7 +195,7 @@ static bool php_phongo_query_init_readconcern(php_phongo_query_t *intern, zval *
 		zval *read_concern = php_array_fetchc(options, "readConcern");
 
 		if (Z_TYPE_P(read_concern) != IS_OBJECT || !instanceof_function(Z_OBJCE_P(read_concern), php_phongo_readconcern_ce TSRMLS_CC)) {
-			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Expected \"readConcern\" option to be %s, %s given", ZSTR_VAL(php_phongo_readconcern_ce->name), zend_get_type_by_const(Z_TYPE_P(read_concern)));
+			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Expected \"readConcern\" option to be %s, %s given", ZSTR_VAL(php_phongo_readconcern_ce->name), PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(read_concern));
 			return false;
 		}
 
@@ -262,7 +262,7 @@ static bool php_phongo_query_init(php_phongo_query_t *intern, zval *filter, zval
 		modifiers = php_array_fetchc(options, "modifiers");
 
 		if (Z_TYPE_P(modifiers) != IS_ARRAY) {
-			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Expected \"modifiers\" option to be array, %s given", zend_get_type_by_const(Z_TYPE_P(modifiers)));
+			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Expected \"modifiers\" option to be array, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(modifiers));
 			return false;
 		}
 	}

--- a/src/MongoDB/ReadPreference.c
+++ b/src/MongoDB/ReadPreference.c
@@ -80,7 +80,7 @@ static PHP_METHOD(ReadPreference, __construct)
 			return;
 		}
 	} else {
-		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Expected mode to be integer or string, %s given", zend_get_type_by_const(Z_TYPE_P(mode)));
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Expected mode to be integer or string, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(mode));
 		return;
 	}
 

--- a/src/MongoDB/WriteConcern.c
+++ b/src/MongoDB/WriteConcern.c
@@ -62,7 +62,7 @@ static PHP_METHOD(WriteConcern, __construct)
 			mongoc_write_concern_set_wtag(intern->write_concern, Z_STRVAL_P(w));
 		}
 	} else {
-		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Expected w to be integer or string, %s given", zend_get_type_by_const(Z_TYPE_P(w)));
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Expected w to be integer or string, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(w));
 		return;
 	}
 

--- a/src/bson-encode.c
+++ b/src/bson-encode.c
@@ -143,24 +143,18 @@ static void php_phongo_bson_append_object(bson_t *bson, php_phongo_bson_flags_t 
 			if (Z_TYPE(obj_data) != IS_ARRAY && !(Z_TYPE(obj_data) == IS_OBJECT && instanceof_function(Z_OBJCE(obj_data), zend_standard_class_def TSRMLS_CC))) {
 				phongo_throw_exception(PHONGO_ERROR_UNEXPECTED_VALUE TSRMLS_CC,
 					"Expected %s::%s() to return an array or stdClass, %s given",
-					Z_OBJCE_P(object)->name->val,
+					ZSTR_VAL(Z_OBJCE_P(object)->name),
 					BSON_SERIALIZE_FUNC_NAME,
-					(Z_TYPE(obj_data) == IS_OBJECT
-						 ? Z_OBJCE(obj_data)->name->val
-						 : zend_get_type_by_const(Z_TYPE(obj_data))
-					)
+					PHONGO_ZVAL_CLASS_OR_TYPE_NAME(obj_data)
 				);
 				zval_ptr_dtor(&obj_data);
 #else
 			if (Z_TYPE_P(obj_data) != IS_ARRAY && !(Z_TYPE_P(obj_data) == IS_OBJECT && instanceof_function(Z_OBJCE_P(obj_data), zend_standard_class_def TSRMLS_CC))) {
 				phongo_throw_exception(PHONGO_ERROR_UNEXPECTED_VALUE TSRMLS_CC,
 					"Expected %s::%s() to return an array or stdClass, %s given",
-					Z_OBJCE_P(object)->name,
+					ZSTR_VAL(Z_OBJCE_P(object)->name),
 					BSON_SERIALIZE_FUNC_NAME,
-					(Z_TYPE_P(obj_data) == IS_OBJECT
-						 ? Z_OBJCE_P(obj_data)->name
-						 : zend_get_type_by_const(Z_TYPE_P(obj_data))
-					)
+					PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(obj_data)
 				);
 				zval_ptr_dtor(&obj_data);
 #endif
@@ -453,22 +447,13 @@ void php_phongo_zval_to_bson(zval *data, php_phongo_bson_flags_t flags, bson_t *
 #endif
 					phongo_throw_exception(PHONGO_ERROR_UNEXPECTED_VALUE TSRMLS_CC,
 						"Expected %s::%s() to return an array or stdClass, %s given",
-#if PHP_VERSION_ID >= 70000
-						Z_OBJCE_P(data)->name->val,
-#else
-						Z_OBJCE_P(data)->name,
-#endif
+						ZSTR_VAL(Z_OBJCE_P(data)->name),
 						BSON_SERIALIZE_FUNC_NAME,
 #if PHP_VERSION_ID >= 70000
-						(Z_TYPE(obj_data) == IS_OBJECT
-							 ? Z_OBJCE(obj_data)->name->val
-							 : zend_get_type_by_const(Z_TYPE(obj_data))
+						PHONGO_ZVAL_CLASS_OR_TYPE_NAME(obj_data)
 #else
-						(Z_TYPE_P(obj_data) == IS_OBJECT
-							 ? Z_OBJCE_P(obj_data)->name
-							 : zend_get_type_by_const(Z_TYPE_P(obj_data))
+						PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(obj_data)
 #endif
-						)
 					);
 
 					goto cleanup;

--- a/tests/bson/bson-timestamp_error-006.phpt
+++ b/tests/bson/bson-timestamp_error-006.phpt
@@ -32,7 +32,7 @@ Expected increment to be an unsigned 32-bit integer or string, boolean given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected increment to be an unsigned 32-bit integer or string, array given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected increment to be an unsigned 32-bit integer or string, object given
+Expected increment to be an unsigned 32-bit integer or string, stdClass given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected timestamp to be an unsigned 32-bit integer or string, %r(null|NULL)%r given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
@@ -42,5 +42,5 @@ Expected timestamp to be an unsigned 32-bit integer or string, boolean given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected timestamp to be an unsigned 32-bit integer or string, array given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected timestamp to be an unsigned 32-bit integer or string, object given
+Expected timestamp to be an unsigned 32-bit integer or string, stdClass given
 ===DONE===

--- a/tests/manager/manager-executeCommand_error-002.phpt
+++ b/tests/manager/manager-executeCommand_error-002.phpt
@@ -32,7 +32,7 @@ echo throws(function() use ($manager, $command) {
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected 'readPreference' option to be 'MongoDB\Driver\ReadPreference', string given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected 'readPreference' option to be 'MongoDB\Driver\ReadPreference', object given
+Expected 'readPreference' option to be 'MongoDB\Driver\ReadPreference', stdClass given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Unknown option 'unknown'
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException

--- a/tests/manager/manager-executeQuery_error-002.phpt
+++ b/tests/manager/manager-executeQuery_error-002.phpt
@@ -32,7 +32,7 @@ echo throws(function() use ($manager, $query) {
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected 'readPreference' option to be 'MongoDB\Driver\ReadPreference', string given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected 'readPreference' option to be 'MongoDB\Driver\ReadPreference', object given
+Expected 'readPreference' option to be 'MongoDB\Driver\ReadPreference', stdClass given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Unknown option 'unknown'
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException

--- a/tests/query/query-ctor_error-001.phpt
+++ b/tests/query/query-ctor_error-001.phpt
@@ -37,7 +37,7 @@ Expected "readConcern" option to be MongoDB\Driver\ReadConcern, boolean given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected "readConcern" option to be MongoDB\Driver\ReadConcern, array given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected "readConcern" option to be MongoDB\Driver\ReadConcern, object given
+Expected "readConcern" option to be MongoDB\Driver\ReadConcern, stdClass given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected "readConcern" option to be MongoDB\Driver\ReadConcern, %r(null|NULL)%r given
 ===DONE===

--- a/tests/server/server-executeCommand_error-001.phpt
+++ b/tests/server/server-executeCommand_error-001.phpt
@@ -34,7 +34,7 @@ echo throws(function() use ($manager, $command) {
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected 'readPreference' option to be 'MongoDB\Driver\ReadPreference', string given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected 'readPreference' option to be 'MongoDB\Driver\ReadPreference', object given
+Expected 'readPreference' option to be 'MongoDB\Driver\ReadPreference', stdClass given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Unknown option 'unknown'
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException

--- a/tests/server/server-executeQuery_error-001.phpt
+++ b/tests/server/server-executeQuery_error-001.phpt
@@ -34,7 +34,7 @@ echo throws(function() use ($manager, $query) {
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected 'readPreference' option to be 'MongoDB\Driver\ReadPreference', string given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected 'readPreference' option to be 'MongoDB\Driver\ReadPreference', object given
+Expected 'readPreference' option to be 'MongoDB\Driver\ReadPreference', stdClass given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Unknown option 'unknown'
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException

--- a/tests/writeConcern/writeconcern-ctor_error-002.phpt
+++ b/tests/writeConcern/writeconcern-ctor_error-002.phpt
@@ -31,7 +31,7 @@ Expected w to be integer or string, boolean given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected w to be integer or string, array given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected w to be integer or string, object given
+Expected w to be integer or string, stdClass given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected w to be integer or string, %r(null|NULL)%r given
 ===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1070
https://jira.mongodb.org/browse/PHPC-1071

Adds a macro for accessing zval's class or type name, depending on whether it's an object type. This replaces existing ternary statements we had for some BSON exceptions. I've also gone through and updated exceptions where object types are entirely unexpected. Options that expect a BSON document (i.e. array or object) remain unchanged and do not use this macro, as any object type would be accepted.

IMO, this makes the exceptions more helpful and also makes PHPC more consistent with the invalid type exception messages in PHPLIB.