### PR TITLE
PHPC-986: APM-based tests for retryable writes

### DIFF
--- a/tests/retryable-writes/retryable-writes-001.phpt
+++ b/tests/retryable-writes/retryable-writes-001.phpt
@@ -1,0 +1,82 @@
+--TEST--
+Retryable writes: supported single-statement operations include transaction IDs
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('REPLICASET'); CLEANUP(REPLICASET); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+class TransactionIdObserver implements MongoDB\Driver\Monitoring\CommandSubscriber
+{
+    public function commandStarted(MongoDB\Driver\Monitoring\CommandStartedEvent $event)
+    {
+        $command = $event->getCommand();
+        $hasTransactionId = isset($command->lsid) && isset($command->txnNumber);
+
+        printf("%s command includes transaction ID: %s\n", $event->getCommandName(), $hasTransactionId ? 'yes' : 'no');
+    }
+
+    public function commandSucceeded(MongoDB\Driver\Monitoring\CommandSucceededEvent $event)
+    {
+    }
+
+    public function commandFailed(MongoDB\Driver\Monitoring\CommandFailedEvent $event)
+    {
+    }
+}
+
+$observer = new TransactionIdObserver;
+MongoDB\Driver\Monitoring\addSubscriber($observer);
+
+$manager = new MongoDB\Driver\Manager(REPLICASET, ['retryWrites' => true]);
+
+echo "Testing deleteOne\n";
+$bulk = new MongoDB\Driver\BulkWrite;
+$bulk->delete(['x' => 1], ['limit' => 1]);
+$manager->executeBulkWrite(NS, $bulk);
+
+echo "\nTesting insertOne\n";
+$bulk = new MongoDB\Driver\BulkWrite;
+$bulk->insert(['x' => 1]);
+$manager->executeBulkWrite(NS, $bulk);
+
+echo "\nTesting replaceOne\n";
+$bulk = new MongoDB\Driver\BulkWrite;
+$bulk->update(['x' => 1], ['x' => 2]);
+$manager->executeBulkWrite(NS, $bulk);
+
+echo "\nTesting updateOne\n";
+$bulk = new MongoDB\Driver\BulkWrite;
+$bulk->update(['x' => 1], ['$inc' => ['x' => 1]]);
+$manager->executeBulkWrite(NS, $bulk);
+
+echo "\nTesting findAndModify\n";
+$command = new MongoDB\Driver\Command([
+    'findAndModify' => COLLECTION_NAME,
+    'query' => ['x' => 1],
+    'update' => ['$inc' => ['x' => 1]],
+]);
+$manager->executeReadWriteCommand(DATABASE_NAME, $command);
+
+MongoDB\Driver\Monitoring\removeSubscriber($observer);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+Testing deleteOne
+delete command includes transaction ID: yes
+
+Testing insertOne
+insert command includes transaction ID: yes
+
+Testing replaceOne
+update command includes transaction ID: yes
+
+Testing updateOne
+update command includes transaction ID: yes
+
+Testing findAndModify
+findAndModify command includes transaction ID: yes
+===DONE===

