### PR TITLE
PHPC-1100: Require SSL or crypto as needed in tests

### DIFF
--- a/tests/causal-consistency/causal-consistency-001.phpt
+++ b/tests/causal-consistency/causal-consistency-001.phpt
@@ -2,6 +2,7 @@
 Causal consistency: new session has no operation time
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
 <?php NEEDS('REPLICASET'); ?>
 --FILE--
 <?php

--- a/tests/causal-consistency/causal-consistency-002.phpt
+++ b/tests/causal-consistency/causal-consistency-002.phpt
@@ -2,6 +2,7 @@
 Causal consistency: first read in session does not include afterClusterTime
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
 <?php NEEDS('REPLICASET'); ?>
 --FILE--
 <?php

--- a/tests/causal-consistency/causal-consistency-003.phpt
+++ b/tests/causal-consistency/causal-consistency-003.phpt
@@ -2,6 +2,7 @@
 Causal consistency: first read or write in session updates operationTime
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
 <?php NEEDS('REPLICASET'); CLEANUP(REPLICASET); ?>
 --FILE--
 <?php

--- a/tests/causal-consistency/causal-consistency-004.phpt
+++ b/tests/causal-consistency/causal-consistency-004.phpt
@@ -2,6 +2,7 @@
 Causal consistency: first read or write in session updates operationTime (even on error)
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
 <?php NEEDS('REPLICASET'); CLEANUP(REPLICASET); ?>
 --FILE--
 <?php

--- a/tests/causal-consistency/causal-consistency-005.phpt
+++ b/tests/causal-consistency/causal-consistency-005.phpt
@@ -2,6 +2,7 @@
 Causal consistency: second read's afterClusterTime uses last reply's operationTime
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
 <?php NEEDS('REPLICASET'); CLEANUP(REPLICASET);  ?>
 --FILE--
 <?php

--- a/tests/causal-consistency/causal-consistency-006.phpt
+++ b/tests/causal-consistency/causal-consistency-006.phpt
@@ -2,6 +2,7 @@
 Causal consistency: second read's afterClusterTime uses last reply's operationTime (even on error)
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
 <?php NEEDS('REPLICASET'); CLEANUP(REPLICASET);  ?>
 --FILE--
 <?php

--- a/tests/causal-consistency/causal-consistency-007.phpt
+++ b/tests/causal-consistency/causal-consistency-007.phpt
@@ -2,6 +2,7 @@
 Causal consistency: reads in non-causally consistent session never include afterClusterTime
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
 <?php NEEDS('REPLICASET'); ?>
 --FILE--
 <?php

--- a/tests/causal-consistency/causal-consistency-008.phpt
+++ b/tests/causal-consistency/causal-consistency-008.phpt
@@ -2,6 +2,7 @@
 Causal consistency: default read concern includes afterClusterTime but not level
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
 <?php NEEDS('REPLICASET'); ?>
 --FILE--
 <?php

--- a/tests/causal-consistency/causal-consistency-009.phpt
+++ b/tests/causal-consistency/causal-consistency-009.phpt
@@ -2,6 +2,7 @@
 Causal consistency: custom read concern merges afterClusterTime and level
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
 <?php NEEDS('REPLICASET'); ?>
 --FILE--
 <?php

--- a/tests/causal-consistency/causal-consistency-010.phpt
+++ b/tests/causal-consistency/causal-consistency-010.phpt
@@ -2,6 +2,7 @@
 Causal consistency: unacknowledged write does not update operationTime
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
 <?php NEEDS('REPLICASET'); CLEANUP(REPLICASET); ?>
 --FILE--
 <?php

--- a/tests/causal-consistency/causal-consistency-011.phpt
+++ b/tests/causal-consistency/causal-consistency-011.phpt
@@ -2,6 +2,7 @@
 Causal consistency: $clusterTime is not sent in commands to unsupported deployments
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
 <?php NEEDS('STANDALONE'); NEEDS_ATLEAST_MONGODB_VERSION(STANDALONE, "3.6"); ?>
 --FILE--
 <?php

