### PR TITLE
PHPC-1072: mongoc_client_command_with_opts() reply must always be freed

### DIFF
--- a/php_phongo.c
+++ b/php_phongo.c
@@ -854,6 +854,7 @@ int phongo_execute_command(mongoc_client_t *client, php_phongo_command_type_t ty
 	}
 	if (!result) {
 		phongo_throw_exception_from_bson_error_t(&error TSRMLS_CC);
+		bson_destroy(&reply);
 		bson_destroy(&opts);
 		return false;
 	}


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1072

Previously, reply might leak if `phongo_execute_command()` returned due to an error (result=false).