### PR TITLE
PHPC-1098: Use exactly representable floats in tests

### DIFF
--- a/tests/bson/bson-toPHP-003.phpt
+++ b/tests/bson/bson-toPHP-003.phpt
@@ -55,7 +55,7 @@ $testGroups = array(
         'tests' => array(
             '{ "foo": "yes", "bar" : false }',
             '{ "foo": "no", "array" : [ 5, 6 ] }',
-            '{ "foo": "no", "obj" : { "embedded" : 3.14 } }',
+            '{ "foo": "no", "obj" : { "embedded" : 4.125 } }',
             '{ "foo": "yes", "__pclass": "MyClass" }',
             '{ "foo": "yes", "__pclass": { "$binary": "' . $bMyClass . '", "$type": "80" } }',
             '{ "foo": "yes", "__pclass": { "$binary": "' . $bYourClass . '", "$type": "80" } }',
@@ -114,7 +114,7 @@ $testGroups = array(
         'tests' => array(
             '{ "foo": "yes", "bar" : false }',
             '{ "foo": "no", "array" : [ 5, 6 ] }',
-            '{ "foo": "no", "obj" : { "embedded" : 3.14 } }',
+            '{ "foo": "no", "obj" : { "embedded" : 4.125 } }',
             '{ "foo": "yes", "__pclass": "MyClass" }',
             '{ "foo": "yes", "__pclass" : { "$binary": "' . $bMyClass . '", "$type": "80" } }',
             '{ "foo": "yes", "__pclass" : { "$binary": "' . $bOurClass . '", "$type": "80" } }',
@@ -176,14 +176,14 @@ object(stdClass)#%d (2) {
   }
 }
 
-{ "foo": "no", "obj" : { "embedded" : 3.14 } }
+{ "foo": "no", "obj" : { "embedded" : 4.125 } }
 object(stdClass)#%d (2) {
   ["foo"]=>
   string(2) "no"
   ["obj"]=>
   object(stdClass)#%d (1) {
     ["embedded"]=>
-    float(3.14)
+    float(4.125)
   }
 }
 
@@ -390,14 +390,14 @@ array(2) {
   }
 }
 
-{ "foo": "no", "obj" : { "embedded" : 3.14 } }
+{ "foo": "no", "obj" : { "embedded" : 4.125 } }
 array(2) {
   ["foo"]=>
   string(2) "no"
   ["obj"]=>
   array(1) {
     ["embedded"]=>
-    float(3.14)
+    float(4.125)
   }
 }
 

--- a/tests/bson/bson-toPHP-004.phpt
+++ b/tests/bson/bson-toPHP-004.phpt
@@ -17,7 +17,7 @@ $tests = [
     null,
     true,
     1,
-    3.14,
+    4.125,
     'foo',
     [],
     (object) [],
@@ -139,14 +139,14 @@ object(stdClass)#%d (1) {
   ["x"]=>
   array(1) {
     [0]=>
-    float(3.14)
+    float(4.125)
   }
 }
 object(stdClass)#%d (1) {
   ["x"]=>
   object(stdClass)#%d (1) {
     [%r(0|"0")%r]=>
-    float(3.14)
+    float(4.125)
   }
 }
 object(stdClass)#%d (1) {
@@ -155,7 +155,7 @@ object(stdClass)#%d (1) {
     ["storage":"ArrayObject":private]=>
     array(1) {
       [0]=>
-      float(3.14)
+      float(4.125)
     }
   }
 }

--- a/tests/bson/bug0341.phpt
+++ b/tests/bson/bug0341.phpt
@@ -8,7 +8,7 @@ require_once __DIR__ . '/../utils/tools.php';
 $tests = array(
     '{ "foo": "yes", "bar" : false }',
     '{ "foo": "no", "array" : [ 5, 6 ] }',
-    '{ "foo": "no", "obj" : { "embedded" : 3.14 } }',
+    '{ "foo": "no", "obj" : { "embedded" : 4.125 } }',
 );
 
 foreach ($tests as $test) {
@@ -43,7 +43,7 @@ object(stdClass)#%d (2) {
   ["obj"]=>
   object(stdClass)#%d (1) {
     ["embedded"]=>
-    float(3.14)
+    float(4.125)
   }
 }
 ===DONE===

--- a/tests/writeResult/writeresult-getupsertedids-002.phpt
+++ b/tests/writeResult/writeresult-getupsertedids-002.phpt
@@ -16,7 +16,7 @@ $tests = [
     null,
     true,
     1,
-    3.14,
+    4.125,
     'foo',
     (object) [],
     new MongoDB\BSON\Binary('foo', MongoDB\BSON\Binary::TYPE_GENERIC),
@@ -52,7 +52,7 @@ array(13) {
   [2]=>
   int(1)
   [3]=>
-  float(3.14)
+  float(4.125)
   [4]=>
   string(3) "foo"
   [5]=>


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1098