### PR TITLE
PHPC-1132, PHPC-1133: Remove HHVM checks and clean up includes

### DIFF
--- a/php_phongo.c
+++ b/php_phongo.c
@@ -2355,8 +2355,6 @@ void phongo_manager_init(php_phongo_manager_t* manager, const char* uri_string, 
 	}
 
 #ifdef MONGOC_ENABLE_SSL
-	/* Construct SSL options even if SSL is not enabled so that exceptions can
-	 * be thrown for unsupported driver options. */
 	ssl_opt = php_phongo_make_ssl_opt(driverOptions TSRMLS_CC);
 
 	/* An exception may be thrown during SSL option creation */

--- a/tests/bson/bson-binary_error-001.phpt
+++ b/tests/bson/bson-binary_error-001.phpt
@@ -1,7 +1,5 @@
 --TEST--
 MongoDB\BSON\Binary #001 error
---SKIPIF--
-<?php if (defined("HHVM_VERSION_ID")) exit("skip HHVM handles parameter parsing differently"); ?>
 --FILE--
 <?php
 

--- a/tests/bson/bson-decimal128_error-001.phpt
+++ b/tests/bson/bson-decimal128_error-001.phpt
@@ -2,7 +2,6 @@
 MongoDB\BSON\Decimal128 requires valid decimal string
 --SKIPIF--
 <?php if (!class_exists('MongoDB\BSON\Decimal128')) { die('skip MongoDB\BSON\Decimal128 is not available'); } ?>
-<?php if (defined("HHVM_VERSION_ID")) exit("skip HHVM handles parameter parsing differently"); ?>
 --FILE--
 <?php
 

--- a/tests/bson/bson-encode-003.phpt
+++ b/tests/bson/bson-encode-003.phpt
@@ -1,7 +1,5 @@
 --TEST--
 BSON encoding: Encoding objects into BSON representation
---SKIPIF--
-<?php if (defined("HHVM_VERSION_ID")) exit("skip HHVM encodes __pclass last"); ?>
 --FILE--
 <?php
 

--- a/tests/bson/bson-encode-004.phpt
+++ b/tests/bson/bson-encode-004.phpt
@@ -1,7 +1,5 @@
 --TEST--
 BSON encoding: Object Document Mapper
---SKIPIF--
-<?php if (defined("HHVM_VERSION_ID")) exit("skip HHVM encodes __pclass last"); ?>
 --FILE--
 <?php
 

--- a/tests/bson/bson-javascript_error-001.phpt
+++ b/tests/bson/bson-javascript_error-001.phpt
@@ -1,7 +1,5 @@
 --TEST--
 MongoDB\BSON\Javascript #001 error
---SKIPIF--
-<?php if (defined("HHVM_VERSION_ID")) exit("skip HHVM handles parameter parsing differently"); ?>
 --FILE--
 <?php
 

--- a/tests/bson/bson-objectid_error-001.phpt
+++ b/tests/bson/bson-objectid_error-001.phpt
@@ -1,7 +1,5 @@
 --TEST--
 MongoDB\BSON\ObjectId #001 error
---SKIPIF--
-<?php if (defined("HHVM_VERSION_ID")) exit("skip HHVM handles parameter parsing differently"); ?>
 --FILE--
 <?php
 

--- a/tests/bson/bson-regex_error-001.phpt
+++ b/tests/bson/bson-regex_error-001.phpt
@@ -1,7 +1,5 @@
 --TEST--
 MongoDB\BSON\Regex #001 error
---SKIPIF--
-<?php if (defined("HHVM_VERSION_ID")) exit("skip HHVM handles parameter parsing differently"); ?>
 --FILE--
 <?php
 

--- a/tests/bson/bson-timestamp_error-001.phpt
+++ b/tests/bson/bson-timestamp_error-001.phpt
@@ -1,7 +1,5 @@
 --TEST--
 MongoDB\BSON\Timestamp #001 error
---SKIPIF--
-<?php if (defined("HHVM_VERSION_ID")) exit("skip HHVM handles parameter parsing differently"); ?>
 --FILE--
 <?php
 