--- a/tests/retryable-writes/retryable-writes-002.phpt
+++ b/tests/retryable-writes/retryable-writes-002.phpt
@@ -1,0 +1,83 @@
+--TEST--
+Retryable writes: supported multi-statement operations include transaction IDs
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('REPLICASET'); CLEANUP(REPLICASET); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+class TransactionIdObserver implements MongoDB\Driver\Monitoring\CommandSubscriber
+{
+    public function commandStarted(MongoDB\Driver\Monitoring\CommandStartedEvent $event)
+    {
+        $command = $event->getCommand();
+        $hasTransactionId = isset($command->lsid) && isset($command->txnNumber);
+
+        printf("%s command includes transaction ID: %s\n", $event->getCommandName(), $hasTransactionId ? 'yes' : 'no');
+    }
+
+    public function commandSucceeded(MongoDB\Driver\Monitoring\CommandSucceededEvent $event)
+    {
+    }
+
+    public function commandFailed(MongoDB\Driver\Monitoring\CommandFailedEvent $event)
+    {
+    }
+}
+
+$observer = new TransactionIdObserver;
+MongoDB\Driver\Monitoring\addSubscriber($observer);
+
+$manager = new MongoDB\Driver\Manager(REPLICASET, ['retryWrites' => true]);
+
+echo "Testing multi-statement bulk write (ordered=true)\n";
+$bulk = new MongoDB\Driver\BulkWrite(['ordered' => true]);
+$bulk->delete(['x' => 1], ['limit' => 1]);
+$bulk->insert(['x' => 1]);
+$bulk->update(['x' => 1], ['$inc' => ['x' => 1]]);
+$bulk->update(['x' => 1], ['x' => 2]);
+$manager->executeBulkWrite(NS, $bulk);
+
+echo "\nTesting multi-statement bulk write (ordered=false)\n";
+$bulk = new MongoDB\Driver\BulkWrite(['ordered' => false]);
+$bulk->delete(['x' => 1], ['limit' => 1]);
+$bulk->insert(['x' => 1]);
+$bulk->update(['x' => 1], ['$inc' => ['x' => 1]]);
+$bulk->update(['x' => 1], ['x' => 2]);
+$manager->executeBulkWrite(NS, $bulk);
+
+echo "\nTesting insertMany (ordered=true)\n";
+$bulk = new MongoDB\Driver\BulkWrite(['ordered' => true]);
+$bulk->insert(['x' => 1]);
+$bulk->insert(['x' => 2]);
+$manager->executeBulkWrite(NS, $bulk);
+
+echo "\nTesting insertMany (ordered=false)\n";
+$bulk = new MongoDB\Driver\BulkWrite(['ordered' => false]);
+$bulk->insert(['x' => 1]);
+$bulk->insert(['x' => 2]);
+$manager->executeBulkWrite(NS, $bulk);
+
+MongoDB\Driver\Monitoring\removeSubscriber($observer);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+Testing multi-statement bulk write (ordered=true)
+delete command includes transaction ID: yes
+insert command includes transaction ID: yes
+update command includes transaction ID: yes
+
+Testing multi-statement bulk write (ordered=false)
+delete command includes transaction ID: yes
+insert command includes transaction ID: yes
+update command includes transaction ID: yes
+
+Testing insertMany (ordered=true)
+insert command includes transaction ID: yes
+
+Testing insertMany (ordered=false)
+insert command includes transaction ID: yes
+===DONE===

--- a/tests/retryable-writes/retryable-writes-003.phpt
+++ b/tests/retryable-writes/retryable-writes-003.phpt
@@ -1,0 +1,97 @@
+--TEST--
+Retryable writes: unsupported operations do not include transaction IDs
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('REPLICASET'); CLEANUP(REPLICASET); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+class TransactionIdObserver implements MongoDB\Driver\Monitoring\CommandSubscriber
+{
+    public function commandStarted(MongoDB\Driver\Monitoring\CommandStartedEvent $event)
+    {
+        $command = $event->getCommand();
+        $hasTransactionId = isset($command->lsid) && isset($command->txnNumber);
+
+        printf("%s command includes transaction ID: %s\n", $event->getCommandName(), $hasTransactionId ? 'yes' : 'no');
+    }
+
+    public function commandSucceeded(MongoDB\Driver\Monitoring\CommandSucceededEvent $event)
+    {
+    }
+
+    public function commandFailed(MongoDB\Driver\Monitoring\CommandFailedEvent $event)
+    {
+    }
+}
+
+$observer = new TransactionIdObserver;
+MongoDB\Driver\Monitoring\addSubscriber($observer);
+
+$manager = new MongoDB\Driver\Manager(REPLICASET, ['retryWrites' => true]);
+
+echo "Testing deleteMany\n";
+$bulk = new MongoDB\Driver\BulkWrite;
+$bulk->delete(['x' => 1], ['limit' => 0]);
+$manager->executeBulkWrite(NS, $bulk);
+
+echo "\nTesting updateMany\n";
+$bulk = new MongoDB\Driver\BulkWrite;
+$bulk->update(['x' => 1], ['$inc' => ['x' => 1]], ['multi' => true]);
+$manager->executeBulkWrite(NS, $bulk);
+
+echo "\nTesting multi-statement bulk write with one unsupported operation (ordered=true)\n";
+$bulk = new MongoDB\Driver\BulkWrite(['ordered' => true]);
+$bulk->delete(['x' => 1], ['limit' => 1]);
+$bulk->insert(['x' => 1]);
+$bulk->update(['x' => 1], ['$inc' => ['x' => 1]]);
+$bulk->update(['x' => 1], ['x' => 2]);
+$bulk->update(['x' => 1], ['$inc' => ['x' => 1]], ['multi' => true]);
+$manager->executeBulkWrite(NS, $bulk);
+
+echo "\nTesting multi-statement bulk write with one unsupported operation (ordered=false)\n";
+$bulk = new MongoDB\Driver\BulkWrite(['ordered' => false]);
+$bulk->delete(['x' => 1], ['limit' => 1]);
+$bulk->insert(['x' => 1]);
+$bulk->update(['x' => 1], ['$inc' => ['x' => 1]]);
+$bulk->update(['x' => 1], ['x' => 2]);
+$bulk->update(['x' => 1], ['$inc' => ['x' => 1]], ['multi' => true]);
+$manager->executeBulkWrite(NS, $bulk);
+
+echo "\nTesting aggregate\n";
+$command = new MongoDB\Driver\Command([
+    'aggregate' => COLLECTION_NAME,
+    'pipeline' => [
+        ['$match' => ['x' => 1]],
+        ['$out' => COLLECTION_NAME . '.out'],
+    ],
+    'cursor' => new stdClass,
+]);
+$manager->executeReadWriteCommand(DATABASE_NAME, $command);
+
+MongoDB\Driver\Monitoring\removeSubscriber($observer);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+Testing deleteMany
+delete command includes transaction ID: no
+
+Testing updateMany
+update command includes transaction ID: no
+
+Testing multi-statement bulk write with one unsupported operation (ordered=true)
+delete command includes transaction ID: yes
+insert command includes transaction ID: yes
+update command includes transaction ID: no
+
+Testing multi-statement bulk write with one unsupported operation (ordered=false)
+delete command includes transaction ID: yes
+insert command includes transaction ID: yes
+update command includes transaction ID: no
+
+Testing aggregate
+aggregate command includes transaction ID: no
+===DONE===

