### PR TITLE
Simplify Matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: php
 
 addons:
@@ -8,26 +9,11 @@ addons:
 
 matrix:
   include:
-    - os: linux
-      dist: trusty
-      sudo: false
-      php: 5.5
-    - os: linux
-      dist: trusty
-      sudo: false
-      php: 5.6
-    - os: linux
-      dist: trusty
-      sudo: false
-      php: 7.0
-    - os: linux
-      dist: trusty
-      sudo: false
-      php: 7.1
-    - os: linux
-      dist: trusty
-      sudo: false
-      php: 7.2
+    - php: 5.5
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+    - php: 7.2
 
 services:
   - mongodb


### PR DESCRIPTION
dist: trusty is now the default container for travis containers 
os: linux is always true unless otherwise specified in the matrix
only need to specify sudo: false once to run containers

Note: if you need sudo: true for a single job in the matrix you can add it to that single matrix line
Note2: if you need a different dist for a single job in the matrix can add it to that single matrix line
Note3: if you need a different os for a single job in the matrix can add it to that single matrix line
no need for all the duplication