### PR TITLE
PHPC-1148: Throw InvalidArgumentException if BulkWrite is executed multiple times

### DIFF
--- a/php_phongo.c
+++ b/php_phongo.c
@@ -616,7 +616,7 @@ bool phongo_execute_bulk_write(mongoc_client_t* client, const char* namespace, p
 	const mongoc_write_concern_t* write_concern = NULL;
 
 	if (bulk_write->executed) {
-		phongo_throw_exception(PHONGO_ERROR_WRITE_FAILED TSRMLS_CC, "BulkWrite objects may only be executed once and this instance has already been executed");
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "BulkWrite objects may only be executed once and this instance has already been executed");
 		return false;
 	}
 

--- a/tests/bulk/bulkwrite_error-002.phpt
+++ b/tests/bulk/bulkwrite_error-002.phpt
@@ -16,13 +16,13 @@ printf("Inserted %d document(s)\n", $result->getInsertedCount());
 
 echo throws(function() use ($manager, $bulk) {
     $result = $manager->executeBulkWrite(NS, $bulk);
-}, 'MongoDB\Driver\Exception\BulkWriteException'), "\n";
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
 Inserted 1 document(s)
-OK: Got MongoDB\Driver\Exception\BulkWriteException
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 BulkWrite objects may only be executed once and this instance has already been executed
 ===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1148