### PR TITLE
 PHPC-1151: Maintain Session reference on Cursor

### DIFF
--- a/php_phongo_structs.h
+++ b/php_phongo_structs.h
@@ -65,6 +65,7 @@ typedef struct {
 	PHONGO_STRUCT_ZVAL     query;
 	PHONGO_STRUCT_ZVAL     command;
 	PHONGO_STRUCT_ZVAL     read_preference;
+	PHONGO_STRUCT_ZVAL     session;
 	PHONGO_ZEND_OBJECT_POST
 } php_phongo_cursor_t;
 

--- a/src/MongoDB/Cursor.c
+++ b/src/MongoDB/Cursor.c
@@ -490,6 +490,18 @@ static HashTable *php_phongo_cursor_get_debug_info(zval *object, int *is_temp TS
 		ADD_ASSOC_NULL_EX(&retval, "readPreference");
 	}
 
+	if (!Z_ISUNDEF(intern->session)) {
+#if PHP_VERSION_ID >= 70000
+		ADD_ASSOC_ZVAL_EX(&retval, "session", &intern->session);
+		Z_ADDREF(intern->session);
+#else
+		ADD_ASSOC_ZVAL_EX(&retval, "session", intern->session);
+		Z_ADDREF_P(intern->session);
+#endif
+	} else {
+		ADD_ASSOC_NULL_EX(&retval, "session");
+	}
+
 	ADD_ASSOC_BOOL_EX(&retval, "isDead", !mongoc_cursor_is_alive(intern->cursor));
 
 	ADD_ASSOC_LONG_EX(&retval, "currentIndex", intern->current);

--- a/src/MongoDB/Cursor.c
+++ b/src/MongoDB/Cursor.c
@@ -392,6 +392,10 @@ static void php_phongo_cursor_free_object(phongo_free_object_arg *object TSRMLS_
 		zval_ptr_dtor(&intern->read_preference);
 	}
 
+	if (!Z_ISUNDEF(intern->session)) {
+		zval_ptr_dtor(&intern->session);
+	}
+
 	php_phongo_cursor_free_current(intern);
 
 #if PHP_VERSION_ID < 70000

--- a/tests/cursor/bug1151-001.phpt
+++ b/tests/cursor/bug1151-001.phpt
@@ -1,0 +1,38 @@
+--TEST--
+PHPC-1151: Segfault if session unset before first getMore (find)
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
+<?php NEEDS('STANDALONE'); ?>
+<?php NEEDS_ATLEAST_MONGODB_VERSION(STANDALONE, "3.6"); ?>
+<?php CLEANUP(STANDALONE); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(STANDALONE);
+
+$bulk = new MongoDB\Driver\BulkWrite;
+$bulk->insert(['_id' => 1]);
+$bulk->insert(['_id' => 2]);
+$bulk->insert(['_id' => 3]);
+$manager->executeBulkWrite(NS, $bulk);
+
+$query = new MongoDB\Driver\Query([], ['batchSize' => 2]);
+$session = $manager->startSession();
+
+$cursor = $manager->executeQuery(NS, $query, ['session' => $session]);
+
+foreach ($cursor as $document) {
+    unset($session);
+    echo $document->_id, "\n";
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+1
+2
+3
+===DONE===

--- a/tests/cursor/bug1151-002.phpt
+++ b/tests/cursor/bug1151-002.phpt
@@ -1,0 +1,42 @@
+--TEST--
+PHPC-1151: Segfault if session unset before first getMore (aggregate)
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
+<?php NEEDS('STANDALONE'); ?>
+<?php NEEDS_ATLEAST_MONGODB_VERSION(STANDALONE, "3.6"); ?>
+<?php CLEANUP(STANDALONE); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(STANDALONE);
+
+$bulk = new MongoDB\Driver\BulkWrite;
+$bulk->insert(['_id' => 1]);
+$bulk->insert(['_id' => 2]);
+$bulk->insert(['_id' => 3]);
+$manager->executeBulkWrite(NS, $bulk);
+
+$command = new MongoDB\Driver\Command([
+    'aggregate' => COLLECTION_NAME,
+    'pipeline' => [],
+    'cursor' => ['batchSize' => 2],
+]);
+$session = $manager->startSession();
+
+$cursor = $manager->executeReadCommand(DATABASE_NAME, $command, ['session' => $session]);
+
+foreach ($cursor as $document) {
+    unset($session);
+    echo $document->_id, "\n";
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+1
+2
+3
+===DONE===

--- a/tests/cursor/bug1151-003.phpt
+++ b/tests/cursor/bug1151-003.phpt
@@ -1,0 +1,32 @@
+--TEST--
+PHPC-1151: Segfault if session unset before cursor is killed (find)
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
+<?php NEEDS('STANDALONE'); ?>
+<?php NEEDS_ATLEAST_MONGODB_VERSION(STANDALONE, "3.6"); ?>
+<?php CLEANUP(STANDALONE); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(STANDALONE);
+
+$bulk = new MongoDB\Driver\BulkWrite;
+$bulk->insert(['_id' => 1]);
+$bulk->insert(['_id' => 2]);
+$bulk->insert(['_id' => 3]);
+$manager->executeBulkWrite(NS, $bulk);
+
+$query = new MongoDB\Driver\Query([], ['batchSize' => 2]);
+$session = $manager->startSession();
+
+$cursor = $manager->executeQuery(NS, $query, ['session' => $session]);
+unset($session);
+unset($cursor);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+===DONE===

--- a/tests/cursor/bug1151-004.phpt
+++ b/tests/cursor/bug1151-004.phpt
@@ -1,0 +1,36 @@
+--TEST--
+PHPC-1151: Segfault if session unset before cursor is killed (aggregate)
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
+<?php NEEDS('STANDALONE'); ?>
+<?php NEEDS_ATLEAST_MONGODB_VERSION(STANDALONE, "3.6"); ?>
+<?php CLEANUP(STANDALONE); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(STANDALONE);
+
+$bulk = new MongoDB\Driver\BulkWrite;
+$bulk->insert(['_id' => 1]);
+$bulk->insert(['_id' => 2]);
+$bulk->insert(['_id' => 3]);
+$manager->executeBulkWrite(NS, $bulk);
+
+$command = new MongoDB\Driver\Command([
+    'aggregate' => COLLECTION_NAME,
+    'pipeline' => [],
+    'cursor' => ['batchSize' => 2],
+]);
+$session = $manager->startSession();
+
+$cursor = $manager->executeReadCommand(DATABASE_NAME, $command, ['session' => $session]);
+unset($session);
+unset($cursor);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+===DONE===

--- a/tests/manager/manager-executeCommand-001.phpt
+++ b/tests/manager/manager-executeCommand-001.phpt
@@ -54,6 +54,8 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
   }
   ["readPreference"]=>
   NULL
+  ["session"]=>
+  NULL
   ["isDead"]=>
   bool(false)
   ["currentIndex"]=>

--- a/tests/manager/manager-executeQuery-001.phpt
+++ b/tests/manager/manager-executeQuery-001.phpt
@@ -64,6 +64,8 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
   NULL
   ["readPreference"]=>
   NULL
+  ["session"]=>
+  NULL
   ["isDead"]=>
   bool(false)
   ["currentIndex"]=>

--- a/tests/manager/manager-executeQuery-002.phpt
+++ b/tests/manager/manager-executeQuery-002.phpt
@@ -64,6 +64,8 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
   NULL
   ["readPreference"]=>
   NULL
+  ["session"]=>
+  NULL
   ["isDead"]=>
   bool(false)
   ["currentIndex"]=>

--- a/tests/readPreference/bug0146-001.phpt
+++ b/tests/readPreference/bug0146-001.phpt
@@ -58,6 +58,8 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     ["mode"]=>
     string(7) "primary"
   }
