### PR TITLE
Update Makefile target for cleaning test dirs

### DIFF
--- a/Makefile.frag
+++ b/Makefile.frag
@@ -1,4 +1,4 @@
-.PHONY: coverage testclean package package.xml
+.PHONY: coverage test-clean package package.xml
 
 DATE=`date +%Y-%m-%d--%H-%M-%S`
 MONGODB_VERSION=$(shell php -n -dextension=modules/mongodb.so -r 'echo MONGODB_VERSION;')
@@ -71,10 +71,8 @@ test-virtual: package
 	sh ./scripts/run-tests-on.sh precise32
 	sh ./scripts/run-tests-on.sh precise64
 
-testclean:
-	@for group in generic standalone; do \
-		find $(top_srcdir)/tests/$$group -type f -name "*.diff" -o -name "*.exp" -o -name "*.log" -o -name "*.mem" -o -name "*.out" -o -name "*.php" -o -name "*.sh" | xargs rm -f; \
-	done;
+test-clean:
+	find $(top_srcdir)/tests -path $(top_srcdir)/tests/utils -prune -type f -name "*.diff" -o -name "*.exp" -o -name "*.log" -o -name "*.mem" -o -name "*.out" -o -name "*.php" -o -name "*.sh" | xargs rm
 
 package:
 	pecl package package.xml


### PR DESCRIPTION
This prunes the utils directory instead of depending on a whitelist, which would need to be more frequently updated.