### PR TITLE
PHPC-1057: Refactor option parsing for execute methods

### DIFF
--- a/php_phongo.c
+++ b/php_phongo.c
@@ -294,7 +294,7 @@ static void phongo_cursor_init_for_query(zval *return_value, mongoc_client_t *cl
 #endif
 } /* }}} */
 
-void phongo_server_init(zval *return_value, mongoc_client_t *client, int server_id TSRMLS_DC) /* {{{ */
+void phongo_server_init(zval *return_value, mongoc_client_t *client, uint32_t server_id TSRMLS_DC) /* {{{ */
 {
 	php_phongo_server_t *server;
 
@@ -428,7 +428,7 @@ zend_bool phongo_writeerror_init(zval *return_value, bson_t *bson TSRMLS_DC) /* 
 	return true;
 } /* }}} */
 
-static php_phongo_writeresult_t *phongo_writeresult_init(zval *return_value, bson_t *reply, mongoc_client_t *client, int server_id TSRMLS_DC) /* {{{ */
+static php_phongo_writeresult_t *phongo_writeresult_init(zval *return_value, bson_t *reply, mongoc_client_t *client, uint32_t server_id TSRMLS_DC) /* {{{ */
 {
 	php_phongo_writeresult_t *writeresult;
 
@@ -630,7 +630,7 @@ static bool phongo_parse_write_concern(zval *options, bson_t *mongoc_opts, zval 
 	return true;
 }
 
-bool phongo_execute_bulk_write(mongoc_client_t *client, const char *namespace, php_phongo_bulkwrite_t *bulk_write, zval *options, int server_id, zval *return_value, int return_value_used TSRMLS_DC) /* {{{ */
+bool phongo_execute_bulk_write(mongoc_client_t *client, const char *namespace, php_phongo_bulkwrite_t *bulk_write, zval *options, uint32_t server_id, zval *return_value, int return_value_used TSRMLS_DC) /* {{{ */
 {
 	bson_error_t error;
 	int success;
@@ -739,7 +739,7 @@ static bool phongo_advance_cursor_and_check_for_error(mongoc_cursor_t *cursor TS
 	return true;
 }
 
-int phongo_execute_query(mongoc_client_t *client, const char *namespace, zval *zquery, zval *options, int server_id, zval *return_value, int return_value_used TSRMLS_DC) /* {{{ */
+int phongo_execute_query(mongoc_client_t *client, const char *namespace, zval *zquery, zval *options, uint32_t server_id, zval *return_value, int return_value_used TSRMLS_DC) /* {{{ */
 {
 	const php_phongo_query_t *query;
 	mongoc_cursor_t *cursor;
@@ -814,7 +814,7 @@ static bson_t *create_wrapped_command_envelope(const char *db, bson_t *reply)
 	return tmp;
 }
 
-int phongo_execute_command(mongoc_client_t *client, php_phongo_command_type_t type, const char *db, zval *zcommand, zval *options, int server_id, zval *return_value, int return_value_used TSRMLS_DC) /* {{{ */
+int phongo_execute_command(mongoc_client_t *client, php_phongo_command_type_t type, const char *db, zval *zcommand, zval *options, uint32_t server_id, zval *return_value, int return_value_used TSRMLS_DC) /* {{{ */
 {
 	const php_phongo_command_t *command;
 	bson_iter_t iter;

--- a/php_phongo.c
+++ b/php_phongo.c
@@ -467,80 +467,101 @@ mongoc_bulk_operation_t *phongo_bulkwrite_init(zend_bool ordered) { /* {{{ */
 	return mongoc_bulk_operation_new(ordered);
 } /* }}} */
 
-static bool process_read_concern(zval *option, bson_t *mongoc_opts TSRMLS_DC)
+/* Parses the "readConcern" option for an execute method. If mongoc_opts is not
+ * NULL, the option will be appended. On error, false is returned and an
+ * exception is thrown. */
+static bool phongo_parse_read_concern(zval *options, bson_t *mongoc_opts TSRMLS_DC) /* {{{ */
 {
-	if (Z_TYPE_P(option) == IS_OBJECT && instanceof_function(Z_OBJCE_P(option), php_phongo_readconcern_ce TSRMLS_CC)) {
-		const mongoc_read_concern_t *read_concern = phongo_read_concern_from_zval(option TSRMLS_CC);
+	zval *option = NULL;
+	mongoc_read_concern_t *read_concern;
 
-		if (!mongoc_read_concern_append((mongoc_read_concern_t*)read_concern, mongoc_opts)) {
-			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Error appending \"%s\" option", "readConcern");
-			return false;
-		}
-	} else {
-		phongo_throw_exception(
-			PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC,
-			"Expected 'readConcern' option to be 'MongoDB\\Driver\\ReadConcern', %s given",
-			PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(option)
-		);
+	if (!options) {
+		return true;
+	}
+
+	if (Z_TYPE_P(options) != IS_ARRAY) {
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Expected options to be array, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(options));
 		return false;
 	}
-	return true;
-}
 
-static uint32_t phongo_do_select_server(mongoc_client_t *client, bson_t *opts, zval *zreadPreference, int server_id TSRMLS_DC)
-{
-	bson_error_t error;
-	uint32_t selected_server_id = 0;
+	option = php_array_fetchc(options, "readConcern");
 
-	if (server_id > 0) {
-		bson_append_int32(opts, "serverId", -1, server_id);
-		selected_server_id = server_id;
-	} else {
-		mongoc_server_description_t  *selected_server = NULL;
-
-		selected_server = mongoc_client_select_server(client, false, (zreadPreference ? phongo_read_preference_from_zval(zreadPreference TSRMLS_CC) : mongoc_client_get_read_prefs(client)), &error);
-		if (selected_server) {
-			selected_server_id = mongoc_server_description_id(selected_server);
-			bson_append_int32(opts, "serverId", -1, selected_server_id);
-			mongoc_server_description_destroy(selected_server);
-		} else {
-			/* Check for connection related exceptions */
-			if (!EG(exception)) {
-				phongo_throw_exception_from_bson_error_t(&error TSRMLS_CC);
-			}
-		}
+	if (!option) {
+		return true;
 	}
 
-	return selected_server_id;
-}
-
-static bool process_read_preference(zval *option, bson_t *mongoc_opts, zval **zreadPreference, mongoc_client_t *client, int server_id TSRMLS_DC)
-{
-	if (Z_TYPE_P(option) == IS_OBJECT && instanceof_function(Z_OBJCE_P(option), php_phongo_readpreference_ce TSRMLS_CC)) {
-		int selected_server_id;
-
-		if (zreadPreference) {
-			*zreadPreference = option;
-		}
-
-		selected_server_id = phongo_do_select_server(client, mongoc_opts, *zreadPreference, server_id TSRMLS_CC);
-		if (!selected_server_id) {
-			return false;
-		}
-	} else {
-		phongo_throw_exception(
-			PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC,
-			"Expected 'readPreference' option to be 'MongoDB\\Driver\\ReadPreference', %s given",
-			PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(option)
-		);
+	if (Z_TYPE_P(option) != IS_OBJECT || !instanceof_function(Z_OBJCE_P(option), php_phongo_readconcern_ce TSRMLS_CC)) {
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Expected \"readConcern\" option to be %s, %s given", ZSTR_VAL(php_phongo_readconcern_ce->name), PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(option));
 		return false;
 	}
-	return true;
-}
 
-static bool process_session(zval *option, bson_t *mongoc_opts, zval **zsession, mongoc_client_t *client TSRMLS_DC)
+	read_concern = Z_READCONCERN_OBJ_P(option)->read_concern;
+
+	if (mongoc_opts && !mongoc_read_concern_append(read_concern, mongoc_opts)) {
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Error appending \"readConcern\" option");
+		return false;
+	}
+
+	return true;
+} /* }}} */
+
+/* Parses the "readPreference" option for an execute method. If zreadPreference
+ * is not NULL, it will be assigned to the option. On error, false is returned
+ * and an exception is thrown. */
+bool phongo_parse_read_preference(zval *options, zval **zreadPreference TSRMLS_DC) /* {{{ */
 {
+	zval *option = NULL;
+
+	if (!options) {
+		return true;
+	}
+
+	if (Z_TYPE_P(options) != IS_ARRAY) {
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Expected options to be array, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(options));
+		return false;
+	}
+
+	option = php_array_fetchc(options, "readPreference");
+
+	if (!option) {
+		return true;
+	}
+
+	if (Z_TYPE_P(option) != IS_OBJECT || !instanceof_function(Z_OBJCE_P(option), php_phongo_readpreference_ce TSRMLS_CC)) {
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Expected \"readPreference\" option to be %s, %s given", ZSTR_VAL(php_phongo_readpreference_ce->name), PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(option));
+		return false;
+	}
+
+	if (zreadPreference) {
+		*zreadPreference = option;
+	}
+
+	return true;
+} /* }}} */
+
+/* Parses the "session" option for an execute method. If mongoc_opts is not
+ * NULL, the option will be appended. If zsession is not NULL, it will be
+ * assigned to the option. On error, false is returned and an exception is
+ * thrown. */
+static bool phongo_parse_session(zval *options, bson_t *mongoc_opts, zval **zsession, mongoc_client_t *client TSRMLS_DC) /* {{{ */
+{
+	zval *option = NULL;
 	const mongoc_client_session_t *client_session;
+
+	if (!options) {
+		return true;
+	}
+
+	if (Z_TYPE_P(options) != IS_ARRAY) {
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Expected options to be array, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(options));
+		return false;
+	}
+
+	option = php_array_fetchc(options, "session");
+
+	if (!option) {
+		return true;
+	}
 
 	if (Z_TYPE_P(option) != IS_OBJECT || !instanceof_function(Z_OBJCE_P(option), php_phongo_session_ce TSRMLS_CC)) {
 		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Expected \"session\" option to be %s, %s given", ZSTR_VAL(php_phongo_session_ce->name), PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(option));
@@ -554,7 +575,7 @@ static bool process_session(zval *option, bson_t *mongoc_opts, zval **zsession, 
 		return false;
 	}
 
-	if (!mongoc_client_session_append(Z_SESSION_OBJ_P(option)->client_session, mongoc_opts, NULL)) {
+	if (mongoc_opts && !mongoc_client_session_append(client_session, mongoc_opts, NULL)) {
 		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Error appending \"session\" option");
 		return false;
 	}