--- a/tests/bson/bson-toPHP-002.phpt
+++ b/tests/bson/bson-toPHP-002.phpt
@@ -1,7 +1,5 @@
 --TEST--
 MongoDB\BSON\fromPHP(): Null type map values imply default behavior
---SKIPIF--
-<?php if (defined("HHVM_VERSION_ID")) exit("skip HHVM encodes __pclass last"); ?>
 --FILE--
 <?php
 

--- a/tests/bson/bson-utcdatetime-int-size-001.phpt
+++ b/tests/bson/bson-utcdatetime-int-size-001.phpt
@@ -1,7 +1,5 @@
 --TEST--
 MongoDB\BSON\UTCDateTime integer parsing from string
---SKIPIF--
-<?php if (defined("HHVM_VERSION_ID")) exit("skip HHVM implements only an older version of DateTime"); ?>
 --INI--
 date.timezone=UTC
 error_reporting=-1

--- a/tests/bson/bson-utcdatetime-int-size-002.phpt
+++ b/tests/bson/bson-utcdatetime-int-size-002.phpt
@@ -2,7 +2,6 @@
 MongoDB\BSON\UTCDateTime integer parsing from number (64-bit)
 --SKIPIF--
 <?php if (8 !== PHP_INT_SIZE) { die('skip Only for 64-bit platform'); } ?>
-<?php if (defined("HHVM_VERSION_ID")) exit("skip HHVM implements only an older version of DateTime"); ?>
 --INI--
 date.timezone=UTC
 error_reporting=-1

--- a/tests/bson/bug0631.phpt
+++ b/tests/bson/bug0631.phpt
@@ -1,7 +1,5 @@
 --TEST--
 PHPC-631: UTCDateTime::toDateTime() may return object that cannot be serialized
---SKIPIF--
-<?php if (defined("HHVM_VERSION_ID")) exit("skip HHVM uses 'UTC' instead of '+00:00'"); ?>
 --INI--
 date.timezone=UTC
 --FILE--

--- a/tests/bulk/bug0667.phpt
+++ b/tests/bulk/bug0667.phpt
@@ -1,10 +1,7 @@
 --TEST--
 PHPC-667: BulkWrite::insert() does not generate ObjectId if another field has "_id" prefix
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 --FILE--
 <?php
-require_once __DIR__ . "/../utils/basic.inc";
 
 $bulk = new MongoDB\Driver\BulkWrite;
 var_dump($bulk->insert(['_ids' => 1]));

--- a/tests/bulk/bulkwrite-count-001.phpt
+++ b/tests/bulk/bulkwrite-count-001.phpt
@@ -1,10 +1,7 @@
 --TEST--
 MongoDB\Driver\BulkWrite::count() should return the number of operations
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 --FILE--
 <?php
-require_once __DIR__ . "/../utils/basic.inc";
 
 $bulk = new MongoDB\Driver\BulkWrite;
 var_dump($bulk->count());

--- a/tests/bulk/bulkwrite-countable-001.phpt
+++ b/tests/bulk/bulkwrite-countable-001.phpt
@@ -1,10 +1,7 @@
 --TEST--
 MongoDB\Driver\BulkWrite implements Countable
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 --FILE--
 <?php
-require_once __DIR__ . "/../utils/basic.inc";
 
 $bulk = new MongoDB\Driver\BulkWrite;
 var_dump($bulk instanceof Countable);

--- a/tests/bulk/bulkwrite-debug-001.phpt
+++ b/tests/bulk/bulkwrite-debug-001.phpt
@@ -1,10 +1,7 @@
 --TEST--
 MongoDB\Driver\BulkWrite debug output before execution
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 --FILE--
 <?php
