### PR TITLE
PHPC-1092: Don't reset hash on successive get_properties calls

### DIFF
--- a/php_phongo.h
+++ b/php_phongo.h
@@ -196,7 +196,6 @@ zend_bool phongo_writeconcernerror_init(zval *return_value, bson_t *bson TSRMLS_
         ALLOC_HASHTABLE(props);                                                 \
         zend_hash_init((props), (size), NULL, ZVAL_PTR_DTOR, 0);                \
     } else if ((intern)->properties) {                                          \
-        zend_hash_clean((intern)->properties);                                  \
         (props) = (intern)->properties;                                         \
     } else {                                                                    \
         ALLOC_HASHTABLE(props);                                                 \

--- a/tests/bson/bson-binary-get_properties-001.phpt
+++ b/tests/bson/bson-binary-get_properties-001.phpt
@@ -1,0 +1,20 @@
+--TEST--
+MongoDB\BSON\Binary get_properties handler (get_object_vars)
+--FILE--
+<?php
+
+$binary = new MongoDB\BSON\Binary('foobar', MongoDB\BSON\Binary::TYPE_GENERIC);
+
+var_dump(get_object_vars($binary));
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+array(2) {
+  ["data"]=>
+  string(6) "foobar"
+  ["type"]=>
+  int(0)
+}
+===DONE===

--- a/tests/bson/bson-binary-get_properties-002.phpt
+++ b/tests/bson/bson-binary-get_properties-002.phpt
@@ -1,0 +1,21 @@
+--TEST--
+MongoDB\BSON\Binary get_properties handler (foreach)
+--FILE--
+<?php
+
+$binary = new MongoDB\BSON\Binary('foobar', MongoDB\BSON\Binary::TYPE_GENERIC);
+
+foreach ($binary as $key => $value) {
+    var_dump($key);
+    var_dump($value);
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+string(4) "data"
+string(6) "foobar"
+string(4) "type"
+int(0)
+===DONE===

--- a/tests/bson/bson-dbpointer-get_properties-001.phpt
+++ b/tests/bson/bson-dbpointer-get_properties-001.phpt
@@ -1,0 +1,21 @@
+--TEST--
+MongoDB\BSON\DBPointer get_properties handler (get_object_vars)
+--FILE--
+<?php
+
+$document = MongoDB\BSON\toPHP(MongoDB\BSON\fromJSON('{"dbptr":{"$dbPointer":{"$ref":"phongo.test","$id":{"$oid":"5a2e78accd485d55b405ac12"}}}}'));
+$dbptr = $document->dbptr;
+
+var_dump(get_object_vars($dbptr));
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+array(2) {
+  ["ref"]=>
+  string(11) "phongo.test"
+  ["id"]=>
+  string(24) "5a2e78accd485d55b405ac12"
+}
+===DONE===

--- a/tests/bson/bson-dbpointer-get_properties-002.phpt
+++ b/tests/bson/bson-dbpointer-get_properties-002.phpt
@@ -1,0 +1,22 @@
+--TEST--
+MongoDB\BSON\DBPointer get_properties handler (foreach)
+--FILE--
+<?php
+
+$document = MongoDB\BSON\toPHP(MongoDB\BSON\fromJSON('{"dbptr":{"$dbPointer":{"$ref":"phongo.test","$id":{"$oid":"5a2e78accd485d55b405ac12"}}}}'));
+$dbptr = $document->dbptr;
+
+foreach ($dbptr as $key => $value) {
+    var_dump($key);
+    var_dump($value);
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+string(3) "ref"
+string(11) "phongo.test"
+string(2) "id"
+string(24) "5a2e78accd485d55b405ac12"
+===DONE===

--- a/tests/bson/bson-decimal128-get_properties-001.phpt
+++ b/tests/bson/bson-decimal128-get_properties-001.phpt
@@ -1,0 +1,20 @@
+--TEST--
+MongoDB\BSON\Decimal128 get_properties handler (get_object_vars)
+--SKIPIF--
+<?php if (!class_exists('MongoDB\BSON\Decimal128')) { die('skip MongoDB\BSON\Decimal128 is not available'); } ?>
+--FILE--
+<?php
+
+$decimal = new MongoDB\BSON\Decimal128('1234.5678');
+
+var_dump(get_object_vars($decimal));
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+array(1) {
+  ["dec"]=>
+  string(9) "1234.5678"
+}
+===DONE===

--- a/tests/bson/bson-decimal128-get_properties-002.phpt
+++ b/tests/bson/bson-decimal128-get_properties-002.phpt
@@ -1,0 +1,21 @@
+--TEST--
+MongoDB\BSON\Decimal128 get_properties handler (foreach)
+--SKIPIF--
+<?php if (!class_exists('MongoDB\BSON\Decimal128')) { die('skip MongoDB\BSON\Decimal128 is not available'); } ?>
+--FILE--
+<?php
+
+$decimal = new MongoDB\BSON\Decimal128('1234.5678');
+
+foreach ($decimal as $key => $value) {
+    var_dump($key);
+    var_dump($value);
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+string(3) "dec"
+string(9) "1234.5678"
+===DONE===

--- a/tests/bson/bson-javascript-get_properties-001.phpt
+++ b/tests/bson/bson-javascript-get_properties-001.phpt
@@ -1,0 +1,34 @@
+--TEST--
+MongoDB\BSON\Javascript get_properties handler (get_object_vars)
+--FILE--
+<?php
+
+$tests = [
+    new MongoDB\BSON\Javascript('function foo(bar) { return bar; }'),
+    new MongoDB\BSON\Javascript('function foo() { return bar; }', ['bar' => 42]),
+];
+
+foreach ($tests as $test) {
+    var_dump(get_object_vars($test));
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+array(2) {
+  ["code"]=>
+  string(33) "function foo(bar) { return bar; }"
+  ["scope"]=>
+  NULL
+}
+array(2) {
+  ["code"]=>
+  string(30) "function foo() { return bar; }"
+  ["scope"]=>
+  object(stdClass)#%d (%d) {
+    ["bar"]=>
+    int(42)
+  }
+}
+===DONE===

--- a/tests/bson/bson-javascript-get_properties-002.phpt
+++ b/tests/bson/bson-javascript-get_properties-002.phpt
@@ -1,0 +1,33 @@
+--TEST--
+MongoDB\BSON\Javascript get_properties handler (foreach)
+--FILE--
+<?php
+
+$tests = [
+    new MongoDB\BSON\Javascript('function foo(bar) { return bar; }'),
+    new MongoDB\BSON\Javascript('function foo() { return bar; }', ['bar' => 42]),
+];
+
+foreach ($tests as $test) {
+    foreach ($test as $key => $value) {
+        var_dump($key);
+        var_dump($value);
+    }
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+string(4) "code"
+string(33) "function foo(bar) { return bar; }"
+string(5) "scope"
+NULL
+string(4) "code"
+string(30) "function foo() { return bar; }"
+string(5) "scope"
+object(stdClass)#%d (%d) {
+  ["bar"]=>
+  int(42)
+}
+===DONE===

--- a/tests/bson/bson-objectid-get_properties-001.phpt
+++ b/tests/bson/bson-objectid-get_properties-001.phpt
@@ -1,0 +1,18 @@
+--TEST--
+MongoDB\BSON\ObjectId get_properties handler (get_object_vars)
+--FILE--
+<?php
+
+$oid = new MongoDB\BSON\ObjectId('53e2a1c40640fd72175d4603');
+
+var_dump(get_object_vars($oid));
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+array(1) {
+  ["oid"]=>
+  string(24) "53e2a1c40640fd72175d4603"
+}
+===DONE===

--- a/tests/bson/bson-objectid-get_properties-002.phpt
+++ b/tests/bson/bson-objectid-get_properties-002.phpt
@@ -1,0 +1,19 @@
+--TEST--
+MongoDB\BSON\ObjectId get_properties handler (foreach)
+--FILE--
+<?php
+
+$oid = new MongoDB\BSON\ObjectId('53e2a1c40640fd72175d4603');
+
+foreach ($oid as $key => $value) {
+    var_dump($key);
+    var_dump($value);
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+string(3) "oid"
+string(24) "53e2a1c40640fd72175d4603"
+===DONE===

--- a/tests/bson/bson-regex-get_properties-001.phpt
+++ b/tests/bson/bson-regex-get_properties-001.phpt
@@ -1,0 +1,20 @@
+--TEST--
+MongoDB\BSON\Regex get_properties handler (get_object_vars)
+--FILE--
+<?php
+
+$regex = new MongoDB\BSON\Regex('regexp', 'i');
+
+var_dump(get_object_vars($regex));
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+array(2) {
+  ["pattern"]=>
+  string(6) "regexp"
+  ["flags"]=>
+  string(1) "i"
+}
+===DONE===

--- a/tests/bson/bson-regex-get_properties-002.phpt
+++ b/tests/bson/bson-regex-get_properties-002.phpt
@@ -1,0 +1,21 @@
+--TEST--
+MongoDB\BSON\Regex get_properties handler (foreach)
+--FILE--
+<?php
+
+$regex = new MongoDB\BSON\Regex('regexp', 'i');
+
+foreach ($regex as $key => $value) {
+    var_dump($key);
+    var_dump($value);
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+string(7) "pattern"
+string(6) "regexp"
+string(5) "flags"
+string(1) "i"
+===DONE===

--- a/tests/bson/bson-symbol-get_properties-001.phpt
+++ b/tests/bson/bson-symbol-get_properties-001.phpt
@@ -1,0 +1,19 @@
+--TEST--
+MongoDB\BSON\Symbol get_properties handler (get_object_vars)
+--FILE--
+<?php
+
+$document = MongoDB\BSON\toPHP(MongoDB\BSON\fromJSON('{"symbol":{"$symbol":"test"}}'));
+$symbol = $document->symbol;
+
+var_dump(get_object_vars($symbol));
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+array(1) {
+  ["symbol"]=>
+  string(4) "test"
+}
+===DONE===

--- a/tests/bson/bson-symbol-get_properties-002.phpt
+++ b/tests/bson/bson-symbol-get_properties-002.phpt
@@ -1,0 +1,20 @@
+--TEST--
+MongoDB\BSON\Symbol get_properties handler (foreach)
+--FILE--
+<?php
+
+$document = MongoDB\BSON\toPHP(MongoDB\BSON\fromJSON('{"symbol":{"$symbol":"test"}}'));
+$symbol = $document->symbol;
+
+foreach ($symbol as $key => $value) {
+    var_dump($key);
+    var_dump($value);
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+string(6) "symbol"
+string(4) "test"
+===DONE===

--- a/tests/bson/bson-timestamp-get_properties-001.phpt
+++ b/tests/bson/bson-timestamp-get_properties-001.phpt
@@ -1,0 +1,20 @@
+--TEST--
+MongoDB\BSON\Timestamp get_properties handler (get_object_vars)
+--FILE--
+<?php
+
+$timestamp = new MongoDB\BSON\Timestamp(1234, 5678);
+
+var_dump(get_object_vars($timestamp));
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+array(2) {
+  ["increment"]=>
+  string(4) "1234"
+  ["timestamp"]=>
+  string(4) "5678"
+}
+===DONE===

--- a/tests/bson/bson-timestamp-get_properties-002.phpt
+++ b/tests/bson/bson-timestamp-get_properties-002.phpt
@@ -1,0 +1,21 @@
+--TEST--
+MongoDB\BSON\Timestamp get_properties handler (foreach)
+--FILE--
+<?php
+
+$timestamp = new MongoDB\BSON\Timestamp(1234, 5678);
+
+foreach ($timestamp as $key => $value) {
+    var_dump($key);
+    var_dump($value);
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+string(9) "increment"
+string(4) "1234"
+string(9) "timestamp"
+string(4) "5678"
+===DONE===

--- a/tests/bson/bson-utcdatetime-get_properties-001.phpt
+++ b/tests/bson/bson-utcdatetime-get_properties-001.phpt
@@ -1,0 +1,18 @@
+--TEST--
+MongoDB\BSON\UTCDateTime get_properties handler (get_object_vars)
+--FILE--
+<?php
+
+$utcdatetime = new MongoDB\BSON\UTCDateTime('1416445411987');
+
+var_dump(get_object_vars($utcdatetime));
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+array(1) {
+  ["milliseconds"]=>
+  string(13) "1416445411987"
+}
+===DONE===

--- a/tests/bson/bson-utcdatetime-get_properties-002.phpt
+++ b/tests/bson/bson-utcdatetime-get_properties-002.phpt
@@ -1,0 +1,19 @@
+--TEST--
+MongoDB\BSON\UTCDateTime get_properties handler (foreach)
+--FILE--
+<?php
+
+$utcdatetime = new MongoDB\BSON\UTCDateTime('1416445411987');
+
+foreach ($utcdatetime as $key => $value) {
+    var_dump($key);
+    var_dump($value);
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+string(12) "milliseconds"
+string(13) "1416445411987"
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1092

This removes a call to `zend_hash_clean()` on successive calls to a BSON object's `get_properties` handler, which can lead to an infinite loop when iterating the object's properties with foreach on PHP 7.x.

For historical reference, the original call to `zend_hash_clean()` was introduced in ad1f3f049f5c101a8b4f89f13e6384bbefb6ef6c for #607 (PHPC-939).

Note: I've only added tests for BSON classes that have a custom `get_properties` handler and utilize the `PHONGO_GET_PROPERTY_HASH_INIT_PROPS()` macro. I do not recall why I originally added  `zend_clean_hash()`, but I assume I was trying to be strict about not inheriting hash state from previous calls.

While testing this, I was surprised to find that iterating the object with `foreach` actually invokes `get_properties` multiple times. If I had to guess, the fact that [`zend_hash_clean()` resets the hash pointer](https://github.com/php/php-src/blob/php-7.2.1/Zend/zend_hash.c#L1333) was causing `foreach` to never advance past the first property.