--- a/tests/causal-consistency/causal-consistency-012.phpt
+++ b/tests/causal-consistency/causal-consistency-012.phpt
@@ -2,6 +2,7 @@
 Causal consistency: $clusterTime is sent in commands to supported deployments
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
 <?php NEEDS('REPLICASET'); ?>
 --FILE--
 <?php

--- a/tests/connect/bug0720.phpt
+++ b/tests/connect/bug0720.phpt
@@ -2,6 +2,7 @@
 PHPC-720: Do not persist SSL streams to avoid SSL reinitialization errors
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_SSL(); ?>
 <?php NEEDS('STANDALONE_SSL'); ?>
 --FILE--
 <?php

--- a/tests/connect/bug1045.phpt
+++ b/tests/connect/bug1045.phpt
@@ -2,6 +2,7 @@
 PHPC-1045: Segfault if username is not provided for SCRAM-SHA-1 authMechanism
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_SSL(); ?>
 <?php NEEDS('STANDALONE'); CLEANUP(STANDALONE); ?>
 --FILE--
 <?php

--- a/tests/connect/standalone-plain-0002.phpt
+++ b/tests/connect/standalone-plain-0002.phpt
@@ -2,6 +2,7 @@
 Connect to MongoDB with using PLAIN auth mechanism #002
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_SSL(); ?>
 <?php NEEDS('STANDALONE_PLAIN'); ?>
 --FILE--
 <?php

--- a/tests/connect/standalone-ssl-no_verify-001.phpt
+++ b/tests/connect/standalone-ssl-no_verify-001.phpt
@@ -2,6 +2,7 @@
 Connect to MongoDB with SSL and no host/cert verification
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_SSL(); ?>
 <?php NEEDS('STANDALONE_SSL'); ?>
 --FILE--
 <?php

--- a/tests/connect/standalone-ssl-no_verify-002.phpt
+++ b/tests/connect/standalone-ssl-no_verify-002.phpt
@@ -2,6 +2,7 @@
 Connect to MongoDB with SSL and no host/cert verification (context options)
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_SSL(); ?>
 <?php NEEDS('STANDALONE_SSL'); ?>
 --FILE--
 <?php

--- a/tests/connect/standalone-ssl-verify_cert-001.phpt
+++ b/tests/connect/standalone-ssl-verify_cert-001.phpt
@@ -2,6 +2,7 @@
 Connect to MongoDB with SSL and cert verification
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_SSL(); ?>
 <?php NEEDS('STANDALONE_SSL'); ?>
 --FILE--
 <?php

--- a/tests/connect/standalone-ssl-verify_cert-002.phpt
+++ b/tests/connect/standalone-ssl-verify_cert-002.phpt
@@ -2,6 +2,7 @@
 Connect to MongoDB with SSL and cert verification (context options)
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_SSL(); ?>
 <?php NEEDS('STANDALONE_SSL'); ?>
 --FILE--
 <?php

--- a/tests/connect/standalone-ssl-verify_cert-error-001.phpt
+++ b/tests/connect/standalone-ssl-verify_cert-error-001.phpt
@@ -2,6 +2,7 @@
 Connect to MongoDB with SSL and cert verification error
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_SSL(); ?>
 <?php NEEDS('STANDALONE_SSL'); ?>
 --FILE--
 <?php

--- a/tests/connect/standalone-ssl-verify_cert-error-002.phpt
+++ b/tests/connect/standalone-ssl-verify_cert-error-002.phpt
@@ -2,6 +2,7 @@
 Connect to MongoDB with SSL and cert verification error (context options)
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_SSL(); ?>
 <?php NEEDS('STANDALONE_SSL'); ?>
 --FILE--
 <?php

--- a/tests/connect/standalone-x509-auth-001.phpt
+++ b/tests/connect/standalone-x509-auth-001.phpt
@@ -2,6 +2,7 @@
 Connect to MongoDB with SSL and X509 auth
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_SSL(); ?>
 <?php NEEDS('STANDALONE_X509'); ?>
 --FILE--
 <?php