+  ["session"]=>
+  NULL
   ["isDead"]=>
   bool(true)
   ["currentIndex"]=>
@@ -96,6 +98,8 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     ["mode"]=>
     string(16) "primaryPreferred"
   }
+  ["session"]=>
+  NULL
   ["isDead"]=>
   bool(true)
   ["currentIndex"]=>
@@ -134,6 +138,8 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     ["mode"]=>
     string(9) "secondary"
   }
+  ["session"]=>
+  NULL
   ["isDead"]=>
   bool(true)
   ["currentIndex"]=>
@@ -172,6 +178,8 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     ["mode"]=>
     string(18) "secondaryPreferred"
   }
+  ["session"]=>
+  NULL
   ["isDead"]=>
   bool(true)
   ["currentIndex"]=>
@@ -210,6 +218,8 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     ["mode"]=>
     string(7) "nearest"
   }
+  ["session"]=>
+  NULL
   ["isDead"]=>
   bool(true)
   ["currentIndex"]=>

--- a/tests/readPreference/bug0146-002.phpt
+++ b/tests/readPreference/bug0146-002.phpt
@@ -58,6 +58,8 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     ["mode"]=>
     string(7) "primary"
   }
+  ["session"]=>
+  NULL
   ["isDead"]=>
   bool(true)
   ["currentIndex"]=>
@@ -96,6 +98,8 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     ["mode"]=>
     string(16) "primaryPreferred"
   }
+  ["session"]=>
+  NULL
   ["isDead"]=>
   bool(true)
   ["currentIndex"]=>
@@ -134,6 +138,8 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     ["mode"]=>
     string(9) "secondary"
   }
+  ["session"]=>
+  NULL
   ["isDead"]=>
   bool(true)
   ["currentIndex"]=>
@@ -172,6 +178,8 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     ["mode"]=>
     string(18) "secondaryPreferred"
   }
+  ["session"]=>
+  NULL
   ["isDead"]=>
   bool(true)
   ["currentIndex"]=>
@@ -210,6 +218,8 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     ["mode"]=>
     string(7) "nearest"
   }
+  ["session"]=>
+  NULL
   ["isDead"]=>
   bool(true)
   ["currentIndex"]=>

--- a/tests/server/server-executeCommand-001.phpt
+++ b/tests/server/server-executeCommand-001.phpt
@@ -43,6 +43,8 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
   }
   ["readPreference"]=>
   NULL
+  ["session"]=>
+  NULL
   ["isDead"]=>
   bool(false)
   ["currentIndex"]=>


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1151

Although Cursors no longer store a reference to client objects, this is similar to what is still done for ReadPreference objects (see: https://github.com/mongodb/mongo-php-driver/commit/78839bde83d3df0d5775485a383d2e67e8a0e969).