### PR TITLE
More improvements to test-clean make target

### DIFF
--- a/Makefile.frag
+++ b/Makefile.frag
@@ -72,7 +72,7 @@ test-virtual: package
 	sh ./scripts/run-tests-on.sh precise64
 
 test-clean:
-	find $(top_srcdir)/tests -not \( -path $(top_srcdir)/tests/utils -prune \) -type f -name "*.diff" -o -name "*.exp" -o -name "*.log" -o -name "*.mem" -o -name "*.out" -o -name "*.php" -o -name "*.sh" | xargs rm
+	find $(top_srcdir)/tests -not \( -path $(top_srcdir)/tests/utils -prune \) -type f -name "*.diff" -o -name "*.exp" -o -name "*.log" -o -name "*.mem" -o -name "*.out" -o -name "*.php" -o -name "*.sh" | xargs -r rm
 
 package:
 	pecl package package.xml

--- a/Makefile.frag
+++ b/Makefile.frag
@@ -72,7 +72,7 @@ test-virtual: package
 	sh ./scripts/run-tests-on.sh precise64
 
 test-clean:
-	find $(top_srcdir)/tests -path $(top_srcdir)/tests/utils -prune -type f -name "*.diff" -o -name "*.exp" -o -name "*.log" -o -name "*.mem" -o -name "*.out" -o -name "*.php" -o -name "*.sh" | xargs rm
+	find $(top_srcdir)/tests -not \( -path $(top_srcdir)/tests/utils -prune \) -type f -name "*.diff" -o -name "*.exp" -o -name "*.log" -o -name "*.mem" -o -name "*.out" -o -name "*.php" -o -name "*.sh" | xargs rm
 
 package:
 	pecl package package.xml


### PR DESCRIPTION
The original modifications in #722 didn't actually prune the `utils` directory from the output of `find` (and input of `xargs rm`). This ensures that both the directory and its contents are omitted.

Additionally `-r` ensures that we never call `rm` with empty input, which would emit an error.