--- a/tests/connect/standalone-x509-auth-002.phpt
+++ b/tests/connect/standalone-x509-auth-002.phpt
@@ -2,6 +2,7 @@
 Connect to MongoDB with SSL and X509 auth (stream context)
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_SSL(); ?>
 <?php NEEDS('STANDALONE_X509'); ?>
 --FILE--
 <?php

--- a/tests/connect/standalone-x509-error-0001.phpt
+++ b/tests/connect/standalone-x509-error-0001.phpt
@@ -2,6 +2,7 @@
 X509 connection should not reuse previous stream after an auth failure
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_SSL(); ?>
 <?php NEEDS('STANDALONE_X509'); ?>
 --FILE--
 <?php

--- a/tests/manager/bug0572.phpt
+++ b/tests/manager/bug0572.phpt
@@ -2,6 +2,7 @@
 PHPC-572: Ensure stream context does not go out of scope before socket init
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_SSL(); ?>
 <?php NEEDS('STANDALONE_SSL'); ?>
 --FILE--
 <?php

--- a/tests/manager/manager-ctor-ssl-001.phpt
+++ b/tests/manager/manager-ctor-ssl-001.phpt
@@ -1,5 +1,8 @@
 --TEST--
 MongoDB\Driver\Manager::__construct(): ssl option does not require driverOptions
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_SSL(); ?>
 --FILE--
 <?php
 

--- a/tests/manager/manager-set-uri-options-002.phpt
+++ b/tests/manager/manager-set-uri-options-002.phpt
@@ -2,6 +2,7 @@
 MongoDB\Driver\Manager: Logging into MongoDB using credentials from $options
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_SSL(); ?>
 <?php NEEDS('STANDALONE_SSL'); ?>
 --FILE--
 <?php

--- a/tests/retryable-writes/retryable-writes-001.phpt
+++ b/tests/retryable-writes/retryable-writes-001.phpt
@@ -2,6 +2,7 @@
 Retryable writes: supported single-statement operations include transaction IDs
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
 <?php NEEDS('REPLICASET'); CLEANUP(REPLICASET); ?>
 --FILE--
 <?php

--- a/tests/retryable-writes/retryable-writes-002.phpt
+++ b/tests/retryable-writes/retryable-writes-002.phpt
@@ -2,6 +2,7 @@
 Retryable writes: supported multi-statement operations include transaction IDs
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
 <?php NEEDS('REPLICASET'); CLEANUP(REPLICASET); ?>
 --FILE--
 <?php

--- a/tests/retryable-writes/retryable-writes-003.phpt
+++ b/tests/retryable-writes/retryable-writes-003.phpt
@@ -2,6 +2,7 @@
 Retryable writes: unsupported operations do not include transaction IDs
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
 <?php NEEDS('REPLICASET'); CLEANUP(REPLICASET); ?>
 --FILE--
 <?php

--- a/tests/retryable-writes/retryable-writes-004.phpt
+++ b/tests/retryable-writes/retryable-writes-004.phpt
@@ -4,6 +4,7 @@ Retryable writes: unacknowledged write operations do not include transaction IDs
 Depends on CDRIVER-2432
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
 <?php NEEDS('REPLICASET'); CLEANUP(REPLICASET); ?>
 --FILE--
 <?php

--- a/tests/retryable-writes/retryable-writes-005.phpt
+++ b/tests/retryable-writes/retryable-writes-005.phpt
@@ -2,6 +2,7 @@
 Retryable writes: non-write command methods do not include transaction IDs
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
 <?php NEEDS('REPLICASET'); CLEANUP(REPLICASET); ?>
 --FILE--
 <?php

--- a/tests/session/session-001.phpt
+++ b/tests/session/session-001.phpt
@@ -2,6 +2,7 @@
 MongoDB\Driver\Session spec test: Pool is LIFO
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
 <?php NEEDS('STANDALONE'); NEEDS_ATLEAST_MONGODB_VERSION(STANDALONE, "3.6"); ?>
 --FILE--
 <?php