@@ -564,106 +585,48 @@ static bool process_session(zval *option, bson_t *mongoc_opts, zval **zsession, 
 	}
 
 	return true;
-}
+} /* }}} */
 
-static bool process_write_concern(zval *option, bson_t *mongoc_opts, zval **zwriteConcern TSRMLS_DC)
+/* Parses the "writeConcern" option for an execute method. If mongoc_opts is not
+ * NULL, the option will be appended. If zwriteConcern is not NULL, it will be
+ * assigned to the option. On error, false is returned and an exception is
+ * thrown. */
+static bool phongo_parse_write_concern(zval *options, bson_t *mongoc_opts, zval **zwriteConcern TSRMLS_DC) /* {{{ */
 {
-	if (Z_TYPE_P(option) == IS_OBJECT && instanceof_function(Z_OBJCE_P(option), php_phongo_writeconcern_ce TSRMLS_CC)) {
-		const mongoc_write_concern_t *write_concern = phongo_write_concern_from_zval(option TSRMLS_CC);
+	zval *option = NULL;
+	mongoc_write_concern_t *write_concern;
 
-		if (zwriteConcern) {
-			*zwriteConcern = option;
-		}
+	if (!options) {
+		return true;
+	}
 
-		if (!mongoc_write_concern_append((mongoc_write_concern_t*) write_concern, mongoc_opts)) {
-			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Error appending \"%s\" option", "writeConcern");
-		}
-	} else {
-		phongo_throw_exception(
-			PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC,
-			"Expected 'writeConcern' option to be 'MongoDB\\Driver\\WriteConcern', %s given",
-			PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(option)
-		);
+	if (Z_TYPE_P(options) != IS_ARRAY) {
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Expected options to be array, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(options));
 		return false;
 	}
-	return true;
-}
 
-static int phongo_execute_parse_options(mongoc_client_t* client, int server_id, zval *driver_options, int type, bson_t *mongoc_opts, zval **zreadPreference, zval **zwriteConcern, zval **zsession TSRMLS_DC)
-{
-	if (driver_options && Z_TYPE_P(driver_options) == IS_ARRAY) {
-		HashTable *ht_data = HASH_OF(driver_options);
-#if PHP_VERSION_ID >= 70000
-		zend_string *string_key = NULL;
-		zend_ulong   num_key = 0;
-		zval        *driver_option;
+	option = php_array_fetchc(options, "writeConcern");
 
-		ZEND_HASH_FOREACH_KEY_VAL(ht_data, num_key, string_key, driver_option) {
-			if (!string_key) {
-				continue;
-			}
-
-			/* URI options are case-insensitive */
-			if ((!strcasecmp(ZSTR_VAL(string_key), "readConcern")) && (type & PHONGO_COMMAND_READ)) {
-				if (!process_read_concern(driver_option, mongoc_opts)) {
-					return false;
-				}
-			} else if ((!strcasecmp(ZSTR_VAL(string_key), "readPreference")) && (type == PHONGO_COMMAND_READ || type == PHONGO_COMMAND_RAW)) {
-				if (!process_read_preference(driver_option, mongoc_opts, zreadPreference, client, server_id)) {
-					return false;
-				}
-			} else if ((!strcmp(ZSTR_VAL(string_key), "session"))) {
-				if (!process_session(driver_option, mongoc_opts, zsession, client)) {
-					return false;
-				}
-			} else if ((!strcasecmp(ZSTR_VAL(string_key), "writeConcern")) && (type & PHONGO_COMMAND_WRITE)) {
-				if (!process_write_concern(driver_option, mongoc_opts, zwriteConcern)) {
-					return false;
-				}
-			} else {
-				phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Unknown option '%s'", ZSTR_VAL(string_key));
-				return false;
-			}
-		} ZEND_HASH_FOREACH_END();
-#else
-		HashPosition   pos;
-		zval         **driver_option;
-
-		for (zend_hash_internal_pointer_reset_ex(ht_data, &pos);
-		     zend_hash_get_current_data_ex(ht_data, (void **) &driver_option, &pos) == SUCCESS;
-		     zend_hash_move_forward_ex(ht_data, &pos)) {
-			char  *string_key = NULL;
-			uint   string_key_len = 0;
-			ulong  num_key = 0;
-
-			if (HASH_KEY_IS_STRING != zend_hash_get_current_key_ex(ht_data, &string_key, &string_key_len, &num_key, 0, &pos)) {
-				continue;
-			}
-
-			/* URI options are case-insensitive */
-			if ((!strcasecmp(string_key, "readConcern")) && (type & PHONGO_COMMAND_READ)) {
-				if (!process_read_concern(*driver_option, mongoc_opts TSRMLS_CC)) {
-					return false;
-				}
-			} else if ((!strcasecmp(string_key, "readPreference")) && (type == PHONGO_COMMAND_READ || type == PHONGO_COMMAND_RAW)) {
-				if (!process_read_preference(*driver_option, mongoc_opts, zreadPreference, client, server_id TSRMLS_CC)) {
-					return false;
-				}
-			} else if ((!strcasecmp(ZSTR_VAL(string_key), "session"))) {
-				if (!process_session(*driver_option, mongoc_opts, zsession, client TSRMLS_CC)) {
-					return false;
-				}
-			} else if ((!strcasecmp(string_key, "writeConcern")) && (type & PHONGO_COMMAND_WRITE)) {
-				if (!process_write_concern(*driver_option, mongoc_opts, zwriteConcern TSRMLS_CC)) {
-					return false;
-				}
-			} else {
-				phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Unknown option '%s'", string_key);
-				return false;
-			}
-		}
-#endif
+	if (!option) {
+		return true;
 	}
+
+	if (Z_TYPE_P(option) != IS_OBJECT || !instanceof_function(Z_OBJCE_P(option), php_phongo_writeconcern_ce TSRMLS_CC)) {
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Expected \"writeConcern\" option to be %s, %s given", ZSTR_VAL(php_phongo_writeconcern_ce->name), PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(option));
+		return false;
+	}
+
+	write_concern = Z_WRITECONCERN_OBJ_P(option)->write_concern;
+
+	if (mongoc_opts && !mongoc_write_concern_append(write_concern, mongoc_opts)) {
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Error appending \"writeConcern\" option");
+		return false;
+	}
+
+	if (zwriteConcern) {
+		*zwriteConcern = option;
+	}
+
 	return true;
 }
 
