### PR TITLE
PHPC-314: Implement type map syntax for documents within field paths

### DIFF
--- a/php_bson.h
+++ b/php_bson.h
@@ -47,21 +47,33 @@ typedef enum {
 } php_phongo_bson_field_path_item_types;
 
 typedef struct {
+	char**                                 elements;
+	php_phongo_bson_field_path_item_types* element_types;
+	size_t                                 allocated;
+	size_t                                 size;
+	size_t                                 ref_count;
+	bool                                   free_elements;
+} php_phongo_field_path;
+
+typedef struct _php_phongo_field_path_map_element {
+	php_phongo_field_path*        entry;
+	php_phongo_bson_typemap_types node_type;
+	zend_class_entry*             node_ce;
+} php_phongo_field_path_map_element;
+
+typedef struct {
 	php_phongo_bson_typemap_types document_type;
 	zend_class_entry*             document;
 	php_phongo_bson_typemap_types array_type;
 	zend_class_entry*             array;
 	php_phongo_bson_typemap_types root_type;
 	zend_class_entry*             root;
+	struct {
+		php_phongo_field_path_map_element** map;
+		size_t                              allocated;
+		size_t                              size;
+	} field_paths;
 } php_phongo_bson_typemap;
-
-typedef struct {
-	const char**                           elements;
-	php_phongo_bson_field_path_item_types* element_types;
-	size_t                                 allocated_levels;
-	size_t                                 current_level;
-	size_t                                 ref_count;
-} php_phongo_field_path;
 
 typedef struct {
 	ZVAL_RETVAL_TYPE        zchild;
@@ -94,8 +106,9 @@ bool php_phongo_bson_typemap_to_state(zval* typemap, php_phongo_bson_typemap* ma
 void php_phongo_bson_state_ctor(php_phongo_bson_state* state);
 void php_phongo_bson_state_dtor(php_phongo_bson_state* state);
 void php_phongo_bson_state_copy_ctor(php_phongo_bson_state* dst, php_phongo_bson_state* src);
+void php_phongo_bson_typemap_dtor(php_phongo_bson_typemap* map);
 
-php_phongo_field_path* php_phongo_field_path_alloc(void);
+php_phongo_field_path* php_phongo_field_path_alloc(bool free_elements);
 void                   php_phongo_field_path_free(php_phongo_field_path* field_path);
 void                   php_phongo_field_path_write_item_at_current_level(php_phongo_field_path* field_path, const char* element);
 void                   php_phongo_field_path_write_type_at_current_level(php_phongo_field_path* field_path, php_phongo_bson_field_path_item_types element_type);

--- a/php_bson.h
+++ b/php_bson.h
@@ -40,6 +40,12 @@ typedef enum {
 	PHONGO_TYPEMAP_CLASS
 } php_phongo_bson_typemap_types;
 
+typedef enum {
+	PHONGO_FIELD_PATH_ITEM_NONE,
+	PHONGO_FIELD_PATH_ITEM_ARRAY,
+	PHONGO_FIELD_PATH_ITEM_DOCUMENT
+} php_phongo_bson_field_path_item_types;
+
 typedef struct {
 	php_phongo_bson_typemap_types document_type;
 	zend_class_entry*             document;
@@ -50,10 +56,11 @@ typedef struct {
 } php_phongo_bson_typemap;
 
 typedef struct {
-	const char** elements;
-	size_t       allocated_levels;
-	size_t       current_level;
-	size_t       ref_count;
+	const char**                           elements;
+	php_phongo_bson_field_path_item_types* element_types;
+	size_t                                 allocated_levels;
+	size_t                                 current_level;
+	size_t                                 ref_count;
 } php_phongo_field_path;
 
 typedef struct {
@@ -91,7 +98,8 @@ void php_phongo_bson_state_copy_ctor(php_phongo_bson_state* dst, php_phongo_bson
 php_phongo_field_path* php_phongo_field_path_alloc(void);
 void                   php_phongo_field_path_free(php_phongo_field_path* field_path);
 void                   php_phongo_field_path_write_item_at_current_level(php_phongo_field_path* field_path, const char* element);
-bool                   php_phongo_field_path_push(php_phongo_field_path* field_path, const char* element);
+void                   php_phongo_field_path_write_type_at_current_level(php_phongo_field_path* field_path, php_phongo_bson_field_path_item_types element_type);
+bool                   php_phongo_field_path_push(php_phongo_field_path* field_path, const char* element, php_phongo_bson_field_path_item_types element_type);
 bool                   php_phongo_field_path_pop(php_phongo_field_path* field_path);
 
 char* php_phongo_field_path_as_string(php_phongo_field_path* field_path);

--- a/php_bson.h
+++ b/php_bson.h
@@ -49,7 +49,7 @@ typedef enum {
 typedef struct {
 	char**                                 elements;
 	php_phongo_bson_field_path_item_types* element_types;
-	size_t                                 allocated;
+	size_t                                 allocated_size;
 	size_t                                 size;
 	size_t                                 ref_count;
 	bool                                   free_elements;
@@ -70,7 +70,7 @@ typedef struct {
 	zend_class_entry*             root;
 	struct {
 		php_phongo_field_path_map_element** map;
-		size_t                              allocated;
+		size_t                              allocated_size;
 		size_t                              size;
 	} field_paths;
 } php_phongo_bson_typemap;

--- a/php_bson.h
+++ b/php_bson.h
@@ -52,7 +52,7 @@ typedef struct {
 	size_t                                 allocated_size;
 	size_t                                 size;
 	size_t                                 ref_count;
-	bool                                   free_elements;
+	bool                                   owns_elements;
 } php_phongo_field_path;
 
 typedef struct _php_phongo_field_path_map_element {
@@ -108,7 +108,7 @@ void php_phongo_bson_state_dtor(php_phongo_bson_state* state);
 void php_phongo_bson_state_copy_ctor(php_phongo_bson_state* dst, php_phongo_bson_state* src);
 void php_phongo_bson_typemap_dtor(php_phongo_bson_typemap* map);
 
-php_phongo_field_path* php_phongo_field_path_alloc(bool free_elements);
+php_phongo_field_path* php_phongo_field_path_alloc(bool owns_elements);
 void                   php_phongo_field_path_free(php_phongo_field_path* field_path);
 void                   php_phongo_field_path_write_item_at_current_level(php_phongo_field_path* field_path, const char* element);
 void                   php_phongo_field_path_write_type_at_current_level(php_phongo_field_path* field_path, php_phongo_bson_field_path_item_types element_type);

--- a/src/BSON/functions.c
+++ b/src/BSON/functions.c
@@ -77,7 +77,7 @@ PHP_FUNCTION(MongoDB_BSON_toPHP)
 		php_phongo_bson_typemap_dtor(&state.map);
 		RETURN_NULL();
 	}
-	
+
 	php_phongo_bson_typemap_dtor(&state.map);
 
 #if PHP_VERSION_ID >= 70000

--- a/src/BSON/functions.c
+++ b/src/BSON/functions.c
@@ -74,8 +74,11 @@ PHP_FUNCTION(MongoDB_BSON_toPHP)
 
 	if (!php_phongo_bson_to_zval_ex((const unsigned char*) data, data_len, &state)) {
 		zval_ptr_dtor(&state.zchild);
+		php_phongo_bson_typemap_dtor(&state.map);
 		RETURN_NULL();
 	}
+	
+	php_phongo_bson_typemap_dtor(&state.map);
 
 #if PHP_VERSION_ID >= 70000
 	RETURN_ZVAL(&state.zchild, 0, 1);

--- a/src/MongoDB/Cursor.c
+++ b/src/MongoDB/Cursor.c
@@ -225,6 +225,8 @@ static PHP_METHOD(Cursor, setTypeMap)
 		restore_current_element = true;
 	}
 
+	php_phongo_bson_typemap_dtor(&intern->visitor_data.map);
+
 	intern->visitor_data = state;
 
 	/* If the cursor has a current element, we just freed it and should restore
@@ -397,6 +399,8 @@ static void php_phongo_cursor_free_object(phongo_free_object_arg* object TSRMLS_
 	if (!Z_ISUNDEF(intern->session)) {
 		zval_ptr_dtor(&intern->session);
 	}
+
+	php_phongo_bson_typemap_dtor(&intern->visitor_data.map);
 
 	php_phongo_cursor_free_current(intern);
 

--- a/src/bson-encode.c
+++ b/src/bson-encode.c
@@ -365,6 +365,7 @@ try_again:
 				}
 
 				bson_append_array_begin(bson, key, key_len, &child);
+				php_phongo_field_path_write_type_at_current_level(field_path, PHONGO_FIELD_PATH_ITEM_ARRAY);
 				field_path->current_level++;
 				php_phongo_zval_to_bson_internal(entry, field_path, flags, &child, NULL TSRMLS_CC);
 				field_path->current_level--;
@@ -391,6 +392,7 @@ try_again:
 				ZEND_HASH_INC_APPLY_COUNT(tmp_ht);
 			}
 
+			php_phongo_field_path_write_type_at_current_level(field_path, PHONGO_FIELD_PATH_ITEM_DOCUMENT);
 			field_path->current_level++;
 			php_phongo_bson_append_object(bson, field_path, flags, key, key_len, entry TSRMLS_CC);
 			field_path->current_level--;

--- a/src/bson-encode.c
+++ b/src/bson-encode.c
@@ -366,9 +366,9 @@ try_again:
 
 				bson_append_array_begin(bson, key, key_len, &child);
 				php_phongo_field_path_write_type_at_current_level(field_path, PHONGO_FIELD_PATH_ITEM_ARRAY);
-				field_path->current_level++;
+				field_path->size++;
 				php_phongo_zval_to_bson_internal(entry, field_path, flags, &child, NULL TSRMLS_CC);
-				field_path->current_level--;
+				field_path->size--;
 				bson_append_array_end(bson, &child);
 
 				if (tmp_ht && ZEND_HASH_APPLY_PROTECTION(tmp_ht)) {
@@ -393,9 +393,9 @@ try_again:
 			}
 
 			php_phongo_field_path_write_type_at_current_level(field_path, PHONGO_FIELD_PATH_ITEM_DOCUMENT);
-			field_path->current_level++;
+			field_path->size++;
 			php_phongo_bson_append_object(bson, field_path, flags, key, key_len, entry TSRMLS_CC);
-			field_path->current_level--;
+			field_path->size--;
 
 			if (tmp_ht && ZEND_HASH_APPLY_PROTECTION(tmp_ht)) {
 				ZEND_HASH_DEC_APPLY_COUNT(tmp_ht);
@@ -650,7 +650,7 @@ cleanup:
  * will be used. */
 void php_phongo_zval_to_bson(zval* data, php_phongo_bson_flags_t flags, bson_t* bson, bson_t** bson_out TSRMLS_DC) /* {{{ */
 {
-	php_phongo_field_path* field_path = php_phongo_field_path_alloc();
+	php_phongo_field_path* field_path = php_phongo_field_path_alloc(false);
 
 	php_phongo_zval_to_bson_internal(data, field_path, flags, bson, bson_out TSRMLS_CC);
 

--- a/src/bson.c
+++ b/src/bson.c
@@ -88,18 +88,18 @@ char* php_phongo_field_path_as_string(php_phongo_field_path* field_path)
 	return path;
 }
 
-php_phongo_field_path* php_phongo_field_path_alloc(bool free_elements)
+php_phongo_field_path* php_phongo_field_path_alloc(bool owns_elements)
 {
 	php_phongo_field_path* tmp = ecalloc(1, sizeof(php_phongo_field_path));
 	tmp->ref_count             = 1;
-	tmp->free_elements         = free_elements;
+	tmp->owns_elements         = owns_elements;
 
 	return tmp;
 }
 
 void php_phongo_field_path_free(php_phongo_field_path* field_path)
 {
-	if (field_path->free_elements) {
+	if (field_path->owns_elements) {
 		size_t i;
 
 		for (i = 0; i < field_path->size; i++) {
@@ -135,7 +135,7 @@ void php_phongo_field_path_write_item_at_current_level(php_phongo_field_path* fi
 {
 	php_phongo_field_path_ensure_allocation(field_path, field_path->size);
 
-	if (field_path->free_elements) {
+	if (field_path->owns_elements) {
 		field_path->elements[field_path->size] = estrdup(element);
 	} else {
 		field_path->elements[field_path->size] = (char*) element;

--- a/src/bson.c
+++ b/src/bson.c
@@ -804,6 +804,9 @@ static bool map_element_matches_field_path(php_phongo_field_path_map_element* ma
 		return false;
 	}
 	for (i = 0; i < current->size; i++) {
+		if (strcmp(map_element->entry->elements[i], "$") == 0) {
+			continue;
+		}
 		if (strcmp(map_element->entry->elements[i], current->elements[i]) != 0) {
 			return false;
 		}

--- a/src/bson.c
+++ b/src/bson.c
@@ -117,14 +117,14 @@ void php_phongo_field_path_free(php_phongo_field_path* field_path)
 
 static void php_phongo_field_path_ensure_allocation(php_phongo_field_path* field_path, size_t level)
 {
-	if (level >= field_path->allocated) {
+	if (level >= field_path->allocated_size) {
 		size_t i;
 
-		field_path->allocated     = field_path->size + PHONGO_FIELD_PATH_EXPANSION;
-		field_path->elements      = erealloc(field_path->elements, sizeof(char**) * field_path->allocated);
-		field_path->element_types = erealloc(field_path->element_types, sizeof(php_phongo_bson_field_path_item_types*) * field_path->allocated);
+		field_path->allocated_size = field_path->size + PHONGO_FIELD_PATH_EXPANSION;
+		field_path->elements       = erealloc(field_path->elements, sizeof(char**) * field_path->allocated_size);
+		field_path->element_types  = erealloc(field_path->element_types, sizeof(php_phongo_bson_field_path_item_types*) * field_path->allocated_size);
 
-		for (i = level; i < field_path->allocated; i++) {
+		for (i = level; i < field_path->allocated_size; i++) {
 			field_path->elements[i]      = NULL;
 			field_path->element_types[i] = PHONGO_FIELD_PATH_ITEM_NONE;
 		}
@@ -1298,9 +1298,9 @@ static void field_path_map_element_set_info(php_phongo_field_path_map_element* e
 static void map_add_field_path_element(php_phongo_bson_typemap* map, php_phongo_field_path_map_element* element)
 {
 	/* Make sure we have allocated enough */
-	if (map->field_paths.allocated < map->field_paths.size + 1) {
-		map->field_paths.allocated += PHONGO_FIELD_PATH_EXPANSION;
-		map->field_paths.map = erealloc(map->field_paths.map, sizeof(php_phongo_field_path_map_element) * map->field_paths.allocated);
+	if (map->field_paths.allocated_size < map->field_paths.size + 1) {
+		map->field_paths.allocated_size += PHONGO_FIELD_PATH_EXPANSION;
+		map->field_paths.map = erealloc(map->field_paths.map, sizeof(php_phongo_field_path_map_element) * map->field_paths.allocated_size);
 	}
 
 	map->field_paths.map[map->field_paths.size] = element;

--- a/src/bson.c
+++ b/src/bson.c
@@ -796,7 +796,7 @@ static const bson_visitor_t php_bson_visitors = {
 	{ NULL }
 };
 
-static bool map_element_matches_field_path(php_phongo_field_path_map_element* map_element, php_phongo_field_path* current)
+static inline bool map_element_matches_field_path(php_phongo_field_path_map_element* map_element, php_phongo_field_path* current)
 {
 	size_t i;
 

--- a/src/bson.c
+++ b/src/bson.c
@@ -121,8 +121,8 @@ static void php_phongo_field_path_ensure_allocation(php_phongo_field_path* field
 		size_t i;
 
 		field_path->allocated_size = field_path->size + PHONGO_FIELD_PATH_EXPANSION;
-		field_path->elements       = erealloc(field_path->elements, sizeof(char**) * field_path->allocated_size);
-		field_path->element_types  = erealloc(field_path->element_types, sizeof(php_phongo_bson_field_path_item_types*) * field_path->allocated_size);
+		field_path->elements       = erealloc(field_path->elements, sizeof(char*) * field_path->allocated_size);
+		field_path->element_types  = erealloc(field_path->element_types, sizeof(php_phongo_bson_field_path_item_types) * field_path->allocated_size);
 
 		for (i = level; i < field_path->allocated_size; i++) {
 			field_path->elements[i]      = NULL;

--- a/tests/bson/bson-toPHP-007.phpt
+++ b/tests/bson/bson-toPHP-007.phpt
@@ -1,7 +1,5 @@
 --TEST--
-MongoDB\Driver\Cursor::setTypeMap(): fieldPath typemaps without server
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+MongoDB\BSON\toPHP(): fieldPath typemaps without server
 --FILE--
 <?php
 

--- a/tests/bson/typemap-002.phpt
+++ b/tests/bson/typemap-002.phpt
@@ -8,14 +8,6 @@ MongoDB\Driver\Cursor::setTypeMap(): Setting using type "object"
 
 require_once __DIR__ . "/../utils/basic.inc";
 
-class MyArrayObject extends ArrayObject implements MongoDB\BSON\Unserializable
-{
-    function bsonUnserialize(array $data)
-    {
-        parent::__construct($data);
-    }
-}
-
 $manager = new MongoDB\Driver\Manager(STANDALONE);
 
 $bulk = new MongoDB\Driver\BulkWrite();

--- a/tests/bson/typemap-003.phpt
+++ b/tests/bson/typemap-003.phpt
@@ -1,0 +1,81 @@
+--TEST--
+MongoDB\Driver\Cursor::setTypeMap(): Setting and replacing typemaps
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('STANDALONE'); CLEANUP(STANDALONE); ?>
+--FILE--
+<?php
+
+require_once __DIR__ . "/../utils/basic.inc";
+
+class MyArrayObject extends ArrayObject implements MongoDB\BSON\Unserializable
+{
+    function bsonUnserialize(array $data)
+    {
+        parent::__construct($data, \ArrayObject::ARRAY_AS_PROPS);
+    }
+}
+
+class MyProperties extends MyArrayObject
+{
+}
+
+$manager = new MongoDB\Driver\Manager(STANDALONE);
+
+$document1 = [
+    '_id' => 1,
+    'array' => [1, 2, 3],
+    'object' => ['string' => ['sleutels', 'keys'] ]
+];
+$document2 = [
+    '_id' => 2,
+    'array' => [4, 5, 6],
+    'object' => ['associative' => ['elementen', 'elements' ]]
+];
+
+$bulk = new MongoDB\Driver\BulkWrite();
+$bulk->insert($document1);
+$bulk->insert($document2);
+$manager->executeBulkWrite(NS, $bulk);
+
+$typemap1 = ["fieldPaths" => [
+    'object.string' => "MyArrayObject",
+    'object'        => "MyArrayObject",
+]];
+$typemap2 = ["fieldPaths" => [
+    'object.associative' => "MyProperties",
+    'object'             => "MyArrayObject",
+]];
+
+$cursor = $manager->executeQuery(NS, new MongoDB\Driver\Query([]));
+$cursor->setTypeMap($typemap1);
+$cursor->setTypeMap($typemap2);
+    
+$documents = $cursor->toArray();
+
+var_dump($documents[0] instanceof stdClass);
+var_dump(is_array($documents[0]->array));
+var_dump($documents[0]->object instanceof MyArrayObject);
+var_dump(is_array($documents[0]->object['string']));
+var_dump(is_array($documents[0]->object->string));
+
+var_dump($documents[1] instanceof stdClass);
+var_dump(is_array($documents[1]->array));
+var_dump($documents[1]->object instanceof MyArrayObject);
+var_dump($documents[1]->object['associative'] instanceof MyProperties);
+var_dump($documents[1]->object->associative instanceof MyProperties);
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+===DONE===

--- a/tests/bson/typemap-004.phpt
+++ b/tests/bson/typemap-004.phpt
@@ -1,0 +1,82 @@
+--TEST--
+MongoDB\Driver\Cursor::setTypeMap(): Setting fieldPath typemaps for compound types with string keys
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('STANDALONE'); CLEANUP(STANDALONE); ?>
+--FILE--
+<?php
+
+require_once __DIR__ . "/../utils/basic.inc";
+
+class MyArrayObject extends ArrayObject implements MongoDB\BSON\Unserializable
+{
+    function bsonUnserialize(array $data)
+    {
+        parent::__construct($data);
+    }
+}
+
+$manager = new MongoDB\Driver\Manager(STANDALONE);
+
+$document = [
+    '_id' => 1,
+    'array' => [1, 2, 3],
+    'object' => ['string' => 'keys', 'for' => 'ever']
+];
+
+$bulk = new MongoDB\Driver\BulkWrite();
+$bulk->insert($document);
+$manager->executeBulkWrite(NS, $bulk);
+
+function fetch($manager, $typemap = []) {
+    $cursor = $manager->executeQuery(NS, new MongoDB\Driver\Query([]));
+    if ($typemap) {
+        $cursor->setTypeMap($typemap);
+    }
+
+    $documents = $cursor->toArray();
+    return $documents;
+}
+
+
+echo "Default\n";
+$documents = fetch($manager);
+var_dump($documents[0] instanceof stdClass);
+var_dump(is_array($documents[0]->array));
+var_dump($documents[0]->object instanceof stdClass);
+
+echo "\nSetting 'object' path to 'MyArrayObject'\n";
+$documents = fetch($manager, ["fieldPaths" => [
+    'object' => "MyArrayObject"
+]]);
+var_dump($documents[0] instanceof stdClass);
+var_dump(is_array($documents[0]->array));
+var_dump($documents[0]->object instanceof MyArrayObject);
+
+echo "\nSetting 'object' and 'array' path to 'MyArrayObject'\n";
+$documents = fetch($manager, ["fieldPaths" => [
+    'object' => "MyArrayObject",
+    'array'  => "MyArrayObject",
+]]);
+var_dump($documents[0] instanceof stdClass);
+var_dump($documents[0]->array instanceof MyArrayObject);
+var_dump($documents[0]->object instanceof MyArrayObject);
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+Default
+bool(true)
+bool(true)
+bool(true)
+
+Setting 'object' path to 'MyArrayObject'
+bool(true)
+bool(true)
+bool(true)
+
+Setting 'object' and 'array' path to 'MyArrayObject'
+bool(true)
+bool(true)
+bool(true)
+===DONE===

--- a/tests/bson/typemap-004.phpt
+++ b/tests/bson/typemap-004.phpt
@@ -34,8 +34,7 @@ function fetch($manager, $typemap = []) {
         $cursor->setTypeMap($typemap);
     }
 
-    $documents = $cursor->toArray();
-    return $documents;
+    return $cursor->toArray();
 }
 
 

--- a/tests/bson/typemap-005.phpt
+++ b/tests/bson/typemap-005.phpt
@@ -1,0 +1,103 @@
+--TEST--
+MongoDB\Driver\Cursor::setTypeMap(): Setting fieldPath typemaps for compound types with numerical keys
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('STANDALONE'); CLEANUP(STANDALONE); ?>
+--FILE--
+<?php
+
+require_once __DIR__ . "/../utils/basic.inc";
+
+class MyArrayObject extends ArrayObject implements MongoDB\BSON\Unserializable
+{
+    function bsonUnserialize(array $data)
+    {
+        parent::__construct($data, ArrayObject::ARRAY_AS_PROPS);
+    }
+}
+
+$manager = new MongoDB\Driver\Manager(STANDALONE);
+
+$document = [
+    '_id' => 1,
+    'array0' => [0 => [ 4, 5, 6 ], 1 => [ 7, 8, 9 ]],
+    'array1' => [1 => [ 4, 5, 6 ], 2 => [ 7, 8, 9 ]],
+];
+
+$bulk = new MongoDB\Driver\BulkWrite();
+$bulk->insert($document);
+$manager->executeBulkWrite(NS, $bulk);
+
+function fetch($manager, $typemap = []) {
+    $cursor = $manager->executeQuery(NS, new MongoDB\Driver\Query([]));
+    if ($typemap) {
+        $cursor->setTypeMap($typemap);
+    }
+
+    $documents = $cursor->toArray();
+    return $documents;
+}
+
+
+echo "Default\n";
+$documents = fetch($manager);
+var_dump($documents[0] instanceof stdClass);
+var_dump(is_array($documents[0]->array0));
+var_dump(is_object($documents[0]->array1));
+var_dump($documents[0]->array1 instanceof stdClass);
+
+echo "\nSetting 'array0' path to 'MyArrayObject'\n";
+$documents = fetch($manager, ["fieldPaths" => [
+    'array0' => "MyArrayObject"
+]]);
+var_dump($documents[0] instanceof stdClass);
+var_dump(is_object($documents[0]->array0));
+var_dump($documents[0]->array0 instanceof MyArrayObject);
+
+echo "\nSetting 'array0.1' path to 'MyArrayObject'\n";
+$documents = fetch($manager, ["fieldPaths" => [
+    'array0.1'  => "MyArrayObject",
+]]);
+var_dump($documents[0] instanceof stdClass);
+var_dump(is_array($documents[0]->array0));
+var_dump(is_array($documents[0]->array0[0]));
+var_dump($documents[0]->array0[1] instanceof MyArrayObject);
+
+echo "\nSetting 'array1.1' path to 'MyArrayObject'\n";
+$documents = fetch($manager, ["fieldPaths" => [
+    'array1.1'  => "MyArrayObject",
+]]);
+var_dump($documents[0] instanceof stdClass);
+var_dump(is_object($documents[0]->array1));
+var_dump($documents[0]->array1 instanceof stdClass);
+$a = ((array) $documents[0]->array1);
+var_dump($a[1] instanceof MyArrayObject);
+var_dump(is_array($a[2]));
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+Default
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+
+Setting 'array0' path to 'MyArrayObject'
+bool(true)
+bool(true)
+bool(true)
+
+Setting 'array0.1' path to 'MyArrayObject'
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+
+Setting 'array1.1' path to 'MyArrayObject'
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+===DONE===

--- a/tests/bson/typemap-006.phpt
+++ b/tests/bson/typemap-006.phpt
@@ -1,5 +1,5 @@
 --TEST--
-MongoDB\Driver\Cursor::setTypeMap(): Setting fieldPath typemaps for compound types with wild card keys
+MongoDB\Driver\Cursor::setTypeMap(): Setting fieldPath typemaps for compound types with wildcard keys
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php NEEDS('STANDALONE'); CLEANUP(STANDALONE); ?>
@@ -16,7 +16,13 @@ class MyArrayObject extends ArrayObject implements MongoDB\BSON\Unserializable
     }
 }
 
-class MyWildCardArrayObject extends MyArrayObject {};
+class MyWildcardArrayObject extends ArrayObject implements MongoDB\BSON\Unserializable
+{
+    function bsonUnserialize(array $data)
+    {
+        parent::__construct($data, ArrayObject::ARRAY_AS_PROPS);
+    }
+}
 
 $manager = new MongoDB\Driver\Manager(STANDALONE);
 
@@ -41,99 +47,99 @@ function fetch($manager, $typemap = []) {
 }
 
 
-echo "\nSetting 'array.$' path to 'MyWildCardArrayObject'\n";
+echo "\nSetting 'array.$' path to 'MyWildcardArrayObject'\n";
 $documents = fetch($manager, ["fieldPaths" => [
-    'array.$' => "MyWildCardArrayObject"
+    'array.$' => "MyWildcardArrayObject"
 ]]);
 var_dump($documents[0] instanceof stdClass);
 var_dump(is_array($documents[0]->array));
-var_dump($documents[0]->array[0] instanceof MyWildCardArrayObject);
-var_dump($documents[0]->array[1] instanceof MyWildCardArrayObject);
+var_dump($documents[0]->array[0] instanceof MyWildcardArrayObject);
+var_dump($documents[0]->array[1] instanceof MyWildcardArrayObject);
 
-echo "\nSetting 'array.1' to 'MyArrayObject' and 'array.$' path to 'MyWildCardArrayObject'\n";
+echo "\nSetting 'array.1' to 'MyArrayObject' and 'array.$' path to 'MyWildcardArrayObject'\n";
 $documents = fetch($manager, ["fieldPaths" => [
     'array.1' => "MyArrayObject",
-    'array.$' => "MyWildCardArrayObject"
+    'array.$' => "MyWildcardArrayObject"
 ]]);
 var_dump($documents[0] instanceof stdClass);
 var_dump(is_array($documents[0]->array));
-var_dump($documents[0]->array[0] instanceof MyWildCardArrayObject);
+var_dump($documents[0]->array[0] instanceof MyWildcardArrayObject);
 var_dump($documents[0]->array[1] instanceof MyArrayObject);
 
-echo "\nSetting 'array.$' to 'MyWildCardArrayObject' and 'array.1' path to 'MyArrayObject'\n";
+echo "\nSetting 'array.$' to 'MyWildcardArrayObject' and 'array.1' path to 'MyArrayObject'\n";
 $documents = fetch($manager, ["fieldPaths" => [
-    'array.$' => "MyWildCardArrayObject",
+    'array.$' => "MyWildcardArrayObject",
     'array.1' => "MyArrayObject"
 ]]);
 var_dump($documents[0] instanceof stdClass);
 var_dump(is_array($documents[0]->array));
-var_dump($documents[0]->array[0] instanceof MyWildCardArrayObject);
-var_dump($documents[0]->array[1] instanceof MyArrayObject);
+var_dump($documents[0]->array[0] instanceof MyWildcardArrayObject);
+var_dump($documents[0]->array[1] instanceof MyWildcardArrayObject);
 
 
-echo "\nSetting 'object.$' path to 'MyWildCardArrayObject'\n";
+echo "\nSetting 'object.$' path to 'MyWildcardArrayObject'\n";
 $documents = fetch($manager, ["fieldPaths" => [
-    'object.$' => "MyWildCardArrayObject"
+    'object.$' => "MyWildcardArrayObject"
 ]]);
 var_dump($documents[0] instanceof stdClass);
 var_dump(is_object($documents[0]->object));
-var_dump($documents[0]->object->one instanceof MyWildCardArrayObject);
-var_dump($documents[0]->object->two instanceof MyWildCardArrayObject);
+var_dump($documents[0]->object->one instanceof MyWildcardArrayObject);
+var_dump($documents[0]->object->two instanceof MyWildcardArrayObject);
 
-echo "\nSetting 'object.two' to 'MyArrayObject' and 'object.$' path to 'MyWildCardArrayObject'\n";
+echo "\nSetting 'object.two' to 'MyArrayObject' and 'object.$' path to 'MyWildcardArrayObject'\n";
 $documents = fetch($manager, ["fieldPaths" => [
     'object.two' => "MyArrayObject",
-    'object.$' => "MyWildCardArrayObject"
+    'object.$' => "MyWildcardArrayObject"
 ]]);
 var_dump($documents[0] instanceof stdClass);
 var_dump(is_object($documents[0]->object));
-var_dump($documents[0]->object->one instanceof MyWildCardArrayObject);
+var_dump($documents[0]->object->one instanceof MyWildcardArrayObject);
 var_dump($documents[0]->object->two instanceof MyArrayObject);
 
-echo "\nSetting 'object.$' to 'MyWildCardArrayObject' and 'object.one' path to 'MyArrayObject'\n";
+echo "\nSetting 'object.$' to 'MyWildcardArrayObject' and 'object.one' path to 'MyArrayObject'\n";
 $documents = fetch($manager, ["fieldPaths" => [
-    'object.$' => "MyWildCardArrayObject",
+    'object.$' => "MyWildcardArrayObject",
     'object.one' => "MyArrayObject"
 ]]);
 var_dump($documents[0] instanceof stdClass);
 var_dump(is_object($documents[0]->object));
-var_dump($documents[0]->object->one instanceof MyArrayObject);
-var_dump($documents[0]->object->two instanceof MyWildCardArrayObject);
+var_dump($documents[0]->object->one instanceof MyWildcardArrayObject);
+var_dump($documents[0]->object->two instanceof MyWildcardArrayObject);
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECT--
-Setting 'array.$' path to 'MyWildCardArrayObject'
+Setting 'array.$' path to 'MyWildcardArrayObject'
 bool(true)
 bool(true)
 bool(true)
 bool(true)
 
-Setting 'array.1' to 'MyArrayObject' and 'array.$' path to 'MyWildCardArrayObject'
+Setting 'array.1' to 'MyArrayObject' and 'array.$' path to 'MyWildcardArrayObject'
 bool(true)
 bool(true)
 bool(true)
 bool(true)
 
-Setting 'array.$' to 'MyWildCardArrayObject' and 'array.1' path to 'MyArrayObject'
+Setting 'array.$' to 'MyWildcardArrayObject' and 'array.1' path to 'MyArrayObject'
 bool(true)
 bool(true)
 bool(true)
 bool(true)
 
-Setting 'object.$' path to 'MyWildCardArrayObject'
+Setting 'object.$' path to 'MyWildcardArrayObject'
 bool(true)
 bool(true)
 bool(true)
 bool(true)
 
-Setting 'object.two' to 'MyArrayObject' and 'object.$' path to 'MyWildCardArrayObject'
+Setting 'object.two' to 'MyArrayObject' and 'object.$' path to 'MyWildcardArrayObject'
 bool(true)
 bool(true)
 bool(true)
 bool(true)
 
-Setting 'object.$' to 'MyWildCardArrayObject' and 'object.one' path to 'MyArrayObject'
+Setting 'object.$' to 'MyWildcardArrayObject' and 'object.one' path to 'MyArrayObject'
 bool(true)
 bool(true)
 bool(true)

--- a/tests/bson/typemap-006.phpt
+++ b/tests/bson/typemap-006.phpt
@@ -1,0 +1,141 @@
+--TEST--
+MongoDB\Driver\Cursor::setTypeMap(): Setting fieldPath typemaps for compound types with wild card keys
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('STANDALONE'); CLEANUP(STANDALONE); ?>
+--FILE--
+<?php
+
+require_once __DIR__ . "/../utils/basic.inc";
+
+class MyArrayObject extends ArrayObject implements MongoDB\BSON\Unserializable
+{
+    function bsonUnserialize(array $data)
+    {
+        parent::__construct($data, ArrayObject::ARRAY_AS_PROPS);
+    }
+}
+
+class MyWildCardArrayObject extends MyArrayObject {};
+
+$manager = new MongoDB\Driver\Manager(STANDALONE);
+
+$document = [
+    '_id' => 1,
+    'array' => [0 => [ 4, 5, 6 ], 1 => [ 7, 8, 9 ]],
+    'object' => ['one' => [ 4, 5, 6 ], 'two' => [ 7, 8, 9 ]],
+];
+
+$bulk = new MongoDB\Driver\BulkWrite();
+$bulk->insert($document);
+$manager->executeBulkWrite(NS, $bulk);
+
+function fetch($manager, $typemap = []) {
+    $cursor = $manager->executeQuery(NS, new MongoDB\Driver\Query([]));
+    if ($typemap) {
+        $cursor->setTypeMap($typemap);
+    }
+
+    $documents = $cursor->toArray();
+    return $documents;
+}
+
+
+echo "\nSetting 'array.$' path to 'MyWildCardArrayObject'\n";
+$documents = fetch($manager, ["fieldPaths" => [
+    'array.$' => "MyWildCardArrayObject"
+]]);
+var_dump($documents[0] instanceof stdClass);
+var_dump(is_array($documents[0]->array));
+var_dump($documents[0]->array[0] instanceof MyWildCardArrayObject);
+var_dump($documents[0]->array[1] instanceof MyWildCardArrayObject);
+
+echo "\nSetting 'array.1' to 'MyArrayObject' and 'array.$' path to 'MyWildCardArrayObject'\n";
+$documents = fetch($manager, ["fieldPaths" => [
+    'array.1' => "MyArrayObject",
+    'array.$' => "MyWildCardArrayObject"
+]]);
+var_dump($documents[0] instanceof stdClass);
+var_dump(is_array($documents[0]->array));
+var_dump($documents[0]->array[0] instanceof MyWildCardArrayObject);
+var_dump($documents[0]->array[1] instanceof MyArrayObject);
+
+echo "\nSetting 'array.$' to 'MyWildCardArrayObject' and 'array.1' path to 'MyArrayObject'\n";
+$documents = fetch($manager, ["fieldPaths" => [
+    'array.$' => "MyWildCardArrayObject",
+    'array.1' => "MyArrayObject"
+]]);
+var_dump($documents[0] instanceof stdClass);
+var_dump(is_array($documents[0]->array));
+var_dump($documents[0]->array[0] instanceof MyWildCardArrayObject);
+var_dump($documents[0]->array[1] instanceof MyArrayObject);
+
+
+echo "\nSetting 'object.$' path to 'MyWildCardArrayObject'\n";
+$documents = fetch($manager, ["fieldPaths" => [
+    'object.$' => "MyWildCardArrayObject"
+]]);
+var_dump($documents[0] instanceof stdClass);
+var_dump(is_object($documents[0]->object));
+var_dump($documents[0]->object->one instanceof MyWildCardArrayObject);
+var_dump($documents[0]->object->two instanceof MyWildCardArrayObject);
+
+echo "\nSetting 'object.two' to 'MyArrayObject' and 'object.$' path to 'MyWildCardArrayObject'\n";
+$documents = fetch($manager, ["fieldPaths" => [
+    'object.two' => "MyArrayObject",
+    'object.$' => "MyWildCardArrayObject"
+]]);
+var_dump($documents[0] instanceof stdClass);
+var_dump(is_object($documents[0]->object));
+var_dump($documents[0]->object->one instanceof MyWildCardArrayObject);
+var_dump($documents[0]->object->two instanceof MyArrayObject);
+
+echo "\nSetting 'object.$' to 'MyWildCardArrayObject' and 'object.one' path to 'MyArrayObject'\n";
+$documents = fetch($manager, ["fieldPaths" => [
+    'object.$' => "MyWildCardArrayObject",
+    'object.one' => "MyArrayObject"
+]]);
+var_dump($documents[0] instanceof stdClass);
+var_dump(is_object($documents[0]->object));
+var_dump($documents[0]->object->one instanceof MyArrayObject);
+var_dump($documents[0]->object->two instanceof MyWildCardArrayObject);
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+Setting 'array.$' path to 'MyWildCardArrayObject'
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+
+Setting 'array.1' to 'MyArrayObject' and 'array.$' path to 'MyWildCardArrayObject'
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+
+Setting 'array.$' to 'MyWildCardArrayObject' and 'array.1' path to 'MyArrayObject'
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+
+Setting 'object.$' path to 'MyWildCardArrayObject'
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+
+Setting 'object.two' to 'MyArrayObject' and 'object.$' path to 'MyWildCardArrayObject'
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+
+Setting 'object.$' to 'MyWildCardArrayObject' and 'object.one' path to 'MyArrayObject'
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+===DONE===

--- a/tests/bson/typemap-007.phpt
+++ b/tests/bson/typemap-007.phpt
@@ -1,5 +1,5 @@
 --TEST--
-MongoDB\Driver\Cursor::setTypeMap(): Setting fieldPath typemaps for compound types with wild card keys (nested)
+MongoDB\Driver\Cursor::setTypeMap(): Setting fieldPath typemaps for compound types with wildcard keys (nested)
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php NEEDS('STANDALONE'); CLEANUP(STANDALONE); ?>
@@ -16,7 +16,7 @@ class MyArrayObject extends ArrayObject implements MongoDB\BSON\Unserializable
     }
 }
 
-class MyWildCardArrayObject extends MyArrayObject {};
+class MyWildcardArrayObject extends MyArrayObject {};
 
 $manager = new MongoDB\Driver\Manager(STANDALONE);
 
@@ -49,57 +49,69 @@ function fetch($manager, $typemap = []) {
 }
 
 
-echo "\nSetting 'object.$.child1' path to 'MyWildCardArrayObject'\n";
+echo "\nSetting 'object.$.child1' path to 'MyWildcardArrayObject'\n";
 $documents = fetch($manager, ["fieldPaths" => [
-    'object.$.child1' => "MyWildCardArrayObject"
+    'object.$.child1' => "MyWildcardArrayObject"
 ]]);
 var_dump($documents[0]->object->parent1 instanceof stdClass);
-var_dump($documents[0]->object->parent1->child1 instanceof MyWildCardArrayObject);
+var_dump($documents[0]->object->parent1->child1 instanceof MyWildcardArrayObject);
 var_dump(is_array($documents[0]->object->parent1->child2));
 var_dump($documents[0]->object->parent2 instanceof stdClass);
-var_dump($documents[0]->object->parent2->child1 instanceof MyWildCardArrayObject);
+var_dump($documents[0]->object->parent2->child1 instanceof MyWildcardArrayObject);
 var_dump(is_array($documents[0]->object->parent2->child2));
 
-echo "\nSetting 'object.parent1.$' path to 'MyWildCardArrayObject' and 'object.parent2.child1' to 'MyArrayObject'\n";
+echo "\nSetting 'object.parent1.$' path to 'MyWildcardArrayObject' and 'object.parent2.child1' to 'MyArrayObject'\n";
 $documents = fetch($manager, ["fieldPaths" => [
-    'object.parent1.$'      => "MyWildCardArrayObject",
+    'object.parent1.$'      => "MyWildcardArrayObject",
     'object.parent2.child1' => "MyArrayObject",
 ]]);
 var_dump($documents[0]->object->parent1 instanceof stdClass);
-var_dump($documents[0]->object->parent1->child1 instanceof MyWildCardArrayObject);
-var_dump($documents[0]->object->parent1->child2 instanceof MyWildCardArrayObject);
+var_dump($documents[0]->object->parent1->child1 instanceof MyWildcardArrayObject);
+var_dump($documents[0]->object->parent1->child2 instanceof MyWildcardArrayObject);
 var_dump($documents[0]->object->parent2 instanceof stdClass);
 var_dump($documents[0]->object->parent2->child1 instanceof MyArrayObject);
 var_dump(is_array($documents[0]->object->parent2->child2));
 
-echo "\nSetting 'object.parent1.$' path to 'MyWildCardArrayObject' and 'object.$.$' to 'MyArrayObject'\n";
+echo "\nSetting 'object.parent1.$' path to 'MyWildcardArrayObject' and 'object.$.$' to 'MyArrayObject'\n";
 $documents = fetch($manager, ["fieldPaths" => [
-    'object.parent1.$'    => "MyWildCardArrayObject",
+    'object.parent1.$'    => "MyWildcardArrayObject",
     'object.$.$'          => "MyArrayObject",
 ]]);
 var_dump($documents[0]->object->parent1 instanceof stdClass);
-var_dump($documents[0]->object->parent1->child1 instanceof MyWildCardArrayObject);
-var_dump($documents[0]->object->parent1->child2 instanceof MyWildCardArrayObject);
+var_dump($documents[0]->object->parent1->child1 instanceof MyWildcardArrayObject);
+var_dump($documents[0]->object->parent1->child2 instanceof MyWildcardArrayObject);
 var_dump($documents[0]->object->parent2 instanceof stdClass);
 var_dump($documents[0]->object->parent2->child1 instanceof MyArrayObject);
 var_dump($documents[0]->object->parent2->child2 instanceof MyArrayObject);
 
-echo "\nSetting 'object.parent1.$' path to 'MyWildCardArrayObject' and 'object.$.child2' to 'MyArrayObject'\n";
+echo "\nSetting 'object.parent1.$' path to 'MyWildcardArrayObject' and 'object.$.child2' to 'MyArrayObject'\n";
 $documents = fetch($manager, ["fieldPaths" => [
-    'object.parent1.child1' => "MyWildCardArrayObject",
+    'object.parent1.child1' => "MyWildcardArrayObject",
     'object.$.child2'       => "MyArrayObject",
 ]]);
 var_dump($documents[0]->object->parent1 instanceof stdClass);
-var_dump($documents[0]->object->parent1->child1 instanceof MyWildCardArrayObject);
+var_dump($documents[0]->object->parent1->child1 instanceof MyWildcardArrayObject);
 var_dump($documents[0]->object->parent1->child2 instanceof MyArrayObject);
 var_dump($documents[0]->object->parent2 instanceof stdClass);
 var_dump(is_array($documents[0]->object->parent2->child1));
 var_dump($documents[0]->object->parent2->child2 instanceof MyArrayObject);
+
+echo "\nSetting 'object.parent1.child2 path to 'MyArrayObject' and 'object.$.$' to 'MyWildcardArrayObject'\n";
+$documents = fetch($manager, ["fieldPaths" => [
+    'object.parent1.child2' => "MyArrayObject",
+    'object.$.$'            => "MyWildcardArrayObject",
+]]);
+var_dump($documents[0]->object->parent1 instanceof stdClass);
+var_dump($documents[0]->object->parent1->child1 instanceof MyWildcardArrayObject);
+var_dump($documents[0]->object->parent1->child2 instanceof MyArrayObject);
+var_dump($documents[0]->object->parent2 instanceof stdClass);
+var_dump($documents[0]->object->parent2->child1 instanceof MyWildcardArrayObject);
+var_dump($documents[0]->object->parent2->child2 instanceof MyWildcardArrayObject);
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECT--
-Setting 'object.$.child1' path to 'MyWildCardArrayObject'
+Setting 'object.$.child1' path to 'MyWildcardArrayObject'
 bool(true)
 bool(true)
 bool(true)
@@ -107,7 +119,7 @@ bool(true)
 bool(true)
 bool(true)
 
-Setting 'object.parent1.$' path to 'MyWildCardArrayObject' and 'object.parent2.child1' to 'MyArrayObject'
+Setting 'object.parent1.$' path to 'MyWildcardArrayObject' and 'object.parent2.child1' to 'MyArrayObject'
 bool(true)
 bool(true)
 bool(true)
@@ -115,7 +127,7 @@ bool(true)
 bool(true)
 bool(true)
 
-Setting 'object.parent1.$' path to 'MyWildCardArrayObject' and 'object.$.$' to 'MyArrayObject'
+Setting 'object.parent1.$' path to 'MyWildcardArrayObject' and 'object.$.$' to 'MyArrayObject'
 bool(true)
 bool(true)
 bool(true)
@@ -123,7 +135,15 @@ bool(true)
 bool(true)
 bool(true)
 
-Setting 'object.parent1.$' path to 'MyWildCardArrayObject' and 'object.$.child2' to 'MyArrayObject'
+Setting 'object.parent1.$' path to 'MyWildcardArrayObject' and 'object.$.child2' to 'MyArrayObject'
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+
+Setting 'object.parent1.child2 path to 'MyArrayObject' and 'object.$.$' to 'MyWildcardArrayObject'
 bool(true)
 bool(true)
 bool(true)

--- a/tests/bson/typemap-007.phpt
+++ b/tests/bson/typemap-007.phpt
@@ -1,0 +1,133 @@
+--TEST--
+MongoDB\Driver\Cursor::setTypeMap(): Setting fieldPath typemaps for compound types with wild card keys (nested)
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('STANDALONE'); CLEANUP(STANDALONE); ?>
+--FILE--
+<?php
+
+require_once __DIR__ . "/../utils/basic.inc";
+
+class MyArrayObject extends ArrayObject implements MongoDB\BSON\Unserializable
+{
+    function bsonUnserialize(array $data)
+    {
+        parent::__construct($data, ArrayObject::ARRAY_AS_PROPS);
+    }
+}
+
+class MyWildCardArrayObject extends MyArrayObject {};
+
+$manager = new MongoDB\Driver\Manager(STANDALONE);
+
+$document = [
+    '_id' => 1,
+    'object' => [
+        'parent1' => [
+            'child1' => [ 1, 2, 3 ],
+            'child2' => [ 4, 5, 6 ],
+        ],
+        'parent2' => [
+            'child1' => [  7,  8,  9 ],
+            'child2' => [ 10, 11, 12 ],
+        ],
+    ],
+];
+
+$bulk = new MongoDB\Driver\BulkWrite();
+$bulk->insert($document);
+$manager->executeBulkWrite(NS, $bulk);
+
+function fetch($manager, $typemap = []) {
+    $cursor = $manager->executeQuery(NS, new MongoDB\Driver\Query([]));
+    if ($typemap) {
+        $cursor->setTypeMap($typemap);
+    }
+
+    $documents = $cursor->toArray();
+    return $documents;
+}
+
+
+echo "\nSetting 'object.$.child1' path to 'MyWildCardArrayObject'\n";
+$documents = fetch($manager, ["fieldPaths" => [
+    'object.$.child1' => "MyWildCardArrayObject"
+]]);
+var_dump($documents[0]->object->parent1 instanceof stdClass);
+var_dump($documents[0]->object->parent1->child1 instanceof MyWildCardArrayObject);
+var_dump(is_array($documents[0]->object->parent1->child2));
+var_dump($documents[0]->object->parent2 instanceof stdClass);
+var_dump($documents[0]->object->parent2->child1 instanceof MyWildCardArrayObject);
+var_dump(is_array($documents[0]->object->parent2->child2));
+
+echo "\nSetting 'object.parent1.$' path to 'MyWildCardArrayObject' and 'object.parent2.child1' to 'MyArrayObject'\n";
+$documents = fetch($manager, ["fieldPaths" => [
+    'object.parent1.$'      => "MyWildCardArrayObject",
+    'object.parent2.child1' => "MyArrayObject",
+]]);
+var_dump($documents[0]->object->parent1 instanceof stdClass);
+var_dump($documents[0]->object->parent1->child1 instanceof MyWildCardArrayObject);
+var_dump($documents[0]->object->parent1->child2 instanceof MyWildCardArrayObject);
+var_dump($documents[0]->object->parent2 instanceof stdClass);
+var_dump($documents[0]->object->parent2->child1 instanceof MyArrayObject);
+var_dump(is_array($documents[0]->object->parent2->child2));
+
+echo "\nSetting 'object.parent1.$' path to 'MyWildCardArrayObject' and 'object.$.$' to 'MyArrayObject'\n";
+$documents = fetch($manager, ["fieldPaths" => [
+    'object.parent1.$'    => "MyWildCardArrayObject",
+    'object.$.$'          => "MyArrayObject",
+]]);
+var_dump($documents[0]->object->parent1 instanceof stdClass);
+var_dump($documents[0]->object->parent1->child1 instanceof MyWildCardArrayObject);
+var_dump($documents[0]->object->parent1->child2 instanceof MyWildCardArrayObject);
+var_dump($documents[0]->object->parent2 instanceof stdClass);
+var_dump($documents[0]->object->parent2->child1 instanceof MyArrayObject);
+var_dump($documents[0]->object->parent2->child2 instanceof MyArrayObject);
+
+echo "\nSetting 'object.parent1.$' path to 'MyWildCardArrayObject' and 'object.$.child2' to 'MyArrayObject'\n";
+$documents = fetch($manager, ["fieldPaths" => [
+    'object.parent1.child1' => "MyWildCardArrayObject",
+    'object.$.child2'       => "MyArrayObject",
+]]);
+var_dump($documents[0]->object->parent1 instanceof stdClass);
+var_dump($documents[0]->object->parent1->child1 instanceof MyWildCardArrayObject);
+var_dump($documents[0]->object->parent1->child2 instanceof MyArrayObject);
+var_dump($documents[0]->object->parent2 instanceof stdClass);
+var_dump(is_array($documents[0]->object->parent2->child1));
+var_dump($documents[0]->object->parent2->child2 instanceof MyArrayObject);
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+Setting 'object.$.child1' path to 'MyWildCardArrayObject'
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+
+Setting 'object.parent1.$' path to 'MyWildCardArrayObject' and 'object.parent2.child1' to 'MyArrayObject'
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+
+Setting 'object.parent1.$' path to 'MyWildCardArrayObject' and 'object.$.$' to 'MyArrayObject'
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+
+Setting 'object.parent1.$' path to 'MyWildCardArrayObject' and 'object.$.child2' to 'MyArrayObject'
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+===DONE===

--- a/tests/bson/typemap-008.phpt
+++ b/tests/bson/typemap-008.phpt
@@ -1,0 +1,122 @@
+--TEST--
+MongoDB\Driver\Cursor::setTypeMap(): fieldPath typemaps without server
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+--FILE--
+<?php
+
+class MyArrayObject extends ArrayObject implements MongoDB\BSON\Unserializable
+{
+    function bsonUnserialize(array $data)
+    {
+        parent::__construct($data, ArrayObject::ARRAY_AS_PROPS);
+    }
+}
+
+class MyWildCardArrayObject extends MyArrayObject {};
+
+$bson = \MongoDB\BSON\fromPHP( [
+    '_id' => 1,
+    'object' => [
+        'parent1' => [
+            'child1' => [ 1, 2, 3 ],
+            'child2' => [ 4, 5, 6 ],
+        ],
+        'parent2' => [
+            'child1' => [  7,  8,  9 ],
+            'child2' => [ 10, 11, 12 ],
+        ],
+    ],
+] );
+
+function fetch($bson, $typeMap = [])
+{
+    for ($i = 0; $i < 25000; $i++) {
+        $documents = [ \MongoDB\BSON\toPHP($bson, $typeMap) ];
+    }
+    return $documents;
+}
+
+
+echo "\nSetting 'object.$.child1' path to 'MyWildCardArrayObject'\n";
+$documents = fetch($bson, ["fieldPaths" => [
+    'object.$.child1' => "MyWildCardArrayObject"
+]]);
+var_dump($documents[0]->object->parent1 instanceof stdClass);
+var_dump($documents[0]->object->parent1->child1 instanceof MyWildCardArrayObject);
+var_dump(is_array($documents[0]->object->parent1->child2));
+var_dump($documents[0]->object->parent2 instanceof stdClass);
+var_dump($documents[0]->object->parent2->child1 instanceof MyWildCardArrayObject);
+var_dump(is_array($documents[0]->object->parent2->child2));
+
+echo "\nSetting 'object.parent1.$' path to 'MyWildCardArrayObject' and 'object.parent2.child1' to 'MyArrayObject'\n";
+$documents = fetch($bson, ["fieldPaths" => [
+    'object.parent1.$'      => "MyWildCardArrayObject",
+    'object.parent2.child1' => "MyArrayObject",
+]]);
+var_dump($documents[0]->object->parent1 instanceof stdClass);
+var_dump($documents[0]->object->parent1->child1 instanceof MyWildCardArrayObject);
+var_dump($documents[0]->object->parent1->child2 instanceof MyWildCardArrayObject);
+var_dump($documents[0]->object->parent2 instanceof stdClass);
+var_dump($documents[0]->object->parent2->child1 instanceof MyArrayObject);
+var_dump(is_array($documents[0]->object->parent2->child2));
+
+echo "\nSetting 'object.parent1.$' path to 'MyWildCardArrayObject' and 'object.$.$' to 'MyArrayObject'\n";
+$documents = fetch($bson, ["fieldPaths" => [
+    'object.parent1.$'    => "MyWildCardArrayObject",
+    'object.$.$'          => "MyArrayObject",
+]]);
+var_dump($documents[0]->object->parent1 instanceof stdClass);
+var_dump($documents[0]->object->parent1->child1 instanceof MyWildCardArrayObject);
+var_dump($documents[0]->object->parent1->child2 instanceof MyWildCardArrayObject);
+var_dump($documents[0]->object->parent2 instanceof stdClass);
+var_dump($documents[0]->object->parent2->child1 instanceof MyArrayObject);
+var_dump($documents[0]->object->parent2->child2 instanceof MyArrayObject);
+
+echo "\nSetting 'object.parent1.$' path to 'MyWildCardArrayObject' and 'object.$.child2' to 'MyArrayObject'\n";
+$documents = fetch($bson, ["fieldPaths" => [
+    'object.parent1.child1' => "MyWildCardArrayObject",
+    'object.$.child2'       => "MyArrayObject",
+]]);
+var_dump($documents[0]->object->parent1 instanceof stdClass);
+var_dump($documents[0]->object->parent1->child1 instanceof MyWildCardArrayObject);
+var_dump($documents[0]->object->parent1->child2 instanceof MyArrayObject);
+var_dump($documents[0]->object->parent2 instanceof stdClass);
+var_dump(is_array($documents[0]->object->parent2->child1));
+var_dump($documents[0]->object->parent2->child2 instanceof MyArrayObject);
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+Setting 'object.$.child1' path to 'MyWildCardArrayObject'
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+
+Setting 'object.parent1.$' path to 'MyWildCardArrayObject' and 'object.parent2.child1' to 'MyArrayObject'
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+
+Setting 'object.parent1.$' path to 'MyWildCardArrayObject' and 'object.$.$' to 'MyArrayObject'
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+
+Setting 'object.parent1.$' path to 'MyWildCardArrayObject' and 'object.$.child2' to 'MyArrayObject'
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+===DONE===

--- a/tests/cursor/cursor-setTypeMap_error-003.phpt
+++ b/tests/cursor/cursor-setTypeMap_error-003.phpt
@@ -1,0 +1,67 @@
+--TEST--
+Cursor::setTypeMap(): fieldPaths must be an array, with single key/string elements
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('STANDALONE'); CLEANUP(STANDALONE); ?>
+--FILE--
+<?php
+
+require_once __DIR__ . "/../utils/basic.inc";
+
+abstract class MyAbstractDocument implements MongoDB\BSON\Unserializable {}
+
+class MyDocument {}
+
+$fieldPaths = [
+    'notAnArray',
+    ['notAssociative'],
+    ['missing' => 'MissingClass'],
+    ['abstract' => 'MyAbstractDocument'],
+    ['my' => 'MyDocument'],
+    ['unserialize' => 'MongoDB\BSON\Unserializable'],
+];
+
+$manager = new MongoDB\Driver\Manager(STANDALONE);
+$cursor = $manager->executeQuery(NS, new MongoDB\Driver\Query([]));
+
+foreach ($fieldPaths as $fieldPath) {
+    $typeMap = ['fieldPaths' => $fieldPath];
+
+    printf("Test typeMap: %s\n", json_encode($typeMap));
+
+    echo throws(function() use ($cursor, $typeMap) {
+        $cursor->setTypeMap($typeMap);
+    }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+    echo "\n";
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+Test typeMap: {"fieldPaths":"notAnArray"}
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+The 'fieldPaths' element is not an array
+
+Test typeMap: {"fieldPaths":["notAssociative"]}
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+The 'fieldPaths' element is not an associative array
+
+Test typeMap: {"fieldPaths":{"missing":"MissingClass"}}
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Class MissingClass does not exist
+
+Test typeMap: {"fieldPaths":{"abstract":"MyAbstractDocument"}}
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Class MyAbstractDocument is not instantiatable
+
+Test typeMap: {"fieldPaths":{"my":"MyDocument"}}
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Class MyDocument does not implement MongoDB\BSON\Unserializable
+
+Test typeMap: {"fieldPaths":{"unserialize":"MongoDB\\BSON\\Unserializable"}}
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Class MongoDB\BSON\Unserializable is not instantiatable
+
+===DONE===

--- a/tests/cursor/cursor-setTypeMap_error-003.phpt
+++ b/tests/cursor/cursor-setTypeMap_error-003.phpt
@@ -31,9 +31,7 @@ foreach ($fieldPaths as $fieldPath) {
 
     echo throws(function() use ($cursor, $typeMap) {
         $cursor->setTypeMap($typeMap);
-    }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
-
-    echo "\n";
+    }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n\n";
 }
 
 ?>

--- a/tests/cursor/cursor-setTypeMap_error-004.phpt
+++ b/tests/cursor/cursor-setTypeMap_error-004.phpt
@@ -1,0 +1,66 @@
+--TEST--
+Cursor::setTypeMap(): invalid fieldPaths keys
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('STANDALONE'); CLEANUP(STANDALONE); ?>
+--FILE--
+<?php
+
+require_once __DIR__ . "/../utils/basic.inc";
+
+class MyDocument extends ArrayObject implements MongoDB\BSON\Unserializable
+{
+    function bsonUnserialize(array $data)
+    {
+        parent::__construct($data, ArrayObject::ARRAY_AS_PROPS);
+    }
+}
+
+$fieldPaths = [
+    ['' => 'MyDocument'],
+    ['.foo' => 'MyDocument'],
+    ['...' => 'MyDocument'],
+    ['foo.' => 'MyDocument'],
+    ['foo..bar' => 'MyDocument'],
+];
+
+$manager = new MongoDB\Driver\Manager(STANDALONE);
+$cursor = $manager->executeQuery(NS, new MongoDB\Driver\Query([]));
+
+foreach ($fieldPaths as $fieldPath) {
+    $typeMap = ['fieldPaths' => $fieldPath];
+
+    printf("Test typeMap: %s\n", json_encode($typeMap));
+
+    echo throws(function() use ($cursor, $typeMap) {
+        $cursor->setTypeMap($typeMap);
+    }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+    echo "\n";
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+Test typeMap: {"fieldPaths":{"":"MyDocument"}}
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+The 'fieldPaths' element may not be an empty string
+
+Test typeMap: {"fieldPaths":{".foo":"MyDocument"}}
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+A 'fieldPaths' key may not start with a '.'
+
+Test typeMap: {"fieldPaths":{"...":"MyDocument"}}
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+A 'fieldPaths' key may not start with a '.'
+
+Test typeMap: {"fieldPaths":{"foo.":"MyDocument"}}
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+A 'fieldPaths' key may not end with a '.'
+
+Test typeMap: {"fieldPaths":{"foo..bar":"MyDocument"}}
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+A 'fieldPaths' key may not have an empty segment
+
+===DONE===


### PR DESCRIPTION
First step of implementing the fieldPath syntax. It doesn't do wild cards yet, or typemaps for scalar types.