--- a/tests/session/session-002.phpt
+++ b/tests/session/session-002.phpt
@@ -2,6 +2,7 @@
 MongoDB\Driver\Session spec test: $clusterTime in commands
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
 <?php NEEDS('REPLICASET'); CLEANUP(REPLICASET); ?>
 --FILE--
 <?php

--- a/tests/session/session-003.phpt
+++ b/tests/session/session-003.phpt
@@ -2,6 +2,7 @@
 MongoDB\Driver\Session spec test: session cannot be used for different clients
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
 <?php NEEDS('STANDALONE'); NEEDS_ATLEAST_MONGODB_VERSION(STANDALONE, "3.6"); CLEANUP(STANDALONE); ?>
 --FILE--
 <?php

--- a/tests/session/session-advanceClusterTime-001.phpt
+++ b/tests/session/session-advanceClusterTime-001.phpt
@@ -2,6 +2,7 @@
 MongoDB\Driver\Session::advanceClusterTime()
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
 <?php NEEDS('REPLICASET'); ?>
 --FILE--
 <?php

--- a/tests/session/session-advanceOperationTime-001.phpt
+++ b/tests/session/session-advanceOperationTime-001.phpt
@@ -2,6 +2,7 @@
 MongoDB\Driver\Session::advanceOperationTime()
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
 <?php NEEDS('REPLICASET'); ?>
 --FILE--
 <?php

--- a/tests/session/session-advanceOperationTime-002.phpt
+++ b/tests/session/session-advanceOperationTime-002.phpt
@@ -2,6 +2,7 @@
 MongoDB\Driver\Session::advanceOperationTime() with Timestamp
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
 <?php NEEDS('REPLICASET'); ?>
 --FILE--
 <?php

--- a/tests/session/session-advanceOperationTime-003.phpt
+++ b/tests/session/session-advanceOperationTime-003.phpt
@@ -2,6 +2,7 @@
 MongoDB\Driver\Session::advanceOperationTime() with TimestampInterface
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
 <?php NEEDS('REPLICASET'); ?>
 --FILE--
 <?php

--- a/tests/session/session-advanceOperationTime_error-001.phpt
+++ b/tests/session/session-advanceOperationTime_error-001.phpt
@@ -2,6 +2,7 @@
 MongoDB\Driver\Session::advanceOperationTime() with TimestampInterface exceptions
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
 <?php NEEDS('REPLICASET'); ?>
 --FILE--
 <?php

--- a/tests/session/session-debug-001.phpt
+++ b/tests/session/session-debug-001.phpt
@@ -2,6 +2,7 @@
 MongoDB\Driver\Session debug output (before an operation)
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
 <?php NEEDS('STANDALONE'); NEEDS_ATLEAST_MONGODB_VERSION(STANDALONE, "3.6"); ?>
 --FILE--
 <?php

--- a/tests/session/session-debug-002.phpt
+++ b/tests/session/session-debug-002.phpt
@@ -2,6 +2,7 @@
 MongoDB\Driver\Session debug output (after an operation)
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
 <?php NEEDS('REPLICASET'); ?>
 --FILE--
 <?php

--- a/tests/session/session-debug-003.phpt
+++ b/tests/session/session-debug-003.phpt
@@ -2,6 +2,7 @@
 MongoDB\Driver\Session debug output (causalConsistency=false)
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
 <?php NEEDS('STANDALONE'); NEEDS_ATLEAST_MONGODB_VERSION(STANDALONE, "3.6"); ?>
 --FILE--
 <?php

--- a/tests/session/session-getClusterTime-001.phpt
+++ b/tests/session/session-getClusterTime-001.phpt
@@ -2,6 +2,7 @@
 MongoDB\Driver\Session::getClusterTime()
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
 <?php NEEDS('REPLICASET'); ?>
 --FILE--
 <?php

