### PR TITLE
Use longer maxAwaitTimeMS in changeStream test

### DIFF
--- a/tests/command/cursor-tailable-001.phpt
+++ b/tests/command/cursor-tailable-001.phpt
@@ -27,7 +27,7 @@ $command = new MongoDB\Driver\Command([
     'pipeline' => $pipeline,
     'cursor' => ['batchSize' => 0],
 ], [
-    'maxAwaitTimeMS' => 100,
+    'maxAwaitTimeMS' => 500,
 ]);
 
 $cursor = $manager->executeCommand(DATABASE_NAME, $command);
@@ -65,5 +65,5 @@ object(stdClass)#%d (%d) {
 Waited for 0.%d seconds
 Awaiting results...
 NULL
-Waited for 0.1%d seconds
+Waited for 0.5%d seconds
 ===DONE===


### PR DESCRIPTION
This makes the test more robust, since 100ms may not be long enough for the change to appear on some runs. I'll note that 500ms is also what @kvwalker decided to use in PHPLIB's [WatchFunctionalTest](https://github.com/mongodb/mongo-php-library/blob/master/tests/Operation/WatchFunctionalTest.php).