### PR TITLE
PHPC-1029: Remove unused Command options in test

### DIFF
--- a/src/MongoDB/Command.c
+++ b/src/MongoDB/Command.c
@@ -64,7 +64,7 @@ static bool php_phongo_command_init(php_phongo_command_t *intern, zval *filter, 
 	php_phongo_zval_to_bson(filter, PHONGO_BSON_NONE, intern->bson, NULL TSRMLS_CC);
 
 	/* Note: if any exceptions are thrown, we can simply return as PHP will
-	* invoke php_phongo_query_free_object to destruct the object. */
+	 * invoke php_phongo_query_free_object to destruct the object. */
 	if (EG(exception)) {
 		return false;
 	}

--- a/tests/command/cursor-tailable-001.phpt
+++ b/tests/command/cursor-tailable-001.phpt
@@ -1,5 +1,5 @@
 --TEST--
-MongoDB\Driver\Cursor tailable iteration with awaitData and maxAwaitTimeMS options
+MongoDB\Driver\Command tailable cursor iteration with maxAwaitTimeMS option
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php NEEDS('REPLICASET'); CLEANUP(REPLICASET); ?>
@@ -27,8 +27,6 @@ $command = new MongoDB\Driver\Command([
     'pipeline' => $pipeline,
     'cursor' => ['batchSize' => 0],
 ], [
-    'tailable' => true,
-    'awaitData' => true,
     'maxAwaitTimeMS' => 100,
 ]);
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1029

Using $changeStream in an aggregation pipeline implies a tailable/awaitData cursor. Unlike Query, Command does not take these options.

I noticed this while updating docs for the Command constructor.