--- a/tests/session/session-getLogicalSessionId-001.phpt
+++ b/tests/session/session-getLogicalSessionId-001.phpt
@@ -2,6 +2,7 @@
 MongoDB\Driver\Session::getLogicalSessionId()
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
 <?php NEEDS('STANDALONE'); NEEDS_ATLEAST_MONGODB_VERSION(STANDALONE, "3.6"); ?>
 --FILE--
 <?php

--- a/tests/session/session-getOperationTime-001.phpt
+++ b/tests/session/session-getOperationTime-001.phpt
@@ -2,6 +2,7 @@
 MongoDB\Driver\Session::getOperationTime()
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
 <?php NEEDS('REPLICASET'); ?>
 --FILE--
 <?php

--- a/tests/utils/tools.php
+++ b/tests/utils/tools.php
@@ -175,14 +175,55 @@ function NEEDS_STORAGE_ENGINE($uri, $engine) {
     }
 }
 
-/* Checks that libmongoc is using one of the following SSL libraries, denoted by
- * the value of "libmongoc SSL library" in phpinfo() output. Possible values are
- * "OpenSSL", "LibreSSL", "Secure Transport", and "Secure Channel". */
-function NEEDS_SSL(array $libs)
+/* Checks that libmongoc supports crypto. If one or more libaries are provided,
+ * additionally check the value of "libmongoc crypto library" as reported by
+ * phpinfo(). Possible values are "libcrypto", "Common Crypto", and "CNG". */
+function NEEDS_CRYPTO(array $libs = [])
 {
     ob_start();
     phpinfo(INFO_MODULES);
     $info = ob_get_clean();
+
+    $pattern = sprintf('/^%s$/m', preg_quote('libmongoc crypto => enabled'));
+
+    if (preg_match($pattern, $info) !== 1) {
+        exit('skip Crypto is not supported');
+    }
+
+    if (empty($libs)) {
+        return;
+    }
+
+    $pattern = sprintf('/^%s([\w ]+)$/m', preg_quote('libmongoc crypto library => '));
+
+    if (preg_match($pattern, $info, $matches) !== 1) {
+        exit('skip Could not determine crypto library');
+    }
+
+    if (!in_array($matches[1], $libs)) {
+        exit('skip Needs crypto library ' . implode(', ', $libs) . ', but found ' . $matches[1]);
+    }
+}
+
+/* Checks that libmongoc supports SSL. If one or more libaries are provided,
+ * additionally check the value of "libmongoc SSL library" as reported by
+ * phpinfo(). Possible values are "OpenSSL", "LibreSSL", "Secure Transport", and
+ * "Secure Channel". */
+function NEEDS_SSL(array $libs = [])
+{
+    ob_start();
+    phpinfo(INFO_MODULES);
+    $info = ob_get_clean();
+
+    $pattern = sprintf('/^%s$/m', preg_quote('libmongoc SSL => enabled'));
+
+    if (preg_match($pattern, $info) !== 1) {
+        exit('skip SSL is not supported');
+    }
+
+    if (empty($libs)) {
+        return;
+    }
 
     $pattern = sprintf('/^%s([\w ]+)$/m', preg_quote('libmongoc SSL library => '));
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1100

This addresses test failures when the driver is compiled without SSL.

Tested with `./configure --with-mongodb-ssl=no`.

Note that unrecognized values (e.g. `--with-mongodb-ssl=whatever`) functions similarly to `no`:

```
checking whether to enable crypto and TLS... whatever
checking deprecated option for OpenSSL library path... auto
checking for pkg-config... /usr/bin/pkg-config
checking pkg-config is at least version 0.9.0... yes
checking which TLS library to use... whatever
checking whether to use system crypto profile... no
checking deprecated option for whether to use system crypto profile... no
```

This skips all of the `AS_IF` branches in `CheckSSL.m4` and simply hits the following:

```
AC_MSG_CHECKING([which TLS library to use])
AC_MSG_RESULT([$PHP_MONGODB_SSL])
```