--- a/tests/retryable-writes/retryable-writes-005.phpt
+++ b/tests/retryable-writes/retryable-writes-005.phpt
@@ -1,0 +1,68 @@
+--TEST--
+Retryable writes: non-write command methods do not include transaction IDs
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('REPLICASET'); CLEANUP(REPLICASET); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+class TransactionIdObserver implements MongoDB\Driver\Monitoring\CommandSubscriber
+{
+    public function commandStarted(MongoDB\Driver\Monitoring\CommandStartedEvent $event)
+    {
+        $command = $event->getCommand();
+        $hasTransactionId = isset($command->lsid) && isset($command->txnNumber);
+
+        printf("%s command includes transaction ID: %s\n", $event->getCommandName(), $hasTransactionId ? 'yes' : 'no');
+    }
+
+    public function commandSucceeded(MongoDB\Driver\Monitoring\CommandSucceededEvent $event)
+    {
+    }
+
+    public function commandFailed(MongoDB\Driver\Monitoring\CommandFailedEvent $event)
+    {
+    }
+}
+
+$observer = new TransactionIdObserver;
+MongoDB\Driver\Monitoring\addSubscriber($observer);
+
+$manager = new MongoDB\Driver\Manager(REPLICASET, ['retryWrites' => true]);
+$command = new MongoDB\Driver\Command([
+    'findAndModify' => COLLECTION_NAME,
+    'query' => ['x' => 1],
+    'update' => ['$inc' => ['x' => 1]],
+]);
+
+echo "Testing Manager::executeCommand()\n";
+$manager->executeCommand(DATABASE_NAME, $command);
+
+echo "\nTesting Manager::executeReadCommand()\n";
+$manager->executeReadCommand(DATABASE_NAME, $command);
+
+echo "\nTesting Manager::executeReadWriteCommand()\n";
+$manager->executeReadWriteCommand(DATABASE_NAME, $command);
+
+echo "\nTesting Manager::executeWriteCommand()\n";
+$manager->executeWriteCommand(DATABASE_NAME, $command);
+
+MongoDB\Driver\Monitoring\removeSubscriber($observer);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+Testing Manager::executeCommand()
+findAndModify command includes transaction ID: no
+
+Testing Manager::executeReadCommand()
+findAndModify command includes transaction ID: no
+
+Testing Manager::executeReadWriteCommand()
+findAndModify command includes transaction ID: yes
+
+Testing Manager::executeWriteCommand()
+findAndModify command includes transaction ID: yes
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-986

PHPC did not require any code changes to support retryable writes, as existing URI option processing allows enabling of retryable writes in libmongoc. These tests utilize APM to assert that certain commands include or exclude a transaction ID.