### PR TITLE
PHPC-1090: phongo_exception_from_mongoc_domain fixes

### DIFF
--- a/php_phongo.c
+++ b/php_phongo.c
@@ -146,8 +146,6 @@ zend_class_entry* phongo_exception_from_mongoc_domain(uint32_t /* mongoc_error_d
 			return php_phongo_invalidargumentexception_ce;
 	}
 	switch (domain) {
-		case MONGOC_ERROR_COMMAND:
-			return php_phongo_commandexception_ce;
 		case MONGOC_ERROR_SERVER:
 			if (code == 50) {
 				return php_phongo_executiontimeoutexception_ce;

--- a/php_phongo.c
+++ b/php_phongo.c
@@ -136,26 +136,35 @@ zend_class_entry* phongo_exception_from_phongo_domain(php_phongo_error_domain_t 
 }
 zend_class_entry* phongo_exception_from_mongoc_domain(uint32_t /* mongoc_error_domain_t */ domain, uint32_t /* mongoc_error_code_t */ code)
 {
-	switch (code) {
-		case MONGOC_ERROR_STREAM_SOCKET:
-		case MONGOC_ERROR_SERVER_SELECTION_FAILURE:
+	if (domain == MONGOC_ERROR_CLIENT && code == MONGOC_ERROR_CLIENT_AUTHENTICATE) {
+		return php_phongo_authenticationexception_ce;
+	}
+
+	if (domain == MONGOC_ERROR_COMMAND && code == MONGOC_ERROR_COMMAND_INVALID_ARG) {
+		return php_phongo_invalidargumentexception_ce;
+	}
+
+	if (domain == MONGOC_ERROR_SERVER) {
+		if (code == 50) {
+			return php_phongo_executiontimeoutexception_ce;
+		}
+
+		return php_phongo_serverexception_ce;
+	}
+
+	if (domain == MONGOC_ERROR_SERVER_SELECTION && code == MONGOC_ERROR_SERVER_SELECTION_FAILURE) {
+		return php_phongo_connectiontimeoutexception_ce;
+	}
+
+	if (domain == MONGOC_ERROR_STREAM) {
+		if (code == MONGOC_ERROR_STREAM_SOCKET) {
 			return php_phongo_connectiontimeoutexception_ce;
-		case MONGOC_ERROR_CLIENT_AUTHENTICATE:
-			return php_phongo_authenticationexception_ce;
-		case MONGOC_ERROR_COMMAND_INVALID_ARG:
-			return php_phongo_invalidargumentexception_ce;
+		}
+
+		return php_phongo_connectionexception_ce;
 	}
-	switch (domain) {
-		case MONGOC_ERROR_SERVER:
-			if (code == 50) {
-				return php_phongo_executiontimeoutexception_ce;
-			}
-			return php_phongo_serverexception_ce;
-		case MONGOC_ERROR_STREAM:
-			return php_phongo_connectionexception_ce;
-		default:
-			return php_phongo_runtimeexception_ce;
-	}
+
+	return php_phongo_runtimeexception_ce;
 }
 void phongo_throw_exception(php_phongo_error_domain_t domain TSRMLS_DC, const char* format, ...)
 {


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1090

The first commit addresses an issue I noticed with:

 * https://github.com/mongodb/mongo-php-driver/commit/1ad6d75b5c47da1095d7647896f66f673019a4b7#diff-c06c6e1c9374aecabcf544157f9d0c26R151
 * https://github.com/mongodb/mongo-php-driver/commit/395719ad47527fd239aef02cd73528521730dbac#diff-c06c6e1c9374aecabcf544157f9d0c26R152

The second commit addresses a concern that was in the description for [PHPC-1090](https://jira.mongodb.org/browse/PHPC-1090), which I didn't pick up on while reviewing #768.