-require_once __DIR__ . "/../utils/basic.inc";
 
 $tests = [
     [],

--- a/tests/cursor/cursor-get_iterator-002.phpt
+++ b/tests/cursor/cursor-get_iterator-002.phpt
@@ -1,7 +1,6 @@
 --TEST--
 MongoDB\Driver\Cursor get_iterator handler does not yield multiple iterators (IteratorIterator)
 --SKIPIF--
-<?php if (defined("HHVM_VERSION_ID")) exit("skip HHVM cannot detect the *wrapping* of a Cursor"); ?>
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php NEEDS('STANDALONE'); CLEANUP(STANDALONE); ?>
 --FILE--

--- a/tests/functional/phpinfo-1.phpt
+++ b/tests/functional/phpinfo-1.phpt
@@ -1,7 +1,5 @@
 --TEST--
 phpinfo() reports mongodb.debug (no value)
---SKIPIF--
-<?php if (defined("HHVM_VERSION_ID")) exit("skip HHVM does not do phpinfo() this way"); ?>
 --FILE--
 <?php
 

--- a/tests/functional/phpinfo-2.phpt
+++ b/tests/functional/phpinfo-2.phpt
@@ -2,8 +2,6 @@
 phpinfo() reports mongodb.debug (default and overridden)
 --INI--
 mongodb.debug=stderr
---SKIPIF--
-<?php if (defined("HHVM_VERSION_ID")) exit("skip HHVM does not do phpinfo() this way"); ?>
 --FILE--
 <?php
 

--- a/tests/manager/bug0940-001.phpt
+++ b/tests/manager/bug0940-001.phpt
@@ -2,6 +2,7 @@
 PHPC-940: php_phongo_free_ssl_opt() attempts to free interned strings
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_SSL(); /* SSL opts are ignored without MONGOC_ENABLE_SSL */ ?>
 --FILE--
 <?php
 

--- a/tests/manager/bug0940-002.phpt
+++ b/tests/manager/bug0940-002.phpt
@@ -2,6 +2,7 @@
 PHPC-940: php_phongo_free_ssl_opt() attempts to free interned strings (context option)
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_SSL(); /* SSL opts are ignored without MONGOC_ENABLE_SSL */ ?>
 --FILE--
 <?php
 

--- a/tests/manager/manager-ctor-002.phpt
+++ b/tests/manager/manager-ctor-002.phpt
@@ -1,13 +1,9 @@
 --TEST--
 MongoDB\Driver\Manager::__construct() with URI
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
-<?php NEEDS('STANDALONE'); CLEANUP(STANDALONE); ?>
 --FILE--
 <?php
-require_once __DIR__ . "/../utils/basic.inc";
 
-$manager = new MongoDB\Driver\Manager(STANDALONE);
+$manager = new MongoDB\Driver\Manager('mongodb://127.0.0.1/');
 
 ?>
 ===DONE===

--- a/tests/manager/manager-ctor-003.phpt
+++ b/tests/manager/manager-ctor-003.phpt
@@ -1,7 +1,5 @@
 --TEST--
 MongoDB\Driver\Manager::__construct() URI defaults to "mongodb://127.0.0.1/"
---SKIPIF--
-<?php if (defined("HHVM_VERSION_ID")) exit("skip HHVM uses HHVM's logging functionality, and hence can't catch this"); ?>
 --FILE--
 <?php
 

--- a/tests/manager/manager-ctor_error-001.phpt
+++ b/tests/manager/manager-ctor_error-001.phpt
@@ -1,7 +1,5 @@
 --TEST--
 MongoDB\Driver\Manager::__construct(): too many arguments
---SKIPIF--
-<?php if (defined("HHVM_VERSION_ID")) exit("skip HHVM throws Exception instead of InvalidArgumentException"); ?>
 --FILE--
 <?php
 

--- a/tests/manager/manager-executeBulkWrite_error-007.phpt
+++ b/tests/manager/manager-executeBulkWrite_error-007.phpt
@@ -1,7 +1,5 @@
 --TEST--
 MongoDB\Driver\Manager::executeBulkWrite() should not issue warning before exception
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";

--- a/tests/manager/manager-executeCommand_error-001.phpt
+++ b/tests/manager/manager-executeCommand_error-001.phpt
@@ -1,7 +1,5 @@
 --TEST--
 MongoDB\Driver\Manager::executeCommand() should not issue warning before exception
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";

--- a/tests/manager/manager-executeQuery_error-001.phpt
+++ b/tests/manager/manager-executeQuery_error-001.phpt
@@ -1,7 +1,5 @@
 --TEST--
 MongoDB\Driver\Manager::executeQuery() should not issue warning before exception
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";

--- a/tests/manager/manager-getreadconcern-001.phpt
+++ b/tests/manager/manager-getreadconcern-001.phpt
@@ -1,20 +1,17 @@
 --TEST--
 MongoDB\Driver\Manager::getReadConcern()
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"?>
 --FILE--
 <?php
-require_once __DIR__ . "/../utils/basic.inc";
 
 $tests = [
-    [STANDALONE, []],
-    [STANDALONE . '/?readconcernlevel=local', []],
-    [STANDALONE . '/?readconcernlevel=majority', []],
-    [STANDALONE . '/?readconcernlevel=not-yet-supported', []],
-    [STANDALONE, ['readconcernlevel' => 'local']],
-    [STANDALONE, ['readconcernlevel' => 'majority']],
-    [STANDALONE, ['readconcernlevel' => 'not-yet-supported']],
-    [STANDALONE . '/?readconcernlevel=local', ['readconcernlevel' => 'majority']],
+    [null, []],
+    ['mongodb://127.0.0.1/?readconcernlevel=local', []],
+    ['mongodb://127.0.0.1/?readconcernlevel=majority', []],
+    ['mongodb://127.0.0.1/?readconcernlevel=not-yet-supported', []],
+    [null, ['readconcernlevel' => 'local']],
+    [null, ['readconcernlevel' => 'majority']],
+    [null, ['readconcernlevel' => 'not-yet-supported']],
+    ['mongodb://127.0.0.1/?readconcernlevel=local', ['readconcernlevel' => 'majority']],
 ];
 
 foreach ($tests as $i => $test) {

--- a/tests/manager/manager-getreadpreference-001.phpt
+++ b/tests/manager/manager-getreadpreference-001.phpt
@@ -1,19 +1,16 @@
 --TEST--
 MongoDB\Driver\Manager::getReadPreference()
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"?>
 --FILE--
 <?php
-require_once __DIR__ . "/../utils/basic.inc";
 
 $tests = array(
-    array(STANDALONE, array()),
-    array(STANDALONE . '/?readPreference=secondary', array()),
-    array(STANDALONE, array('readPreference' => 'primaryPreferred')),
-    array(STANDALONE . '/?readPreference=secondary', array('readPreference' => 'secondaryPreferred')),
-    array(STANDALONE . '/?readPreference=secondary&readPreferenceTags=dc:ny,use:reports&readPreferenceTags=', array()),
-    array(STANDALONE . '/?readPreference=secondary', array('readPreferenceTags' => array(array('dc' => 'ny', 'use' => 'reports'), array()))),
-    array(STANDALONE . '/?readPreference=secondary&readPreferenceTags=dc:ny,use:reports', array('readPreferenceTags' => array(array('dc' => 'ca')))),
+    array(null, array()),
+    array('mongodb://127.0.0.1/?readPreference=secondary', array()),
+    array(null, array('readPreference' => 'primaryPreferred')),
+    array('mongodb://127.0.0.1/?readPreference=secondary', array('readPreference' => 'secondaryPreferred')),
+    array('mongodb://127.0.0.1/?readPreference=secondary&readPreferenceTags=dc:ny,use:reports&readPreferenceTags=', array()),
+    array('mongodb://127.0.0.1/?readPreference=secondary', array('readPreferenceTags' => array(array('dc' => 'ny', 'use' => 'reports'), array()))),
+    array('mongodb://127.0.0.1/?readPreference=secondary&readPreferenceTags=dc:ny,use:reports', array('readPreferenceTags' => array(array('dc' => 'ca')))),
 );
 
 foreach ($tests as $i => $test) {

--- a/tests/manager/manager-getwriteconcern-001.phpt
+++ b/tests/manager/manager-getwriteconcern-001.phpt
@@ -1,24 +1,21 @@
 --TEST--
 MongoDB\Driver\Manager::getWriteConcern()
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"?>
 --FILE--
 <?php
-require_once __DIR__ . "/../utils/basic.inc";
 
 $tests = array(
-    array(STANDALONE, array()),
-    array(STANDALONE . '/?w=1', array()),
-    array(STANDALONE . '/?w=majority', array()),
-    array(STANDALONE, array('w' => 1, 'journal' => true)),
-    array(STANDALONE, array('w' => 'majority', 'journal' => true)),
-    array(STANDALONE . '/?w=majority&journal=true', array('w' => 1, 'journal' => false)),
+    array(null, array()),
+    array('mongodb://127.0.0.1/?w=1', array()),
+    array('mongodb://127.0.0.1/?w=majority', array()),
+    array(null, array('w' => 1, 'journal' => true)),
+    array(null, array('w' => 'majority', 'journal' => true)),
+    array('mongodb://127.0.0.1/?w=majority&journal=true', array('w' => 1, 'journal' => false)),
     // wtimeoutms does not get applied unless w > 1, w = majority, or tag sets are used
-    array(STANDALONE . '/?wtimeoutms=1000', array()),
-    array(STANDALONE, array('wtimeoutms' => 1000)),
-    array(STANDALONE . '/?w=2', array('wtimeoutms' => 1000)),
-    array(STANDALONE . '/?w=majority', array('wtimeoutms' => 1000)),
-    array(STANDALONE . '/?w=customTagSet', array('wtimeoutms' => 1000)),
+    array('mongodb://127.0.0.1/?wtimeoutms=1000', array()),
+    array(null, array('wtimeoutms' => 1000)),
+    array('mongodb://127.0.0.1/?w=2', array('wtimeoutms' => 1000)),
+    array('mongodb://127.0.0.1/?w=majority', array('wtimeoutms' => 1000)),
+    array('mongodb://127.0.0.1/?w=customTagSet', array('wtimeoutms' => 1000)),
 );
 
 foreach ($tests as $i => $test) {

--- a/tests/manager/manager-invalidnamespace.phpt
+++ b/tests/manager/manager-invalidnamespace.phpt
@@ -1,12 +1,11 @@
 --TEST--
 MongoDB\Driver\Manager: Invalid namespace
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"?>
 --FILE--
 <?php
-require_once __DIR__ . "/../utils/basic.inc";
 
-$manager = new MongoDB\Driver\Manager(STANDALONE);
+require_once __DIR__ . '/../utils/tools.php';
+
+$manager = new MongoDB\Driver\Manager();
 $bulk = new MongoDB\Driver\BulkWrite;
 $bulk->insert(array("my" => "value"));
 

--- a/tests/manager/manager-selectserver_error-001.phpt
+++ b/tests/manager/manager-selectserver_error-001.phpt
@@ -1,7 +1,5 @@
 --TEST--
 MongoDB\Driver\Manager::selectServer() should not issue warning before exception
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";

--- a/tests/manager/manager-wakeup.phpt
+++ b/tests/manager/manager-wakeup.phpt
@@ -1,12 +1,11 @@
 --TEST--
 MongoDB\Driver\Manager: Manager cannot be woken up
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"?>
 --FILE--
 <?php
-require_once __DIR__ . "/../utils/basic.inc";
 
-$manager = new MongoDB\Driver\Manager(STANDALONE);
+require_once __DIR__ . '/../utils/tools.php';
+
+$manager = new MongoDB\Driver\Manager();
 throws(function() use($manager) {
     $manager->__wakeup();
 }, "MongoDB\Driver\Exception\RuntimeException");

--- a/tests/query/bug0430-001.phpt
+++ b/tests/query/bug0430-001.phpt
@@ -1,10 +1,7 @@
 --TEST--
 PHPC-430: Query constructor arguments are modified
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"?>
 --FILE--
 <?php
-require_once __DIR__ . "/../utils/basic.inc";
 
 $filter = [];
 $options = ['sort' => ['x' => 1]];

--- a/tests/query/bug0430-002.phpt
+++ b/tests/query/bug0430-002.phpt
@@ -1,10 +1,7 @@
 --TEST--
 PHPC-430: Query constructor arguments are modified
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"?>
 --FILE--
 <?php
-require_once __DIR__ . "/../utils/basic.inc";
 
 $options = ['sort' => ['x' => 1]];
 

--- a/tests/query/bug0430-003.phpt
+++ b/tests/query/bug0430-003.phpt
@@ -1,10 +1,7 @@
 --TEST--
 PHPC-430: Query constructor arguments are modified
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"?>
 --FILE--
 <?php
-require_once __DIR__ . "/../utils/basic.inc";
 
 function buildQuery($filter, $options)
 {

--- a/tests/query/query-ctor_error-001.phpt
+++ b/tests/query/query-ctor_error-001.phpt
@@ -1,7 +1,5 @@
 --TEST--
 MongoDB\Driver\Query construction (invalid readConcern type)
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";

--- a/tests/query/query-debug-001.phpt
+++ b/tests/query/query-debug-001.phpt
@@ -1,10 +1,7 @@
 --TEST--
 MongoDB\Driver\Query debug output
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"?>
 --FILE--
 <?php
-require_once __DIR__ . "/../utils/basic.inc";
 
 var_dump(new MongoDB\Driver\Query(
     ['a' => 123],

--- a/tests/readConcern/readconcern-constants.phpt
+++ b/tests/readConcern/readconcern-constants.phpt
@@ -1,10 +1,7 @@
 --TEST--
 MongoDB\Driver\ReadConcern constants
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"?>
 --FILE--
 <?php
-require_once __DIR__ . "/../utils/basic.inc";
 
 var_dump(MongoDB\Driver\ReadConcern::LINEARIZABLE);
 var_dump(MongoDB\Driver\ReadConcern::LOCAL);

--- a/tests/readConcern/readconcern-ctor-001.phpt
+++ b/tests/readConcern/readconcern-ctor-001.phpt
@@ -1,10 +1,7 @@
 --TEST--
 MongoDB\Driver\ReadConcern construction
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"?>
 --FILE--
 <?php
-require_once __DIR__ . "/../utils/basic.inc";
 
 var_dump(new MongoDB\Driver\ReadConcern());
 var_dump(new MongoDB\Driver\ReadConcern(null));

--- a/tests/readConcern/readconcern-ctor_error-001.phpt
+++ b/tests/readConcern/readconcern-ctor_error-001.phpt
@@ -2,7 +2,6 @@
 MongoDB\Driver\ReadConcern construction (invalid arguments)
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
-<?php if (defined("HHVM_VERSION_ID")) exit("skip HHVM throws Exception instead of InvalidArgumentException"); ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";

--- a/tests/readConcern/readconcern-ctor_error-001.phpt
+++ b/tests/readConcern/readconcern-ctor_error-001.phpt
@@ -1,7 +1,5 @@
 --TEST--
 MongoDB\Driver\ReadConcern construction (invalid arguments)
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";

--- a/tests/readConcern/readconcern-ctor_error-002.phpt
+++ b/tests/readConcern/readconcern-ctor_error-002.phpt
@@ -2,7 +2,6 @@
 MongoDB\Driver\ReadConcern construction (invalid level type)
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
-<?php if (defined("HHVM_VERSION_ID")) exit("skip HHVM throws Exception instead of InvalidArgumentException"); ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";

--- a/tests/readConcern/readconcern-ctor_error-002.phpt
+++ b/tests/readConcern/readconcern-ctor_error-002.phpt
@@ -1,7 +1,5 @@
 --TEST--
 MongoDB\Driver\ReadConcern construction (invalid level type)
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";

--- a/tests/readConcern/readconcern-getlevel-001.phpt
+++ b/tests/readConcern/readconcern-getlevel-001.phpt
@@ -1,10 +1,7 @@
 --TEST--
 MongoDB\Driver\ReadConcern::getLevel()
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"?>
 --FILE--
 <?php
-require_once __DIR__ . "/../utils/basic.inc";
 
 $tests = [
     null,

--- a/tests/server/server-constants.phpt
+++ b/tests/server/server-constants.phpt
@@ -1,10 +1,7 @@
 --TEST--
 MongoDB\Driver\Server constants
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc" ?>
 --FILE--
 <?php
-require_once __DIR__ . "/../utils/basic.inc";
 
 var_dump(MongoDB\Driver\Server::TYPE_UNKNOWN);
 var_dump(MongoDB\Driver\Server::TYPE_STANDALONE);

--- a/tests/standalone/bug0357.phpt
+++ b/tests/standalone/bug0357.phpt
@@ -1,12 +1,10 @@
 --TEST--
 PHPC-357: The exception for "invalid namespace" does not list the broken name
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";
 
-$m = new MongoDB\Driver\Manager(STANDALONE);
+$m = new MongoDB\Driver\Manager(null);
 $c = new MongoDB\Driver\Query(array());
 
 echo throws(function() use($m, $c) {

--- a/tests/standalone/bug0545.phpt
+++ b/tests/standalone/bug0545.phpt
@@ -1,7 +1,6 @@
 --TEST--
 PHPC-545: Update does not serialize embedded Persistable's __pclass field
 --SKIPIF--
-<?php if (defined("HHVM_VERSION_ID")) exit("skip HHVM encodes __pclass last"); ?>
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php NEEDS('STANDALONE'); CLEANUP(STANDALONE); ?>
 --FILE--

--- a/tests/standalone/bug0655.phpt
+++ b/tests/standalone/bug0655.phpt
@@ -1,7 +1,5 @@
 --TEST--
 PHPC-655: Use case insensitive parsing for Manager connectTimeoutMS array option
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";

--- a/tests/standalone/bug0655.phpt
+++ b/tests/standalone/bug0655.phpt
@@ -1,7 +1,6 @@
 --TEST--
 PHPC-655: Use case insensitive parsing for Manager connectTimeoutMS array option
 --SKIPIF--
-<?php if (defined("HHVM_VERSION_ID")) exit("skip HHVM does not use custom streams"); ?>
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 --FILE--
 <?php

--- a/tests/standalone/manager-as-singleton.phpt
+++ b/tests/standalone/manager-as-singleton.phpt
@@ -2,6 +2,7 @@
 PHPC-431: Segfault when using Manager through singleton class
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('STANDALONE'); ?>
 --FILE--
 <?php
 use MongoDB\Driver\Manager;

--- a/tests/standalone/query-errors.phpt
+++ b/tests/standalone/query-errors.phpt
@@ -1,7 +1,5 @@
 --TEST--
 MongoDB\Driver\Query: Invalid types
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";

--- a/tests/writeConcern/writeconcern-constants.phpt
+++ b/tests/writeConcern/writeconcern-constants.phpt
@@ -1,10 +1,7 @@
 --TEST--
 MongoDB\Driver\WriteConcern constants
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"?>
 --FILE--
 <?php
-require_once __DIR__ . "/../utils/basic.inc";
 
 var_dump(MongoDB\Driver\WriteConcern::MAJORITY);
 

--- a/tests/writeConcern/writeconcern-ctor-001.phpt
+++ b/tests/writeConcern/writeconcern-ctor-001.phpt
@@ -1,10 +1,7 @@
 --TEST--
 MongoDB\Driver\WriteConcern construction
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"?>
 --FILE--
 <?php
-require_once __DIR__ . "/../utils/basic.inc";
 
 var_dump(new MongoDB\Driver\WriteConcern(MongoDB\Driver\WriteConcern::MAJORITY));
 var_dump(new MongoDB\Driver\WriteConcern(MongoDB\Driver\WriteConcern::MAJORITY, 1000));

--- a/tests/writeConcern/writeconcern-ctor_error-001.phpt
+++ b/tests/writeConcern/writeconcern-ctor_error-001.phpt
@@ -2,7 +2,6 @@
 MongoDB\Driver\WriteConcern construction (invalid arguments)
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
-<?php if (defined("HHVM_VERSION_ID")) exit("skip HHVM throws Exception instead of InvalidArgumentException"); ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";

--- a/tests/writeConcern/writeconcern-ctor_error-001.phpt
+++ b/tests/writeConcern/writeconcern-ctor_error-001.phpt
@@ -1,10 +1,9 @@
 --TEST--
 MongoDB\Driver\WriteConcern construction (invalid arguments)
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 --FILE--
 <?php
-require_once __DIR__ . "/../utils/basic.inc";
+
+require_once __DIR__ . '/../utils/tools.php';
 
 echo throws(function() {
     new MongoDB\Driver\WriteConcern("string", 10000, false, 1);

--- a/tests/writeConcern/writeconcern-ctor_error-002.phpt
+++ b/tests/writeConcern/writeconcern-ctor_error-002.phpt
@@ -1,10 +1,9 @@
 --TEST--
 MongoDB\Driver\WriteConcern construction (invalid w type)
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 --FILE--
 <?php
-require_once __DIR__ . "/../utils/basic.inc";
+
+require_once __DIR__ . '/../utils/tools.php';
 
 $tests = array(
     1.0,

--- a/tests/writeConcern/writeconcern-ctor_error-003.phpt
+++ b/tests/writeConcern/writeconcern-ctor_error-003.phpt
@@ -1,10 +1,9 @@
 --TEST--
 MongoDB\Driver\WriteConcern construction (invalid w range)
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 --FILE--
 <?php
-require_once __DIR__ . "/../utils/basic.inc";
+
+require_once __DIR__ . '/../utils/tools.php';
 
 echo throws(function() {
     new MongoDB\Driver\WriteConcern(-4);

--- a/tests/writeConcern/writeconcern-ctor_error-004.phpt
+++ b/tests/writeConcern/writeconcern-ctor_error-004.phpt
@@ -1,10 +1,9 @@
 --TEST--
 MongoDB\Driver\WriteConcern construction (invalid wtimeout range)
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 --FILE--
 <?php
-require_once __DIR__ . "/../utils/basic.inc";
+
+require_once __DIR__ . '/../utils/tools.php';
 
 echo throws(function() {
     new MongoDB\Driver\WriteConcern(1, -1);

--- a/tests/writeConcern/writeconcern-ctor_error-005.phpt
+++ b/tests/writeConcern/writeconcern-ctor_error-005.phpt
@@ -2,10 +2,10 @@
 MongoDB\Driver\WriteConcern construction (invalid wtimeout range)
 --SKIPIF--
 <?php if (8 !== PHP_INT_SIZE) { die('skip Only for 64-bit platform'); } ?>
-<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 --FILE--
 <?php
-require_once __DIR__ . "/../utils/basic.inc";
+
+require_once __DIR__ . '/../utils/tools.php';
 
 echo throws(function() {
     new MongoDB\Driver\WriteConcern(1, 2147483648);

--- a/tests/writeConcern/writeconcern-debug-001.phpt
+++ b/tests/writeConcern/writeconcern-debug-001.phpt
@@ -1,10 +1,7 @@
 --TEST--
 MongoDB\Driver\WriteConcern debug output should include all fields for w default
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"?>
 --FILE--
 <?php
-require_once __DIR__ . "/../utils/basic.inc";
 
 /* -2 is libmongoc's constant for relying on the server's default value for "w".
  * Although "w" will be omitted from the write concern sent to the server, we

--- a/tests/writeConcern/writeconcern-debug-002.phpt
+++ b/tests/writeConcern/writeconcern-debug-002.phpt
@@ -1,10 +1,7 @@
 --TEST--
 MongoDB\Driver\WriteConcern debug output
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"?>
 --FILE--
 <?php
-require_once __DIR__ . "/../utils/basic.inc";
 
 var_dump(new MongoDB\Driver\WriteConcern(1));
 var_dump(new MongoDB\Driver\WriteConcern("tag", 1000, false));

--- a/tests/writeConcern/writeconcern-getjournal-001.phpt
+++ b/tests/writeConcern/writeconcern-getjournal-001.phpt
@@ -1,10 +1,7 @@
 --TEST--
 MongoDB\Driver\WriteConcern::getJournal()
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"?>
 --FILE--
 <?php
-require_once __DIR__ . "/../utils/basic.inc";
 
 $tests = array(
     true,

--- a/tests/writeConcern/writeconcern-getw-001.phpt
+++ b/tests/writeConcern/writeconcern-getw-001.phpt
@@ -1,10 +1,7 @@
 --TEST--
 MongoDB\Driver\WriteConcern::getW()
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"?>
 --FILE--
 <?php
-require_once __DIR__ . "/../utils/basic.inc";
 
 $tests = array(
     MongoDB\Driver\WriteConcern::MAJORITY,

--- a/tests/writeConcern/writeconcern-getwtimeout-001.phpt
+++ b/tests/writeConcern/writeconcern-getwtimeout-001.phpt
@@ -1,10 +1,7 @@
 --TEST--
 MongoDB\Driver\WriteConcern::getWtimeout()
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"?>
 --FILE--
 <?php
-require_once __DIR__ . "/../utils/basic.inc";
 
 $tests = array(
     0,


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1132
https://jira.mongodb.org/browse/PHPC-1133

There was some overlap with the commit for removing HHVM checks, so I've bundled these tickets into one PR.