@@ -676,8 +639,7 @@ bool phongo_execute_bulk_write(mongoc_client_t *client, const char *namespace, p
 	php_phongo_writeresult_t *writeresult;
 	zval *zwriteConcern = NULL;
 	zval *zsession = NULL;
-	const mongoc_write_concern_t *write_concern;
-	bson_t opts = BSON_INITIALIZER;
+	const mongoc_write_concern_t *write_concern = NULL;
 
 	if (bulk_write->executed) {
 		phongo_throw_exception(PHONGO_ERROR_WRITE_FAILED TSRMLS_CC, "BulkWrite objects may only be executed once and this instance has already been executed");
@@ -689,19 +651,20 @@ bool phongo_execute_bulk_write(mongoc_client_t *client, const char *namespace, p
 		return false;
 	}
 
-	/* FIXME: Legacy way of specifying the writeConcern option into this function */
-	if (options && Z_TYPE_P(options) == IS_OBJECT && instanceof_function(Z_OBJCE_P(options), php_phongo_writeconcern_ce TSRMLS_CC)) {
-		zwriteConcern = options;
-	} else if (!phongo_execute_parse_options(client, server_id, options, PHONGO_COMMAND_WRITE, &opts, NULL, &zwriteConcern, &zsession TSRMLS_CC)) {
-		bson_destroy(&opts);
+	if (!phongo_parse_session(options, NULL, &zsession, client TSRMLS_CC)) {
+		/* Exception should already have been thrown */
 		return false;
 	}
 
-	bson_destroy(&opts);
+	if (!phongo_parse_write_concern(options, NULL, &zwriteConcern TSRMLS_CC)) {
+		/* Exception should already have been thrown */
+		return false;
+	}
 
 	mongoc_bulk_operation_set_database(bulk, bulk_write->database);
 	mongoc_bulk_operation_set_collection(bulk, bulk_write->collection);
 	mongoc_bulk_operation_set_client(bulk, client);
+	mongoc_bulk_operation_set_hint(bulk, server_id);
 
 	if (zsession) {
 		mongoc_bulk_operation_set_client_session(bulk, Z_SESSION_OBJ_P(zsession)->client_session);
@@ -714,10 +677,6 @@ bool phongo_execute_bulk_write(mongoc_client_t *client, const char *namespace, p
 		mongoc_bulk_operation_set_write_concern(bulk, write_concern);
 	} else {
 		write_concern = mongoc_client_get_write_concern(client);
-	}
-
-	if (server_id > 0) {
-		mongoc_bulk_operation_set_hint(bulk, server_id);
 	}
 
 	success = mongoc_bulk_operation_execute(bulk, &reply, &error);
@@ -803,21 +762,26 @@ int phongo_execute_query(mongoc_client_t *client, const char *namespace, zval *z
 		mongoc_collection_set_read_concern(collection, query->read_concern);
 	}
 
-	/* FIXME: Legacy way of specifying the readPreference option into this function */
-	if (options && Z_TYPE_P(options) == IS_OBJECT && instanceof_function(Z_OBJCE_P(options), php_phongo_readpreference_ce TSRMLS_CC)) {
-		zreadPreference = options;
-	} else if (!phongo_execute_parse_options(client, server_id, options, PHONGO_COMMAND_READ, query->opts, &zreadPreference, NULL, NULL TSRMLS_CC)) {
+	if (!phongo_parse_read_preference(options, &zreadPreference TSRMLS_CC)) {
+		/* Exception should already have been thrown */
+		mongoc_collection_destroy(collection);
+		return false;
+	}
+
+	if (!phongo_parse_session(options, query->opts, NULL, client TSRMLS_CC)) {
+		/* Exception should already have been thrown */
+		mongoc_collection_destroy(collection);
+		return false;
+	}
+
+	if (!BSON_APPEND_INT32(query->opts, "serverId", server_id)) {
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Error appending \"serverId\" option");
+		mongoc_collection_destroy(collection);
 		return false;
 	}
 
 	cursor = mongoc_collection_find_with_opts(collection, query->filter, query->opts, phongo_read_preference_from_zval(zreadPreference TSRMLS_CC));
 	mongoc_collection_destroy(collection);
-
-	if (server_id > 0 && !mongoc_cursor_set_hint(cursor, server_id)) {
-		phongo_throw_exception(PHONGO_ERROR_MONGOC_FAILED TSRMLS_CC, "%s", "Could not set cursor server_id");
-		mongoc_cursor_destroy(cursor);
-		return false;
-	}
 
 	/* maxAwaitTimeMS must be set before the cursor is sent */
 	if (query->max_await_time_ms) {
@@ -858,21 +822,37 @@ int phongo_execute_command(mongoc_client_t *client, php_phongo_command_type_t ty
 	bson_error_t error;
 	bson_t opts = BSON_INITIALIZER;
 	mongoc_cursor_t *cmd_cursor;
-	uint32_t selected_server_id;
-	zval                     *zreadPreference = NULL;
+	zval *zreadPreference = NULL;
 	int result;
 
 	command = Z_COMMAND_OBJ_P(zcommand);
 
-	/* FIXME: Legacy way of specifying the readPreference option into this function */
-	if (options && Z_TYPE_P(options) == IS_OBJECT && instanceof_function(Z_OBJCE_P(options), php_phongo_readpreference_ce TSRMLS_CC)) {
-		zreadPreference = options;
-	} else if (!phongo_execute_parse_options(client, server_id, options, type, &opts, &zreadPreference, NULL, NULL TSRMLS_CC)) {
+	if ((type & PHONGO_OPTION_READ_CONCERN) && !phongo_parse_read_concern(options, &opts TSRMLS_CC)) {
+		/* Exception should already have been thrown */
+		bson_destroy(&opts);
 		return false;
 	}
 
-	selected_server_id = phongo_do_select_server(client, &opts, zreadPreference, server_id TSRMLS_CC);
-	if (!selected_server_id) {
+	if ((type & PHONGO_OPTION_READ_PREFERENCE) && !phongo_parse_read_preference(options, &zreadPreference TSRMLS_CC)) {
+		/* Exception should already have been thrown */
+		bson_destroy(&opts);
+		return false;
+	}
+
+	if (!phongo_parse_session(options, &opts, NULL, client TSRMLS_CC)) {
+		/* Exception should already have been thrown */
+		bson_destroy(&opts);
+		return false;
+	}
+
+	if ((type & PHONGO_OPTION_WRITE_CONCERN) && !phongo_parse_write_concern(options, &opts, NULL TSRMLS_CC)) {
+		/* Exception should already have been thrown */
+		bson_destroy(&opts);
+		return false;
+	}
+
+	if (!BSON_APPEND_INT32(&opts, "serverId", server_id)) {
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Error appending \"serverId\" option");
 		bson_destroy(&opts);
 		return false;
 	}
@@ -927,12 +907,12 @@ int phongo_execute_command(mongoc_client_t *client, php_phongo_command_type_t ty
 			bson_append_bool(&initial_reply, "tailable", -1, 1);
 		}
 
-		cmd_cursor = mongoc_cursor_new_from_command_reply(client, &initial_reply, selected_server_id);
+		cmd_cursor = mongoc_cursor_new_from_command_reply(client, &initial_reply, server_id);
 		bson_destroy(&reply);
 	} else {
 		bson_t *wrapped_reply = create_wrapped_command_envelope(db, &reply);
 
-		cmd_cursor = mongoc_cursor_new_from_command_reply(client, wrapped_reply, selected_server_id);
+		cmd_cursor = mongoc_cursor_new_from_command_reply(client, wrapped_reply, server_id);
 		bson_destroy(&reply);
 	}
 
@@ -1088,6 +1068,47 @@ void php_phongo_read_concern_to_zval(zval *retval, const mongoc_read_concern_t *
 		ADD_ASSOC_STRING(retval, "level", level);
 	}
 } /* }}} */
+
+/* If options is not an array, insert it as a field in a newly allocated array.
+ * This may be used to convert legacy options (e.g. ReadPreference option for
+ * an executeQuery method) into an options array.
+ *
+ * A pointer to the array zval will always be returned. If allocated is set to
+ * true, php_phongo_prep_legacy_option_free() should be used to free the array
+ * zval later. */
+zval *php_phongo_prep_legacy_option(zval *options, const char *key, bool *allocated TSRMLS_DC) /* {{{ */
+{
+	*allocated = false;
+
+	if (options && Z_TYPE_P(options) != IS_ARRAY) {
+#if PHP_VERSION_ID >= 70000
+		zval *new_options = ecalloc(sizeof(zval), 1);
+#else
+		zval *new_options = NULL;
+		ALLOC_INIT_ZVAL(new_options);
+#endif
+
+		array_init_size(new_options, 1);
+		add_assoc_zval(new_options, key, options);
+		Z_ADDREF_P(options);
+		*allocated = true;
+
+		return new_options;
+	}
+
+	return options;
+} /* }}} */
+
+void php_phongo_prep_legacy_option_free(zval *options TSRMLS_DC) /* {{{ */
+{
+#if PHP_VERSION_ID >= 70000
+	zval_ptr_dtor(options);
+	efree(options);
+#else
+	zval_ptr_dtor(&options);
+#endif
+} /* }}} */
+
 
 /* Prepare tagSets for BSON encoding by converting each array in the set to an
  * object. This ensures that empty arrays will serialize as empty documents.

--- a/php_phongo.h
+++ b/php_phongo.h
@@ -128,15 +128,15 @@ typedef enum {
 
 zend_object_handlers *phongo_get_std_object_handlers(void);
 
-void                     phongo_server_init          (zval *return_value, mongoc_client_t *client, int server_id TSRMLS_DC);
+void                     phongo_server_init          (zval *return_value, mongoc_client_t *client, uint32_t server_id TSRMLS_DC);
 void                     phongo_session_init         (zval *return_value, mongoc_client_session_t *client_session TSRMLS_DC);
 void                     phongo_readconcern_init     (zval *return_value, const mongoc_read_concern_t *read_concern TSRMLS_DC);
 void                     phongo_readpreference_init  (zval *return_value, const mongoc_read_prefs_t *read_prefs TSRMLS_DC);
 void                     phongo_writeconcern_init    (zval *return_value, const mongoc_write_concern_t *write_concern TSRMLS_DC);
 mongoc_bulk_operation_t* phongo_bulkwrite_init       (zend_bool ordered);
-bool                     phongo_execute_bulk_write   (mongoc_client_t *client, const char *namespace, php_phongo_bulkwrite_t *bulk_write, zval *zwriteConcern, int server_id, zval *return_value, int return_value_used TSRMLS_DC);
-int                      phongo_execute_command      (mongoc_client_t *client, php_phongo_command_type_t type, const char *db, zval *zcommand, zval *zreadPreference, int server_id, zval *return_value, int return_value_used TSRMLS_DC);
-int                      phongo_execute_query        (mongoc_client_t *client, const char *namespace, zval *zquery, zval *zreadPreference, int server_id, zval *return_value, int return_value_used TSRMLS_DC);
+bool                     phongo_execute_bulk_write   (mongoc_client_t *client, const char *namespace, php_phongo_bulkwrite_t *bulk_write, zval *zwriteConcern, uint32_t server_id, zval *return_value, int return_value_used TSRMLS_DC);
+int                      phongo_execute_command      (mongoc_client_t *client, php_phongo_command_type_t type, const char *db, zval *zcommand, zval *zreadPreference, uint32_t server_id, zval *return_value, int return_value_used TSRMLS_DC);
+int                      phongo_execute_query        (mongoc_client_t *client, const char *namespace, zval *zquery, zval *zreadPreference, uint32_t server_id, zval *return_value, int return_value_used TSRMLS_DC);
 
 const mongoc_read_concern_t*  phongo_read_concern_from_zval   (zval *zread_concern TSRMLS_DC);
 const mongoc_read_prefs_t*    phongo_read_preference_from_zval(zval *zread_preference TSRMLS_DC);

--- a/php_phongo.h
+++ b/php_phongo.h
@@ -112,15 +112,18 @@ void phongo_throw_exception(php_phongo_error_domain_t domain TSRMLS_DC, const ch
 ;
 void phongo_throw_exception_from_bson_error_t(bson_error_t *error TSRMLS_DC);
 
-/* This enum is used for libmongoc function selection for the
- * phongo_execute_command types. The values are important, as the READ and
- * WRITE fields are also used as a bit field to see whether ReadPreference,
- * ReadConcern, and WriteConcern are supported for each type. */
+/* This enum is used for processing options in phongo_execute_parse_options and
+ * selecting a libmongoc function to use in phongo_execute_command. The values
+ * are important, as READ and WRITE are also used as a bit field to determine
+ * whether readPreference, readConcern, and writeConcern options are parsed. */
 typedef enum {
-	PHONGO_COMMAND_RAW =        0x13,
-	PHONGO_COMMAND_READ =       0x01,
-	PHONGO_COMMAND_WRITE =      0x02,
-	PHONGO_COMMAND_READ_WRITE = 0x03
+	PHONGO_OPTION_READ_CONCERN    = 0x01,
+	PHONGO_OPTION_READ_PREFERENCE = 0x02,
+	PHONGO_OPTION_WRITE_CONCERN   = 0x04,
+	PHONGO_COMMAND_RAW            = 0x07,
+	PHONGO_COMMAND_READ           = 0x03,
+	PHONGO_COMMAND_WRITE          = 0x04,
+	PHONGO_COMMAND_READ_WRITE     = 0x05,
 } php_phongo_command_type_t;
 
 zend_object_handlers *phongo_get_std_object_handlers(void);
@@ -140,6 +143,11 @@ const mongoc_read_prefs_t*    phongo_read_preference_from_zval(zval *zread_prefe
 const mongoc_write_concern_t* phongo_write_concern_from_zval  (zval *zwrite_concern TSRMLS_DC);
 
 php_phongo_server_description_type_t php_phongo_server_description_type(mongoc_server_description_t *sd);
+
+bool phongo_parse_read_preference(zval *options, zval **zreadPreference TSRMLS_DC);
+
+zval* php_phongo_prep_legacy_option(zval *options, const char *key, bool *allocated TSRMLS_DC);
+void php_phongo_prep_legacy_option_free(zval *options TSRMLS_DC);
 
 void php_phongo_read_preference_prep_tagsets(zval *tagSets TSRMLS_DC);
 bool php_phongo_read_preference_tags_are_valid(const bson_t *tags);

--- a/php_phongo_structs.h
+++ b/php_phongo_structs.h
@@ -54,7 +54,7 @@ typedef struct {
 	PHONGO_ZEND_OBJECT_PRE
 	mongoc_cursor_t       *cursor;
 	mongoc_client_t       *client;
-	int                    server_id;
+	uint32_t               server_id;
 	php_phongo_bson_state  visitor_data;
 	int                    got_iterator;
 	long                   current;
@@ -102,7 +102,7 @@ typedef struct {
 typedef struct {
 	PHONGO_ZEND_OBJECT_PRE
 	mongoc_client_t    *client;
-	int                 server_id;
+	uint32_t            server_id;
 	PHONGO_ZEND_OBJECT_POST
 } php_phongo_server_t;
 
@@ -140,7 +140,7 @@ typedef struct {
 	mongoc_write_concern_t *write_concern;
 	bson_t                 *reply;
 	mongoc_client_t        *client;
-	int                     server_id;
+	uint32_t                server_id;
 	PHONGO_ZEND_OBJECT_POST
 } php_phongo_writeresult_t;
 

--- a/src/MongoDB/Server.c
+++ b/src/MongoDB/Server.c
@@ -36,6 +36,7 @@ static PHP_METHOD(Server, executeCommand)
 	phongo_zpp_char_len       db_len;
 	zval                     *command;
 	zval                     *options = NULL;
+	bool                      free_options = false;
 	DECLARE_RETURN_VALUE_USED
 	SUPPRESS_UNUSED_WARNING(return_value_ptr)
 
@@ -46,7 +47,13 @@ static PHP_METHOD(Server, executeCommand)
 		return;
 	}
 
+	options = php_phongo_prep_legacy_option(options, "readPreference", &free_options TSRMLS_CC);
+
 	phongo_execute_command(intern->client, PHONGO_COMMAND_RAW, db, command, options, intern->server_id, return_value, return_value_used TSRMLS_CC);
+
+	if (free_options) {
+		php_phongo_prep_legacy_option_free(options TSRMLS_CC);
+	}
 } /* }}} */
 
 /* {{{ proto MongoDB\Driver\Cursor MongoDB\Driver\Server::executeReadCommand(string $db, MongoDB\Driver\Command $command[, array $options = null]))
@@ -124,6 +131,7 @@ static PHP_METHOD(Server, executeQuery)
 	phongo_zpp_char_len       namespace_len;
 	zval                     *query;
 	zval                     *options = NULL;
+	bool                      free_options = false;
 	DECLARE_RETURN_VALUE_USED
 	SUPPRESS_UNUSED_WARNING(return_value_ptr)
 
@@ -134,7 +142,13 @@ static PHP_METHOD(Server, executeQuery)
 		return;
 	}
 
+	options = php_phongo_prep_legacy_option(options, "readPreference", &free_options TSRMLS_CC);
+
 	phongo_execute_query(intern->client, namespace, query, options, intern->server_id, return_value, return_value_used TSRMLS_CC);
+
+	if (free_options) {
+		php_phongo_prep_legacy_option_free(options TSRMLS_CC);
+	}
 } /* }}} */
 
 /* {{{ proto MongoDB\Driver\WriteResult MongoDB\Driver\Server::executeBulkWrite(string $namespace, MongoDB\Driver\BulkWrite $zbulk[, array $options = null])
@@ -146,8 +160,9 @@ static PHP_METHOD(Server, executeBulkWrite)
 	char                     *namespace;
 	phongo_zpp_char_len       namespace_len;
 	zval                     *zbulk;
-	zval                     *options = NULL;
 	php_phongo_bulkwrite_t   *bulk;
+	zval                     *options = NULL;
+	bool                      free_options = false;
 	DECLARE_RETURN_VALUE_USED
 	SUPPRESS_UNUSED_WARNING(return_value_ptr)
 
@@ -161,7 +176,13 @@ static PHP_METHOD(Server, executeBulkWrite)
 
 	bulk = Z_BULKWRITE_OBJ_P(zbulk);
 
+	options = php_phongo_prep_legacy_option(options, "writeConcern", &free_options TSRMLS_CC);
+
 	phongo_execute_bulk_write(intern->client, namespace, bulk, options, intern->server_id, return_value, return_value_used TSRMLS_CC);
+
+	if (free_options) {
+		php_phongo_prep_legacy_option_free(options TSRMLS_CC);
+	}
 } /* }}} */
 
 /* {{{ proto string MongoDB\Driver\Server::getHost()

--- a/tests/manager/manager-executeBulkWrite_error-009.phpt
+++ b/tests/manager/manager-executeBulkWrite_error-009.phpt
@@ -1,5 +1,5 @@
 --TEST--
-MongoDB\Driver\Manager::executeBulkWrite() with wrong options and values
+MongoDB\Driver\Manager::executeBulkWrite() with invalid options
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php NEEDS('REPLICASET'); ?>
@@ -8,41 +8,41 @@ MongoDB\Driver\Manager::executeBulkWrite() with wrong options and values
 require_once __DIR__ . "/../utils/basic.inc";
 
 $manager = new MongoDB\Driver\Manager(REPLICASET);
-    
+
 echo throws(function() use ($manager) {
     $bulk = new MongoDB\Driver\BulkWrite();
-    $bulk->insert(['wc' => 1]);
+    $bulk->insert(['x' => 1]);
+    $manager->executeBulkWrite(NS, $bulk, ['session' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($manager) {
+    $bulk = new MongoDB\Driver\BulkWrite();
+    $bulk->insert(['x' => 1]);
+    $manager->executeBulkWrite(NS, $bulk, ['session' =>  new stdClass]);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($manager) {
+    $bulk = new MongoDB\Driver\BulkWrite();
+    $bulk->insert(['x' => 1]);
     $manager->executeBulkWrite(NS, $bulk, ['writeConcern' => 'foo']);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
 echo throws(function() use ($manager) {
     $bulk = new MongoDB\Driver\BulkWrite();
-    $bulk->insert(['wc' => 1]);
-    $manager->executeBulkWrite(NS, $bulk, ['writeConcern' => 42]);
-}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
-
-echo throws(function() use ($manager) {
-    $bulk = new MongoDB\Driver\BulkWrite();
-    $bulk->insert(['wc' => 1]);
-    $manager->executeBulkWrite(NS, $bulk, ['unknown' => 'foo']);
-}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
-
-echo throws(function() use ($manager) {
-    $bulk = new MongoDB\Driver\BulkWrite();
-    $bulk->insert(['wc' => 1]);
-    $manager->executeBulkWrite(NS, $bulk, ['readPreference' => 'foo']);
+    $bulk->insert(['x' => 1]);
+    $manager->executeBulkWrite(NS, $bulk, ['writeConcern' => new stdClass]);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECTF--
+--EXPECT--
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected 'writeConcern' option to be 'MongoDB\Driver\WriteConcern', string given
+Expected "session" option to be MongoDB\Driver\Session, string given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected 'writeConcern' option to be 'MongoDB\Driver\WriteConcern', integer given
+Expected "session" option to be MongoDB\Driver\Session, stdClass given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Unknown option 'unknown'
+Expected "writeConcern" option to be MongoDB\Driver\WriteConcern, string given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Unknown option 'readPreference'
+Expected "writeConcern" option to be MongoDB\Driver\WriteConcern, stdClass given
 ===DONE===

--- a/tests/manager/manager-executeBulkWrite_error-010.phpt
+++ b/tests/manager/manager-executeBulkWrite_error-010.phpt
@@ -1,0 +1,42 @@
+--TEST--
+MongoDB\Driver\Manager::executeBulkWrite() with unknown options
+--XFAIL--
+Depends on PHPC-1066
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('REPLICASET'); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(REPLICASET);
+
+echo throws(function() use ($manager) {
+    $bulk = new MongoDB\Driver\BulkWrite();
+    $bulk->insert(['x' => 1]);
+    $manager->executeBulkWrite(NS, $bulk, ['readConcern' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($manager) {
+    $bulk = new MongoDB\Driver\BulkWrite();
+    $bulk->insert(['x' => 1]);
+    $manager->executeBulkWrite(NS, $bulk, ['readPreference' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($manager) {
+    $bulk = new MongoDB\Driver\BulkWrite();
+    $bulk->insert(['x' => 1]);
+    $manager->executeBulkWrite(NS, $bulk, ['unknown' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Unknown option 'readConcern'
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Unknown option 'readPreference'
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Unknown option 'unknown'
+===DONE===

--- a/tests/manager/manager-executeCommand_error-002.phpt
+++ b/tests/manager/manager-executeCommand_error-002.phpt
@@ -1,5 +1,5 @@
 --TEST--
-MongoDB\Driver\Manager::executeCommand(): wrong options and values (MONGOC_CMD_RAW)
+MongoDB\Driver\Manager::executeCommand() with invalid options (MONGOC_CMD_RAW)
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php NEEDS('REPLICASET'); CLEANUP(REPLICASET); ?>
@@ -12,29 +12,55 @@ $manager = new MongoDB\Driver\Manager(REPLICASET);
 $command = new MongoDB\Driver\Command(['ping' => 1]);
 
 echo throws(function() use ($manager, $command) {
+    $manager->executeCommand(DATABASE_NAME, $command, ['readConcern' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($manager, $command) {
+    $manager->executeCommand(DATABASE_NAME, $command, ['readConcern' => new stdClass]);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($manager, $command) {
     $manager->executeCommand(DATABASE_NAME, $command, ['readPreference' => 'foo']);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
 echo throws(function() use ($manager, $command) {
     $manager->executeCommand(DATABASE_NAME, $command, ['readPreference' => new stdClass]);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
 echo throws(function() use ($manager, $command) {
-    $manager->executeCommand(DATABASE_NAME, $command, ['unknown' => 'foo']);
+    $manager->executeCommand(DATABASE_NAME, $command, ['session' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($manager, $command) {
+    $manager->executeCommand(DATABASE_NAME, $command, ['session' => new stdClass]);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
 echo throws(function() use ($manager, $command) {
     $manager->executeCommand(DATABASE_NAME, $command, ['writeConcern' => 'foo']);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($manager, $command) {
+    $manager->executeCommand(DATABASE_NAME, $command, ['writeConcern' => new stdClass]);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECTF--
+--EXPECT--
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected 'readPreference' option to be 'MongoDB\Driver\ReadPreference', string given
+Expected "readConcern" option to be MongoDB\Driver\ReadConcern, string given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected 'readPreference' option to be 'MongoDB\Driver\ReadPreference', stdClass given
+Expected "readConcern" option to be MongoDB\Driver\ReadConcern, stdClass given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Unknown option 'unknown'
+Expected "readPreference" option to be MongoDB\Driver\ReadPreference, string given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected 'writeConcern' option to be 'MongoDB\Driver\WriteConcern', string given
+Expected "readPreference" option to be MongoDB\Driver\ReadPreference, stdClass given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "session" option to be MongoDB\Driver\Session, string given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "session" option to be MongoDB\Driver\Session, stdClass given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "writeConcern" option to be MongoDB\Driver\WriteConcern, string given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "writeConcern" option to be MongoDB\Driver\WriteConcern, stdClass given
 ===DONE===

--- a/tests/manager/manager-executeCommand_error-003.phpt
+++ b/tests/manager/manager-executeCommand_error-003.phpt
@@ -1,0 +1,26 @@
+--TEST--
+MongoDB\Driver\Manager::executeCommand() with unknown options (MONGOC_CMD_RAW)
+--XFAIL--
+Depends on PHPC-1066
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('REPLICASET'); CLEANUP(REPLICASET); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(REPLICASET);
+
+$command = new MongoDB\Driver\Command(['ping' => 1]);
+
+echo throws(function() use ($manager, $command) {
+    $manager->executeCommand(DATABASE_NAME, $command, ['unknown' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Unknown option 'unknown'
+===DONE===

--- a/tests/manager/manager-executeQuery-001.phpt
+++ b/tests/manager/manager-executeQuery-001.phpt
@@ -54,6 +54,8 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
         ["y"]=>
         int(1)
       }
+      ["serverId"]=>
+      int(%d)
     }
     ["readConcern"]=>
     NULL

--- a/tests/manager/manager-executeQuery-002.phpt
+++ b/tests/manager/manager-executeQuery-002.phpt
@@ -54,6 +54,8 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
         ["y"]=>
         int(1)
       }
+      ["serverId"]=>
+      int(%d)
     }
     ["readConcern"]=>
     NULL

--- a/tests/manager/manager-executeQuery_error-002.phpt
+++ b/tests/manager/manager-executeQuery_error-002.phpt
@@ -1,5 +1,5 @@
 --TEST--
-MongoDB\Driver\Manager::executeQuery(): wrong options and values
+MongoDB\Driver\Manager::executeQuery() with invalid options
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php NEEDS('REPLICASET'); CLEANUP(REPLICASET); ?>
@@ -14,27 +14,29 @@ $query = new MongoDB\Driver\Query(['x' => 3], ['projection' => ['y' => 1]]);
 echo throws(function() use ($manager, $query) {
     $manager->executeQuery(NS, $query, ['readPreference' => 'foo']);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
 echo throws(function() use ($manager, $query) {
     $manager->executeQuery(NS, $query, ['readPreference' => new stdClass]);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
 echo throws(function() use ($manager, $query) {
-    $manager->executeQuery(NS, $query, ['unknown' => 'foo']);
+    $manager->executeQuery(NS, $query, ['session' => 'foo']);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
 echo throws(function() use ($manager, $query) {
-    $manager->executeQuery(NS, $query, ['writeConcern' => 'foo']);
+    $manager->executeQuery(NS, $query, ['session' => new stdClass]);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECTF--
+--EXPECT--
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected 'readPreference' option to be 'MongoDB\Driver\ReadPreference', string given
+Expected "readPreference" option to be MongoDB\Driver\ReadPreference, string given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected 'readPreference' option to be 'MongoDB\Driver\ReadPreference', stdClass given
+Expected "readPreference" option to be MongoDB\Driver\ReadPreference, stdClass given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Unknown option 'unknown'
+Expected "session" option to be MongoDB\Driver\Session, string given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Unknown option 'writeConcern'
+Expected "session" option to be MongoDB\Driver\Session, stdClass given
 ===DONE===

--- a/tests/manager/manager-executeQuery_error-003.phpt
+++ b/tests/manager/manager-executeQuery_error-003.phpt
@@ -1,0 +1,38 @@
+--TEST--
+MongoDB\Driver\Manager::executeQuery() with unknown options
+--XFAIL--
+Depends on PHPC-1066
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('REPLICASET'); CLEANUP(REPLICASET); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(REPLICASET);
+
+$query = new MongoDB\Driver\Query(['x' => 3], ['projection' => ['y' => 1]]);
+
+echo throws(function() use ($manager, $query) {
+    $manager->executeQuery(NS, $query, ['readConcern' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($manager, $query) {
+    $manager->executeQuery(NS, $query, ['writeConcern' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($manager, $query) {
+    $manager->executeQuery(NS, $query, ['unknown' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Unknown option 'readConcern'
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Unknown option 'writeConcern'
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Unknown option 'unknown'
+===DONE===

--- a/tests/manager/manager-executeReadCommand_error-001.phpt
+++ b/tests/manager/manager-executeReadCommand_error-001.phpt
@@ -1,5 +1,5 @@
 --TEST--
-MongoDB\Driver\Manager::executeReadCommand()
+MongoDB\Driver\Manager::executeReadCommand() with invalid options
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php NEEDS('STANDALONE'); CLEANUP(STANDALONE); ?>
@@ -9,20 +9,46 @@ require_once __DIR__ . "/../utils/basic.inc";
 
 $manager = new MongoDB\Driver\Manager(STANDALONE);
 
-$command = new MongoDB\Driver\Command([]);
+$command = new MongoDB\Driver\Command(['ping' => 1]);
 
 echo throws(function() use ($manager, $command) {
-    $manager->executeReadCommand(
-        DATABASE_NAME, $command,
-        [
-            'writeConcern' => new \MongoDB\Driver\ReadConcern(\MongoDB\Driver\WriteConcern::MAJORITY),
-        ]
-    );
+    $manager->executeReadCommand(DATABASE_NAME, $command, ['readConcern' => 'foo']);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($manager, $command) {
+    $manager->executeReadCommand(DATABASE_NAME, $command, ['readConcern' => new stdClass]);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($manager, $command) {
+    $manager->executeReadCommand(DATABASE_NAME, $command, ['readPreference' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($manager, $command) {
+    $manager->executeReadCommand(DATABASE_NAME, $command, ['readPreference' => new stdClass]);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($manager, $command) {
+    $manager->executeReadCommand(DATABASE_NAME, $command, ['session' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($manager, $command) {
+    $manager->executeReadCommand(DATABASE_NAME, $command, ['session' => new stdClass]);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECTF--
+--EXPECT--
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Unknown option 'writeConcern'
+Expected "readConcern" option to be MongoDB\Driver\ReadConcern, string given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "readConcern" option to be MongoDB\Driver\ReadConcern, stdClass given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "readPreference" option to be MongoDB\Driver\ReadPreference, string given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "readPreference" option to be MongoDB\Driver\ReadPreference, stdClass given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "session" option to be MongoDB\Driver\Session, string given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "session" option to be MongoDB\Driver\Session, stdClass given
 ===DONE===

--- a/tests/manager/manager-executeReadCommand_error-002.phpt
+++ b/tests/manager/manager-executeReadCommand_error-002.phpt
@@ -1,0 +1,32 @@
+--TEST--
+MongoDB\Driver\Manager::executeReadCommand() with unknown options
+--XFAIL--
+Depends on PHPC-1066
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('STANDALONE'); CLEANUP(STANDALONE); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(STANDALONE);
+
+$command = new MongoDB\Driver\Command(['ping' => 1]);
+
+echo throws(function() use ($manager, $command) {
+    $manager->executeReadCommand(DATABASE_NAME, $command, ['writeConcern' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($manager, $command) {
+    $manager->executeReadCommand(DATABASE_NAME, $command, ['unknown' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Unknown option 'writeConcern'
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Unknown option 'unknown'
+===DONE===

--- a/tests/manager/manager-executeReadWriteCommand_error-001.phpt
+++ b/tests/manager/manager-executeReadWriteCommand_error-001.phpt
@@ -1,5 +1,5 @@
 --TEST--
-MongoDB\Driver\Manager::executeReadWriteCommand()
+MongoDB\Driver\Manager::executeReadWriteCommand() with invalid options
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php NEEDS('STANDALONE'); CLEANUP(STANDALONE); ?>
@@ -9,21 +9,46 @@ require_once __DIR__ . "/../utils/basic.inc";
 
 $manager = new MongoDB\Driver\Manager(STANDALONE);
 
-$command = new MongoDB\Driver\Command([]);
+$command = new MongoDB\Driver\Command(['ping' => 1]);
 
 echo throws(function() use ($manager, $command) {
-    $manager->executeReadWriteCommand(
-        DATABASE_NAME, $command,
-        [
-            'readPreference' => new \MongoDB\Driver\ReadPreference(\MongoDB\Driver\ReadPreference::RP_SECONDARY),
-        ]
-    );
+    $manager->executeReadWriteCommand(DATABASE_NAME, $command, ['readConcern' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($manager, $command) {
+    $manager->executeReadWriteCommand(DATABASE_NAME, $command, ['readConcern' => new stdClass]);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($manager, $command) {
+    $manager->executeReadWriteCommand(DATABASE_NAME, $command, ['session' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($manager, $command) {
+    $manager->executeReadWriteCommand(DATABASE_NAME, $command, ['session' => new stdClass]);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($manager, $command) {
+    $manager->executeReadWriteCommand(DATABASE_NAME, $command, ['writeConcern' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($manager, $command) {
+    $manager->executeReadWriteCommand(DATABASE_NAME, $command, ['writeConcern' => new stdClass]);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECTF--
+--EXPECT--
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Unknown option 'readPreference'
+Expected "readConcern" option to be MongoDB\Driver\ReadConcern, string given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "readConcern" option to be MongoDB\Driver\ReadConcern, stdClass given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "session" option to be MongoDB\Driver\Session, string given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "session" option to be MongoDB\Driver\Session, stdClass given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "writeConcern" option to be MongoDB\Driver\WriteConcern, string given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "writeConcern" option to be MongoDB\Driver\WriteConcern, stdClass given
 ===DONE===

--- a/tests/manager/manager-executeReadWriteCommand_error-002.phpt
+++ b/tests/manager/manager-executeReadWriteCommand_error-002.phpt
@@ -1,0 +1,32 @@
+--TEST--
+MongoDB\Driver\Manager::executeReadWriteCommand() with unknown options
+--XFAIL--
+Depends on PHPC-1066
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('STANDALONE'); CLEANUP(STANDALONE); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(STANDALONE);
+
+$command = new MongoDB\Driver\Command(['ping' => 1]);
+
+echo throws(function() use ($manager, $command) {
+    $manager->executeReadWriteCommand(DATABASE_NAME, $command, ['readPreference' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($manager, $command) {
+    $manager->executeReadWriteCommand(DATABASE_NAME, $command, ['unknown' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Unknown option 'readPreference'
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Unknown option 'unknown'
+===DONE===

--- a/tests/manager/manager-executeWriteCommand_error-001.phpt
+++ b/tests/manager/manager-executeWriteCommand_error-001.phpt
@@ -1,40 +1,42 @@
 --TEST--
-MongoDB\Driver\Manager::executeWriteCommand()
+MongoDB\Driver\Manager::executeWriteCommand() with invalid options
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php NEEDS('STANDALONE'); CLEANUP(STANDALONE); ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";
-require_once __DIR__ . "/../utils/observer.php";
 
 $manager = new MongoDB\Driver\Manager(STANDALONE);
 
-$command = new MongoDB\Driver\Command([]);
+$command = new MongoDB\Driver\Command(['ping' => 1]);
 
 echo throws(function() use ($manager, $command) {
-    $manager->executeWriteCommand(
-        DATABASE_NAME, $command,
-        [
-            'readConcern' => new \MongoDB\Driver\ReadConcern(\MongoDB\Driver\ReadConcern::MAJORITY),
-        ]
-    );
+    $manager->executeWriteCommand(DATABASE_NAME, $command, ['session' => 'foo']);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
 echo throws(function() use ($manager, $command) {
-    $manager->executeWriteCommand(
-        DATABASE_NAME, $command,
-        [
-            'readPreference' => new \MongoDB\Driver\ReadConcern(\MongoDB\Driver\ReadPreference::RP_NEAREST),
-        ]
-    );
+    $manager->executeWriteCommand(DATABASE_NAME, $command, ['session' => new stdClass]);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($manager, $command) {
+    $manager->executeWriteCommand(DATABASE_NAME, $command, ['writeConcern' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($manager, $command) {
+    $manager->executeWriteCommand(DATABASE_NAME, $command, ['writeConcern' => new stdClass]);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECTF--
+--EXPECT--
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Unknown option 'readConcern'
+Expected "session" option to be MongoDB\Driver\Session, string given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Unknown option 'readPreference'
+Expected "session" option to be MongoDB\Driver\Session, stdClass given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "writeConcern" option to be MongoDB\Driver\WriteConcern, string given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "writeConcern" option to be MongoDB\Driver\WriteConcern, stdClass given
 ===DONE===

--- a/tests/manager/manager-executeWriteCommand_error-002.phpt
+++ b/tests/manager/manager-executeWriteCommand_error-002.phpt
@@ -1,0 +1,38 @@
+--TEST--
+MongoDB\Driver\Manager::executeWriteCommand() with unknown options
+--XFAIL--
+Depends on PHPC-1066
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('STANDALONE'); CLEANUP(STANDALONE); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(STANDALONE);
+
+$command = new MongoDB\Driver\Command(['ping' => 1]);
+
+echo throws(function() use ($manager, $command) {
+    $manager->executeWriteCommand(DATABASE_NAME, $command, ['readConcern' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($manager, $command) {
+    $manager->executeWriteCommand(DATABASE_NAME, $command, ['readPreference' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($manager, $command) {
+    $manager->executeWriteCommand(DATABASE_NAME, $command, ['unknown' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Unknown option 'readConcern'
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Unknown option 'readPreference'
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Unknown option 'unknown'
+===DONE===

--- a/tests/readPreference/bug0146-001.phpt
+++ b/tests/readPreference/bug0146-001.phpt
@@ -45,6 +45,8 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     }
     ["options"]=>
     object(stdClass)#%d (%d) {
+      ["serverId"]=>
+      int(%d)
     }
     ["readConcern"]=>
     NULL
@@ -81,6 +83,8 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     }
     ["options"]=>
     object(stdClass)#%d (%d) {
+      ["serverId"]=>
+      int(%d)
     }
     ["readConcern"]=>
     NULL
@@ -117,6 +121,8 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     }
     ["options"]=>
     object(stdClass)#%d (%d) {
+      ["serverId"]=>
+      int(%d)
     }
     ["readConcern"]=>
     NULL
@@ -153,6 +159,8 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     }
     ["options"]=>
     object(stdClass)#%d (%d) {
+      ["serverId"]=>
+      int(%d)
     }
     ["readConcern"]=>
     NULL
@@ -189,6 +197,8 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     }
     ["options"]=>
     object(stdClass)#%d (%d) {
+      ["serverId"]=>
+      int(%d)
     }
     ["readConcern"]=>
     NULL

--- a/tests/readPreference/bug0146-002.phpt
+++ b/tests/readPreference/bug0146-002.phpt
@@ -45,6 +45,8 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     }
     ["options"]=>
     object(stdClass)#%d (%d) {
+      ["serverId"]=>
+      int(%d)
     }
     ["readConcern"]=>
     NULL
@@ -81,6 +83,8 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     }
     ["options"]=>
     object(stdClass)#%d (%d) {
+      ["serverId"]=>
+      int(%d)
     }
     ["readConcern"]=>
     NULL
@@ -117,6 +121,8 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     }
     ["options"]=>
     object(stdClass)#%d (%d) {
+      ["serverId"]=>
+      int(%d)
     }
     ["readConcern"]=>
     NULL
@@ -153,6 +159,8 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     }
     ["options"]=>
     object(stdClass)#%d (%d) {
+      ["serverId"]=>
+      int(%d)
     }
     ["readConcern"]=>
     NULL
@@ -189,6 +197,8 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     }
     ["options"]=>
     object(stdClass)#%d (%d) {
+      ["serverId"]=>
+      int(%d)
     }
     ["readConcern"]=>
     NULL

--- a/tests/server/server-executeBulkWrite_error-002.phpt
+++ b/tests/server/server-executeBulkWrite_error-002.phpt
@@ -1,5 +1,5 @@
 --TEST--
-MongoDB\Driver\Server::executeBulkWrite() with wrong options and values
+MongoDB\Driver\Server::executeBulkWrite() with invalid options
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php NEEDS('REPLICASET'); ?>
@@ -9,41 +9,41 @@ require_once __DIR__ . "/../utils/basic.inc";
 
 $manager = new MongoDB\Driver\Manager(REPLICASET);
 $server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY));
-    
+
 echo throws(function() use ($server) {
     $bulk = new MongoDB\Driver\BulkWrite();
-    $bulk->insert(['wc' => 1]);
+    $bulk->insert(['x' => 1]);
+    $server->executeBulkWrite(NS, $bulk, ['session' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($server) {
+    $bulk = new MongoDB\Driver\BulkWrite();
+    $bulk->insert(['x' => 1]);
+    $server->executeBulkWrite(NS, $bulk, ['session' =>  new stdClass]);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($server) {
+    $bulk = new MongoDB\Driver\BulkWrite();
+    $bulk->insert(['x' => 1]);
     $server->executeBulkWrite(NS, $bulk, ['writeConcern' => 'foo']);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
 echo throws(function() use ($server) {
     $bulk = new MongoDB\Driver\BulkWrite();
-    $bulk->insert(['wc' => 1]);
-    $server->executeBulkWrite(NS, $bulk, ['writeConcern' => 42]);
-}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
-
-echo throws(function() use ($server) {
-    $bulk = new MongoDB\Driver\BulkWrite();
-    $bulk->insert(['wc' => 1]);
-    $server->executeBulkWrite(NS, $bulk, ['unknown' => 'foo']);
-}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
-
-echo throws(function() use ($server) {
-    $bulk = new MongoDB\Driver\BulkWrite();
-    $bulk->insert(['wc' => 1]);
-    $server->executeBulkWrite(NS, $bulk, ['readPreference' => 'foo']);
+    $bulk->insert(['x' => 1]);
+    $server->executeBulkWrite(NS, $bulk, ['writeConcern' => new stdClass]);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECTF--
+--EXPECT--
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected 'writeConcern' option to be 'MongoDB\Driver\WriteConcern', string given
+Expected "session" option to be MongoDB\Driver\Session, string given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected 'writeConcern' option to be 'MongoDB\Driver\WriteConcern', integer given
+Expected "session" option to be MongoDB\Driver\Session, stdClass given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Unknown option 'unknown'
+Expected "writeConcern" option to be MongoDB\Driver\WriteConcern, string given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Unknown option 'readPreference'
+Expected "writeConcern" option to be MongoDB\Driver\WriteConcern, stdClass given
 ===DONE===

--- a/tests/server/server-executeBulkWrite_error-003.phpt
+++ b/tests/server/server-executeBulkWrite_error-003.phpt
@@ -1,0 +1,43 @@
+--TEST--
+MongoDB\Driver\Server::executeBulkWrite() with unknown options
+--XFAIL--
+Depends on PHPC-1066
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('REPLICASET'); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(REPLICASET);
+$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY));
+
+echo throws(function() use ($server) {
+    $bulk = new MongoDB\Driver\BulkWrite();
+    $bulk->insert(['x' => 1]);
+    $server->executeBulkWrite(NS, $bulk, ['readConcern' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($server) {
+    $bulk = new MongoDB\Driver\BulkWrite();
+    $bulk->insert(['x' => 1]);
+    $server->executeBulkWrite(NS, $bulk, ['readPreference' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($server) {
+    $bulk = new MongoDB\Driver\BulkWrite();
+    $bulk->insert(['x' => 1]);
+    $server->executeBulkWrite(NS, $bulk, ['unknown' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Unknown option 'readConcern'
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Unknown option 'readPreference'
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Unknown option 'unknown'
+===DONE===

--- a/tests/server/server-executeCommand_error-001.phpt
+++ b/tests/server/server-executeCommand_error-001.phpt
@@ -1,5 +1,5 @@
 --TEST--
-MongoDB\Driver\Server::executeCommand(): wrong options and values (MONGOC_CMD_RAW)
+MongoDB\Driver\Server::executeCommand() with invalid options (MONGOC_CMD_RAW)
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php NEEDS('REPLICASET'); CLEANUP(REPLICASET); ?>
@@ -8,35 +8,60 @@ MongoDB\Driver\Server::executeCommand(): wrong options and values (MONGOC_CMD_RA
 require_once __DIR__ . "/../utils/basic.inc";
 
 $manager = new MongoDB\Driver\Manager(REPLICASET);
-$primary = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY);
-$server = $manager->selectServer($primary);
+$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY));
 
 $command = new MongoDB\Driver\Command(['ping' => 1]);
 
-echo throws(function() use ($manager, $command) {
-    $manager->executeCommand(DATABASE_NAME, $command, ['readPreference' => 'foo']);
-}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
-echo throws(function() use ($manager, $command) {
-    $manager->executeCommand(DATABASE_NAME, $command, ['readPreference' => new stdClass]);
+echo throws(function() use ($server, $command) {
+    $server->executeCommand(DATABASE_NAME, $command, ['readConcern' => 'foo']);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
-echo throws(function() use ($manager, $command) {
-    $manager->executeCommand(DATABASE_NAME, $command, ['unknown' => 'foo']);
+echo throws(function() use ($server, $command) {
+    $server->executeCommand(DATABASE_NAME, $command, ['readConcern' => new stdClass]);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
-echo throws(function() use ($manager, $command) {
-    $manager->executeCommand(DATABASE_NAME, $command, ['writeConcern' => 'foo']);
+echo throws(function() use ($server, $command) {
+    $server->executeCommand(DATABASE_NAME, $command, ['readPreference' => 'foo']);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($server, $command) {
+    $server->executeCommand(DATABASE_NAME, $command, ['readPreference' => new stdClass]);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($server, $command) {
+    $server->executeCommand(DATABASE_NAME, $command, ['session' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($server, $command) {
+    $server->executeCommand(DATABASE_NAME, $command, ['session' => new stdClass]);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($server, $command) {
+    $server->executeCommand(DATABASE_NAME, $command, ['writeConcern' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($server, $command) {
+    $server->executeCommand(DATABASE_NAME, $command, ['writeConcern' => new stdClass]);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECTF--
+--EXPECT--
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected 'readPreference' option to be 'MongoDB\Driver\ReadPreference', string given
+Expected "readConcern" option to be MongoDB\Driver\ReadConcern, string given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected 'readPreference' option to be 'MongoDB\Driver\ReadPreference', stdClass given
+Expected "readConcern" option to be MongoDB\Driver\ReadConcern, stdClass given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Unknown option 'unknown'
+Expected "readPreference" option to be MongoDB\Driver\ReadPreference, string given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected 'writeConcern' option to be 'MongoDB\Driver\WriteConcern', string given
+Expected "readPreference" option to be MongoDB\Driver\ReadPreference, stdClass given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "session" option to be MongoDB\Driver\Session, string given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "session" option to be MongoDB\Driver\Session, stdClass given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "writeConcern" option to be MongoDB\Driver\WriteConcern, string given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "writeConcern" option to be MongoDB\Driver\WriteConcern, stdClass given
 ===DONE===

--- a/tests/server/server-executeCommand_error-002.phpt
+++ b/tests/server/server-executeCommand_error-002.phpt
@@ -1,0 +1,27 @@
+--TEST--
+MongoDB\Driver\Server::executeCommand() with unknown options (MONGOC_CMD_RAW)
+--XFAIL--
+Depends on PHPC-1066
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('REPLICASET'); CLEANUP(REPLICASET); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(REPLICASET);
+$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY));
+
+$command = new MongoDB\Driver\Command(['ping' => 1]);
+
+echo throws(function() use ($server, $command) {
+    $server->executeCommand(DATABASE_NAME, $command, ['unknown' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Unknown option 'unknown'
+===DONE===

--- a/tests/server/server-executeQuery_error-001.phpt
+++ b/tests/server/server-executeQuery_error-001.phpt
@@ -1,5 +1,5 @@
 --TEST--
-MongoDB\Driver\Server::executeQuery(): wrong options and values
+MongoDB\Driver\Server::executeQuery() with invalid options
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php NEEDS('REPLICASET'); CLEANUP(REPLICASET); ?>
@@ -8,35 +8,36 @@ MongoDB\Driver\Server::executeQuery(): wrong options and values
 require_once __DIR__ . "/../utils/basic.inc";
 
 $manager = new MongoDB\Driver\Manager(REPLICASET);
-$primary = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY);
-$server = $manager->selectServer($primary);
+$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY));
 
 $query = new MongoDB\Driver\Query(['x' => 3], ['projection' => ['y' => 1]]);
 
-echo throws(function() use ($manager, $query) {
-    $manager->executeQuery(NS, $query, ['readPreference' => 'foo']);
-}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
-echo throws(function() use ($manager, $query) {
-    $manager->executeQuery(NS, $query, ['readPreference' => new stdClass]);
+echo throws(function() use ($server, $query) {
+    $server->executeQuery(NS, $query, ['readPreference' => 'foo']);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
-echo throws(function() use ($manager, $query) {
-    $manager->executeQuery(NS, $query, ['unknown' => 'foo']);
+echo throws(function() use ($server, $query) {
+    $server->executeQuery(NS, $query, ['readPreference' => new stdClass]);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
-echo throws(function() use ($manager, $query) {
-    $manager->executeQuery(NS, $query, ['writeConcern' => 'foo']);
+echo throws(function() use ($server, $query) {
+    $server->executeQuery(NS, $query, ['session' => 'foo']);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($server, $query) {
+    $server->executeQuery(NS, $query, ['session' => new stdClass]);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECTF--
+--EXPECT--
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected 'readPreference' option to be 'MongoDB\Driver\ReadPreference', string given
+Expected "readPreference" option to be MongoDB\Driver\ReadPreference, string given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected 'readPreference' option to be 'MongoDB\Driver\ReadPreference', stdClass given
+Expected "readPreference" option to be MongoDB\Driver\ReadPreference, stdClass given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Unknown option 'unknown'
+Expected "session" option to be MongoDB\Driver\Session, string given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Unknown option 'writeConcern'
+Expected "session" option to be MongoDB\Driver\Session, stdClass given
 ===DONE===

--- a/tests/server/server-executeQuery_error-002.phpt
+++ b/tests/server/server-executeQuery_error-002.phpt
@@ -1,0 +1,39 @@
+--TEST--
+MongoDB\Driver\Server::executeQuery() with unknown options
+--XFAIL--
+Depends on PHPC-1066
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('REPLICASET'); CLEANUP(REPLICASET); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(REPLICASET);
+$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY));
+
+$query = new MongoDB\Driver\Query(['x' => 3], ['projection' => ['y' => 1]]);
+
+echo throws(function() use ($server, $query) {
+    $server->executeQuery(NS, $query, ['readConcern' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($server, $query) {
+    $server->executeQuery(NS, $query, ['writeConcern' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($server, $query) {
+    $server->executeQuery(NS, $query, ['unknown' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Unknown option 'readConcern'
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Unknown option 'writeConcern'
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Unknown option 'unknown'
+===DONE===

--- a/tests/server/server-executeReadCommand-001.phpt
+++ b/tests/server/server-executeReadCommand-001.phpt
@@ -1,5 +1,5 @@
 --TEST--
-MongoDB\Driver\Manager::executeReadCommand()
+MongoDB\Driver\Server::executeReadCommand()
 --SKIPIF--
 <?php if (getenv("TRAVIS")) exit("skip This currently tails on Travis because it doesn't run 3.6 yet"); ?>
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>

--- a/tests/server/server-executeReadCommand_error-001.phpt
+++ b/tests/server/server-executeReadCommand_error-001.phpt
@@ -1,5 +1,5 @@
 --TEST--
-MongoDB\Driver\Manager::executeReadCommand()
+MongoDB\Driver\Server::executeReadCommand()
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php NEEDS('STANDALONE'); CLEANUP(STANDALONE); ?>

--- a/tests/server/server-executeReadCommand_error-001.phpt
+++ b/tests/server/server-executeReadCommand_error-001.phpt
@@ -1,5 +1,5 @@
 --TEST--
-MongoDB\Driver\Server::executeReadCommand()
+MongoDB\Driver\Server::executeReadCommand() with invalid options
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php NEEDS('STANDALONE'); CLEANUP(STANDALONE); ?>
@@ -10,20 +10,46 @@ require_once __DIR__ . "/../utils/basic.inc";
 $manager = new MongoDB\Driver\Manager(STANDALONE);
 $server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY));
 
-$command = new MongoDB\Driver\Command([]);
+$command = new MongoDB\Driver\Command(['ping' => 1]);
 
 echo throws(function() use ($server, $command) {
-    $server->executeReadCommand(
-        DATABASE_NAME, $command,
-        [
-            'writeConcern' => new \MongoDB\Driver\ReadConcern(\MongoDB\Driver\WriteConcern::MAJORITY),
-        ]
-    );
+    $server->executeReadCommand(DATABASE_NAME, $command, ['readConcern' => 'foo']);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($server, $command) {
+    $server->executeReadCommand(DATABASE_NAME, $command, ['readConcern' => new stdClass]);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($server, $command) {
+    $server->executeReadCommand(DATABASE_NAME, $command, ['readPreference' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($server, $command) {
+    $server->executeReadCommand(DATABASE_NAME, $command, ['readPreference' => new stdClass]);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($server, $command) {
+    $server->executeReadCommand(DATABASE_NAME, $command, ['session' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($server, $command) {
+    $server->executeReadCommand(DATABASE_NAME, $command, ['session' => new stdClass]);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECTF--
+--EXPECT--
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Unknown option 'writeConcern'
+Expected "readConcern" option to be MongoDB\Driver\ReadConcern, string given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "readConcern" option to be MongoDB\Driver\ReadConcern, stdClass given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "readPreference" option to be MongoDB\Driver\ReadPreference, string given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "readPreference" option to be MongoDB\Driver\ReadPreference, stdClass given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "session" option to be MongoDB\Driver\Session, string given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "session" option to be MongoDB\Driver\Session, stdClass given
 ===DONE===

--- a/tests/server/server-executeReadCommand_error-002.phpt
+++ b/tests/server/server-executeReadCommand_error-002.phpt
@@ -1,0 +1,33 @@
+--TEST--
+MongoDB\Driver\Server::executeReadCommand() with unknown options
+--XFAIL--
+Depends on PHPC-1066
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('STANDALONE'); CLEANUP(STANDALONE); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(STANDALONE);
+$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY));
+
+$command = new MongoDB\Driver\Command(['ping' => 1]);
+
+echo throws(function() use ($server, $command) {
+    $server->executeReadCommand(DATABASE_NAME, $command, ['writeConcern' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($server, $command) {
+    $server->executeReadCommand(DATABASE_NAME, $command, ['unknown' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Unknown option 'writeConcern'
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Unknown option 'unknown'
+===DONE===

--- a/tests/server/server-executeReadWriteCommand-001.phpt
+++ b/tests/server/server-executeReadWriteCommand-001.phpt
@@ -1,5 +1,5 @@
 --TEST--
-MongoDB\Driver\Manager::executeReadWriteCommand()
+MongoDB\Driver\Server::executeReadWriteCommand()
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php NEEDS('STANDALONE'); CLEANUP(STANDALONE); ?>

--- a/tests/server/server-executeReadWriteCommand_error-001.phpt
+++ b/tests/server/server-executeReadWriteCommand_error-001.phpt
@@ -1,5 +1,5 @@
 --TEST--
-MongoDB\Driver\Server::executeReadWriteCommand()
+MongoDB\Driver\Server::executeReadWriteCommand() with invalid options
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php NEEDS('STANDALONE'); CLEANUP(STANDALONE); ?>
@@ -10,21 +10,46 @@ require_once __DIR__ . "/../utils/basic.inc";
 $manager = new MongoDB\Driver\Manager(STANDALONE);
 $server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY));
 
-$command = new MongoDB\Driver\Command([]);
+$command = new MongoDB\Driver\Command(['ping' => 1]);
 
 echo throws(function() use ($server, $command) {
-    $server->executeReadWriteCommand(
-        DATABASE_NAME, $command,
-        [
-            'readPreference' => new \MongoDB\Driver\ReadPreference(\MongoDB\Driver\ReadPreference::RP_SECONDARY),
-        ]
-    );
+    $server->executeReadWriteCommand(DATABASE_NAME, $command, ['readConcern' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($server, $command) {
+    $server->executeReadWriteCommand(DATABASE_NAME, $command, ['readConcern' => new stdClass]);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($server, $command) {
+    $server->executeReadWriteCommand(DATABASE_NAME, $command, ['session' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($server, $command) {
+    $server->executeReadWriteCommand(DATABASE_NAME, $command, ['session' => new stdClass]);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($server, $command) {
+    $server->executeReadWriteCommand(DATABASE_NAME, $command, ['writeConcern' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($server, $command) {
+    $server->executeReadWriteCommand(DATABASE_NAME, $command, ['writeConcern' => new stdClass]);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECTF--
+--EXPECT--
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Unknown option 'readPreference'
+Expected "readConcern" option to be MongoDB\Driver\ReadConcern, string given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "readConcern" option to be MongoDB\Driver\ReadConcern, stdClass given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "session" option to be MongoDB\Driver\Session, string given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "session" option to be MongoDB\Driver\Session, stdClass given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "writeConcern" option to be MongoDB\Driver\WriteConcern, string given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "writeConcern" option to be MongoDB\Driver\WriteConcern, stdClass given
 ===DONE===

--- a/tests/server/server-executeReadWriteCommand_error-001.phpt
+++ b/tests/server/server-executeReadWriteCommand_error-001.phpt
@@ -1,5 +1,5 @@
 --TEST--
-MongoDB\Driver\Manager::executeReadWriteCommand()
+MongoDB\Driver\Server::executeReadWriteCommand()
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php NEEDS('STANDALONE'); CLEANUP(STANDALONE); ?>

--- a/tests/server/server-executeReadWriteCommand_error-002.phpt
+++ b/tests/server/server-executeReadWriteCommand_error-002.phpt
@@ -1,0 +1,33 @@
+--TEST--
+MongoDB\Driver\Server::executeReadWriteCommand() with unknown options
+--XFAIL--
+Depends on PHPC-1066
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('STANDALONE'); CLEANUP(STANDALONE); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(STANDALONE);
+$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY));
+
+$command = new MongoDB\Driver\Command(['ping' => 1]);
+
+echo throws(function() use ($manager, $command) {
+    $manager->executeReadWriteCommand(DATABASE_NAME, $command, ['readPreference' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($manager, $command) {
+    $manager->executeReadWriteCommand(DATABASE_NAME, $command, ['unknown' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Unknown option 'readPreference'
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Unknown option 'unknown'
+===DONE===

--- a/tests/server/server-executeWriteCommand-001.phpt
+++ b/tests/server/server-executeWriteCommand-001.phpt
@@ -1,5 +1,5 @@
 --TEST--
-MongoDB\Driver\Manager::executeWriteCommand()
+MongoDB\Driver\Server::executeWriteCommand()
 --SKIPIF--
 <?php if (getenv("TRAVIS")) exit("skip This currently tails on Travis because it doesn't run 3.6 yet"); ?>
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>

--- a/tests/server/server-executeWriteCommand_error-001.phpt
+++ b/tests/server/server-executeWriteCommand_error-001.phpt
@@ -1,5 +1,5 @@
 --TEST--
-MongoDB\Driver\Manager::executeWriteCommand()
+MongoDB\Driver\Server::executeWriteCommand()
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php NEEDS('STANDALONE'); CLEANUP(STANDALONE); ?>

--- a/tests/server/server-executeWriteCommand_error-001.phpt
+++ b/tests/server/server-executeWriteCommand_error-001.phpt
@@ -1,5 +1,5 @@
 --TEST--
-MongoDB\Driver\Server::executeWriteCommand()
+MongoDB\Driver\Server::executeWriteCommand() with invalid options
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php NEEDS('STANDALONE'); CLEANUP(STANDALONE); ?>
@@ -14,28 +14,31 @@ $server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Drive
 $command = new MongoDB\Driver\Command([]);
 
 echo throws(function() use ($server, $command) {
-    $server->executeWriteCommand(
-        DATABASE_NAME, $command,
-        [
-            'readConcern' => new \MongoDB\Driver\ReadConcern(\MongoDB\Driver\ReadConcern::MAJORITY),
-        ]
-    );
+    $server->executeWriteCommand(DATABASE_NAME, $command, ['session' => 'foo']);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
 echo throws(function() use ($server, $command) {
-    $server->executeWriteCommand(
-        DATABASE_NAME, $command,
-        [
-            'readPreference' => new \MongoDB\Driver\ReadConcern(\MongoDB\Driver\ReadPreference::RP_NEAREST),
-        ]
-    );
+    $server->executeWriteCommand(DATABASE_NAME, $command, ['session' => new stdClass]);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($server, $command) {
+    $server->executeWriteCommand(DATABASE_NAME, $command, ['writeConcern' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($server, $command) {
+    $server->executeWriteCommand(DATABASE_NAME, $command, ['writeConcern' => new stdClass]);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECTF--
+--EXPECT--
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Unknown option 'readConcern'
+Expected "session" option to be MongoDB\Driver\Session, string given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Unknown option 'readPreference'
+Expected "session" option to be MongoDB\Driver\Session, stdClass given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "writeConcern" option to be MongoDB\Driver\WriteConcern, string given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "writeConcern" option to be MongoDB\Driver\WriteConcern, stdClass given
 ===DONE===

--- a/tests/server/server-executeWriteCommand_error-002.phpt
+++ b/tests/server/server-executeWriteCommand_error-002.phpt
@@ -1,0 +1,40 @@
+--TEST--
+MongoDB\Driver\Server::executeWriteCommand() with unknown options
+--XFAIL--
+Depends on PHPC-1066
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('STANDALONE'); CLEANUP(STANDALONE); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+require_once __DIR__ . "/../utils/observer.php";
+
+$manager = new MongoDB\Driver\Manager(STANDALONE);
+$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY));
+
+$command = new MongoDB\Driver\Command([]);
+
+echo throws(function() use ($server, $command) {
+    $server->executeWriteCommand(DATABASE_NAME, $command, ['readConcern' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($server, $command) {
+    $server->executeWriteCommand(DATABASE_NAME, $command, ['readPreference' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($server, $command) {
+    $server->executeWriteCommand(DATABASE_NAME, $command, ['unknown' => 'foo']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Unknown option 'readConcern'
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Unknown option 'readPreference'
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Unknown option 'unknown'
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1057
https://jira.mongodb.org/browse/PHPC-1066

This depends on the initial session implementation in #680. I've split up the PRs to make reviewing a bit easier, although I'll note that the option parsing refactoring in this PR was necessary to finish the session API (`phongo_execute_query` in particular).

Since I ended up improving the error tests to cover all invalid, known options, I ended up moving (and enhancing) tests for unknown options into separate files. Those split tests for unknown options now have `XFAIL` blocks depending on [PHPC-1066](https://jira.mongodb.org/browse/PHPC-1066). There are no other changes related to PHPC-1066 in this PR, but I didn't want to lose track of any existing test cases we had.

The other two commits for fixing titles in server tests and updating `server_id` to `uint32_t` are just small cleanup tasks.