### PR TITLE
PHPC-1152, PHPC-1161: Emulate implicit sessions for command cursors

### DIFF
--- a/php_phongo.h
+++ b/php_phongo.h
@@ -134,8 +134,8 @@ void                     phongo_readconcern_init     (zval *return_value, const 
 void                     phongo_readpreference_init  (zval *return_value, const mongoc_read_prefs_t *read_prefs TSRMLS_DC);
 void                     phongo_writeconcern_init    (zval *return_value, const mongoc_write_concern_t *write_concern TSRMLS_DC);
 bool                     phongo_execute_bulk_write   (mongoc_client_t *client, const char *namespace, php_phongo_bulkwrite_t *bulk_write, zval *zwriteConcern, uint32_t server_id, zval *return_value, int return_value_used TSRMLS_DC);
-int                      phongo_execute_command      (mongoc_client_t *client, php_phongo_command_type_t type, const char *db, zval *zcommand, zval *zreadPreference, uint32_t server_id, zval *return_value, int return_value_used TSRMLS_DC);
-int                      phongo_execute_query        (mongoc_client_t *client, const char *namespace, zval *zquery, zval *zreadPreference, uint32_t server_id, zval *return_value, int return_value_used TSRMLS_DC);
+bool                     phongo_execute_command      (mongoc_client_t *client, php_phongo_command_type_t type, const char *db, zval *zcommand, zval *zreadPreference, uint32_t server_id, zval *return_value, int return_value_used TSRMLS_DC);
+bool                     phongo_execute_query        (mongoc_client_t *client, const char *namespace, zval *zquery, zval *zreadPreference, uint32_t server_id, zval *return_value, int return_value_used TSRMLS_DC);
 
 bool phongo_cursor_advance_and_check_for_error(mongoc_cursor_t *cursor TSRMLS_DC);
 

--- a/src/MongoDB/Cursor.c
+++ b/src/MongoDB/Cursor.c
@@ -460,7 +460,7 @@ static HashTable *php_phongo_cursor_get_debug_info(zval *object, int *is_temp TS
 	*is_temp = 1;
 	intern = Z_CURSOR_OBJ_P(object);
 
-	array_init_size(&retval, 9);
+	array_init_size(&retval, 10);
 
 	if (intern->database) {
 		ADD_ASSOC_STRING(&retval, "database", intern->database);

--- a/src/MongoDB/Cursor.c
+++ b/src/MongoDB/Cursor.c
@@ -28,6 +28,22 @@
 
 zend_class_entry *php_phongo_cursor_ce;
 
+/* Check if the cursor is exhausted (i.e. ID is zero) and free any reference to
+ * the session. Calling this function during iteration will allow an implicit
+ * session to return to the pool immediately after a getMore indicates that the
+ * server has no more results to return. */
+static void php_phongo_cursor_free_session_if_exhausted(php_phongo_cursor_t *cursor) /* {{{ */
+{
+	if (mongoc_cursor_get_id(cursor->cursor)) {
+		return;
+	}
+
+	if (!Z_ISUNDEF(cursor->session)) {
+		zval_ptr_dtor(&cursor->session);
+		ZVAL_UNDEF(&cursor->session);
+	}
+} /* }}} */
+
 static void php_phongo_cursor_free_current(php_phongo_cursor_t *cursor) /* {{{ */
 {
 	if (!Z_ISUNDEF(cursor->visitor_data.zchild)) {
@@ -117,6 +133,8 @@ static void php_phongo_cursor_iterator_move_forward(zend_object_iterator *iter T
 			phongo_throw_exception_from_bson_error_t(&error TSRMLS_CC);
 		}
 	}
+
+	php_phongo_cursor_free_session_if_exhausted(cursor);
 } /* }}} */
 
 static void php_phongo_cursor_iterator_rewind(zend_object_iterator *iter TSRMLS_DC) /* {{{ */
@@ -147,6 +165,8 @@ static void php_phongo_cursor_iterator_rewind(zend_object_iterator *iter TSRMLS_
 	if (doc) {
 		php_phongo_bson_to_zval_ex(bson_get_data(doc), doc->len, &cursor->visitor_data);
 	}
+
+	php_phongo_cursor_free_session_if_exhausted(cursor);
 } /* }}} */
 
 static zend_object_iterator_funcs php_phongo_cursor_iterator_funcs = {

--- a/tests/cursor/bug1152-001.phpt
+++ b/tests/cursor/bug1152-001.phpt
@@ -1,0 +1,133 @@
+--TEST--
+PHPC-1152: Command cursors should use the same session for getMore and killCursors (implicit)
+--SKIPIF--
+ <?php if (PHP_INT_SIZE !== 8) { die("skip Can't represent 64-bit ints on a 32-bit platform"); } ?>
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
+<?php NEEDS('STANDALONE'); ?>
+<?php NEEDS_ATLEAST_MONGODB_VERSION(STANDALONE, "3.6"); ?>
+<?php CLEANUP(STANDALONE); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+class Test implements MongoDB\Driver\Monitoring\CommandSubscriber
+{
+    private $lsidByCursorId = [];
+    private $lsidByRequestId = [];
+
+    public function executeCommand()
+    {
+        $manager = new MongoDB\Driver\Manager(STANDALONE);
+
+        $bulk = new MongoDB\Driver\BulkWrite;
+        $bulk->insert(['_id' => 1]);
+        $bulk->insert(['_id' => 2]);
+        $bulk->insert(['_id' => 3]);
+        $manager->executeBulkWrite(NS, $bulk);
+
+        $command = new MongoDB\Driver\Command([
+            'aggregate' => COLLECTION_NAME,
+            'pipeline' => [['$match' => new stdClass]],
+            'cursor' => ['batchSize' => 2],
+        ]);
+
+        MongoDB\Driver\Monitoring\addSubscriber($this);
+
+        /* By creating two cursors with the same name, PHP's reference counting
+         * will destroy the first after the second is created. Note that
+         * mongoc_cursor_destroy also destroys implicit sessions and returns
+         * them to the LIFO pool. This sequencing allows us to test that getMore
+         * and killCursors use the session ID corresponding to the original
+         * aggregate command. */
+        $cursor = $manager->executeCommand(DATABASE_NAME, $command);
+        $cursor->toArray();
+
+        $cursor = $manager->executeCommand(DATABASE_NAME, $command);
+        $cursor->toArray();
+
+        $cursor = $manager->executeCommand(DATABASE_NAME, $command);
+        $cursor = $manager->executeCommand(DATABASE_NAME, $command);
+        unset($cursor);
+
+        MongoDB\Driver\Monitoring\removeSubscriber($this);
+
+        /* We should expect two unique session IDs over the course of the test,
+         * since at most two implicit sessions would have been in use at any
+         * given time. */
+        printf("Unique session IDs used: %d\n", count(array_unique($this->lsidByRequestId)));
+    }
+
+    public function commandStarted(MongoDB\Driver\Monitoring\CommandStartedEvent $event)
+    {
+        $requestId = $event->getRequestId();
+        $sessionId = bin2hex((string) $event->getCommand()->lsid->id);
+
+        printf("%s session ID: %s\n", $event->getCommandName(), $sessionId);
+
+        if ($event->getCommandName() === 'aggregate') {
+            if (isset($this->lsidByRequestId[$requestId])) {
+                throw new UnexpectedValueException('Previous command observed for request ID: ' . $requestId);
+            }
+
+            $this->lsidByRequestId[$requestId] = $sessionId;
+        }
+
+        if ($event->getCommandName() === 'getMore') {
+            $cursorId = $event->getCommand()->getMore;
+
+            if ( ! isset($this->lsidByCursorId[$cursorId])) {
+                throw new UnexpectedValueException('No previous command observed for cursor ID: ' . $cursorId);
+            }
+
+            printf("getMore used same session as aggregate: %s\n", $sessionId === $this->lsidByCursorId[$cursorId] ? 'yes' : 'no');
+        }
+
+        if ($event->getCommandName() === 'killCursors') {
+            $cursorId = $event->getCommand()->cursors[0];
+
+            if ( ! isset($this->lsidByCursorId[$cursorId])) {
+                throw new UnexpectedValueException('No previous command observed for cursor ID: ' . $cursorId);
+            }
+
+            printf("killCursors used same session as aggregate: %s\n", $sessionId === $this->lsidByCursorId[$cursorId] ? 'yes' : 'no');
+        }
+    }
+
+    public function commandSucceeded(MongoDB\Driver\Monitoring\CommandSucceededEvent $event)
+    {
+        /* Associate the aggregate's session ID with its cursor ID so it can be
+         * looked up by the subsequent getMore or killCursors */
+        if ($event->getCommandName() === 'aggregate') {
+            $cursorId = $event->getReply()->cursor->id;
+            $requestId = $event->getRequestId();
+
+            $this->lsidByCursorId[$cursorId] = $this->lsidByRequestId[$requestId];
+        }
+    }
+
+    public function commandFailed(MongoDB\Driver\Monitoring\CommandFailedEvent $event)
+    {
+    }
+}
+
+(new Test)->executeCommand();
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+aggregate session ID: %x
+getMore session ID: %x
+getMore used same session as aggregate: yes
+aggregate session ID: %x
+getMore session ID: %x
+getMore used same session as aggregate: yes
+aggregate session ID: %x
+aggregate session ID: %x
+killCursors session ID: %x
+killCursors used same session as aggregate: yes
+killCursors session ID: %x
+killCursors used same session as aggregate: yes
+Unique session IDs used: 2
+===DONE===

--- a/tests/cursor/bug1152-002.phpt
+++ b/tests/cursor/bug1152-002.phpt
@@ -1,0 +1,131 @@
+--TEST--
+PHPC-1152: Command cursors should use the same session for getMore and killCursors (explicit)
+--SKIPIF--
+ <?php if (PHP_INT_SIZE !== 8) { die("skip Can't represent 64-bit ints on a 32-bit platform"); } ?>
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
+<?php NEEDS('STANDALONE'); ?>
+<?php NEEDS_ATLEAST_MONGODB_VERSION(STANDALONE, "3.6"); ?>
+<?php CLEANUP(STANDALONE); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+class Test implements MongoDB\Driver\Monitoring\CommandSubscriber
+{
+    private $lsidByCursorId = [];
+    private $lsidByRequestId = [];
+
+    public function executeCommand()
+    {
+        $manager = new MongoDB\Driver\Manager(STANDALONE);
+
+        $bulk = new MongoDB\Driver\BulkWrite;
+        $bulk->insert(['_id' => 1]);
+        $bulk->insert(['_id' => 2]);
+        $bulk->insert(['_id' => 3]);
+        $manager->executeBulkWrite(NS, $bulk);
+
+        $command = new MongoDB\Driver\Command([
+            'aggregate' => COLLECTION_NAME,
+            'pipeline' => [['$match' => new stdClass]],
+            'cursor' => ['batchSize' => 2],
+        ]);
+
+        $session = $manager->startSession();
+
+        MongoDB\Driver\Monitoring\addSubscriber($this);
+
+        /* This uses the same sequencing as the implicit session test; however,
+         * we should expect all commands (aggregate, getMore, and killCursors)
+         * to use the same explicit session ID. */
+        $cursor = $manager->executeCommand(DATABASE_NAME, $command, ['session' => $session]);
+        $cursor->toArray();
+
+        $cursor = $manager->executeCommand(DATABASE_NAME, $command, ['session' => $session]);
+        $cursor->toArray();
+
+        $cursor = $manager->executeCommand(DATABASE_NAME, $command, ['session' => $session]);
+        $cursor = $manager->executeCommand(DATABASE_NAME, $command, ['session' => $session]);
+        unset($cursor);
+
+        MongoDB\Driver\Monitoring\removeSubscriber($this);
+
+        /* We should expect one unique session ID over the course of the test,
+         * since all commands used the same explicit session. */
+        printf("Unique session IDs used: %d\n", count(array_unique($this->lsidByRequestId)));
+    }
+
+    public function commandStarted(MongoDB\Driver\Monitoring\CommandStartedEvent $event)
+    {
+        $requestId = $event->getRequestId();
+        $sessionId = bin2hex((string) $event->getCommand()->lsid->id);
+
+        printf("%s session ID: %s\n", $event->getCommandName(), $sessionId);
+
+        if ($event->getCommandName() === 'aggregate') {
+            if (isset($this->lsidByRequestId[$requestId])) {
+                throw new UnexpectedValueException('Previous command observed for request ID: ' . $requestId);
+            }
+
+            $this->lsidByRequestId[$requestId] = $sessionId;
+        }
+
+        if ($event->getCommandName() === 'getMore') {
+            $cursorId = $event->getCommand()->getMore;
+
+            if ( ! isset($this->lsidByCursorId[$cursorId])) {
+                throw new UnexpectedValueException('No previous command observed for cursor ID: ' . $cursorId);
+            }
+
+            printf("getMore used same session as aggregate: %s\n", $sessionId === $this->lsidByCursorId[$cursorId] ? 'yes' : 'no');
+        }
+
+        if ($event->getCommandName() === 'killCursors') {
+            $cursorId = $event->getCommand()->cursors[0];
+
+            if ( ! isset($this->lsidByCursorId[$cursorId])) {
+                throw new UnexpectedValueException('No previous command observed for cursor ID: ' . $cursorId);
+            }
+
+            printf("killCursors used same session as aggregate: %s\n", $sessionId === $this->lsidByCursorId[$cursorId] ? 'yes' : 'no');
+        }
+    }
+
+    public function commandSucceeded(MongoDB\Driver\Monitoring\CommandSucceededEvent $event)
+    {
+        /* Associate the aggregate's session ID with its cursor ID so it can be
+         * looked up by the subsequent getMore or killCursors */
+        if ($event->getCommandName() === 'aggregate') {
+            $cursorId = $event->getReply()->cursor->id;
+            $requestId = $event->getRequestId();
+
+            $this->lsidByCursorId[$cursorId] = $this->lsidByRequestId[$requestId];
+        }
+    }
+
+    public function commandFailed(MongoDB\Driver\Monitoring\CommandFailedEvent $event)
+    {
+    }
+}
+
+(new Test)->executeCommand();
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+aggregate session ID: %x
+getMore session ID: %x
+getMore used same session as aggregate: yes
+aggregate session ID: %x
+getMore session ID: %x
+getMore used same session as aggregate: yes
+aggregate session ID: %x
+aggregate session ID: %x
+killCursors session ID: %x
+killCursors used same session as aggregate: yes
+killCursors session ID: %x
+killCursors used same session as aggregate: yes
+Unique session IDs used: 1
+===DONE===

--- a/tests/cursor/cursor-session-001.phpt
+++ b/tests/cursor/cursor-session-001.phpt
@@ -1,0 +1,63 @@
+--TEST--
+MongoDB\Driver\Cursor debug output for query cursor includes explicit session
+--SKIPIF--
+<?php require __DIR__ . "/" ."../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
+<?php NEEDS('STANDALONE'); ?>
+<?php NEEDS_ATLEAST_MONGODB_VERSION(STANDALONE, "3.6"); ?>
+<?php CLEANUP(STANDALONE); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(STANDALONE);
+
+$bulk = new MongoDB\Driver\BulkWrite;
+$bulk->insert(['_id' => 1]);
+$bulk->insert(['_id' => 2]);
+$bulk->insert(['_id' => 3]);
+$manager->executeBulkWrite(NS, $bulk);
+
+$query = new MongoDB\Driver\Query([], ['batchSize' => 2]);
+$session = $manager->startSession();
+
+$cursor = $manager->executeQuery(NS, $query, ['session' => $session]);
+
+$iterator = new IteratorIterator($cursor);
+$iterator->rewind();
+$iterator->next();
+
+printf("Cursor ID is zero: %s\n", (string) $cursor->getId() === '0' ? 'yes' : 'no');
+var_dump($cursor);
+
+$iterator->next();
+
+/* Per PHPC-1161, the Cursor will free a reference to the Session as soon as it
+ * is exhausted. While this is primarily done to ensure implicit sessions for
+ * command cursors are returned to the pool ASAP, it also applies to explicit
+ * sessions. */
+printf("\nCursor ID is zero: %s\n", (string) $cursor->getId() === '0' ? 'yes' : 'no');
+var_dump($cursor);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+Cursor ID is zero: no
+object(MongoDB\Driver\Cursor)#%d (%d) {
+  %a
+  ["session"]=>
+  object(MongoDB\Driver\Session)#%d (%d) {
+    %a
+  }
+  %a
+}
+
+Cursor ID is zero: yes
+object(MongoDB\Driver\Cursor)#%d (%d) {
+  %a
+  ["session"]=>
+  NULL
+  %a
+}
+===DONE===

--- a/tests/cursor/cursor-session-002.phpt
+++ b/tests/cursor/cursor-session-002.phpt
@@ -1,0 +1,59 @@
+--TEST--
+MongoDB\Driver\Cursor debug output for query cursor omits implicit session
+--SKIPIF--
+<?php require __DIR__ . "/" ."../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
+<?php NEEDS('STANDALONE'); ?>
+<?php NEEDS_ATLEAST_MONGODB_VERSION(STANDALONE, "3.6"); ?>
+<?php CLEANUP(STANDALONE); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(STANDALONE);
+
+$bulk = new MongoDB\Driver\BulkWrite;
+$bulk->insert(['_id' => 1]);
+$bulk->insert(['_id' => 2]);
+$bulk->insert(['_id' => 3]);
+$manager->executeBulkWrite(NS, $bulk);
+
+$query = new MongoDB\Driver\Query([], ['batchSize' => 2]);
+
+$cursor = $manager->executeQuery(NS, $query);
+
+$iterator = new IteratorIterator($cursor);
+$iterator->rewind();
+$iterator->next();
+
+/* Implicit sessions for query cursors are never exposed to PHPC, as they are
+ * handled internally by libmongoc. Cursor debug ouput should never report such
+ * sessions. */
+printf("Cursor ID is zero: %s\n", (string) $cursor->getId() === '0' ? 'yes' : 'no');
+var_dump($cursor);
+
+$iterator->next();
+
+printf("\nCursor ID is zero: %s\n", (string) $cursor->getId() === '0' ? 'yes' : 'no');
+var_dump($cursor);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+Cursor ID is zero: no
+object(MongoDB\Driver\Cursor)#%d (%d) {
+  %a
+  ["session"]=>
+  NULL
+  %a
+}
+
+Cursor ID is zero: yes
+object(MongoDB\Driver\Cursor)#%d (%d) {
+  %a
+  ["session"]=>
+  NULL
+  %a
+}
+===DONE===

--- a/tests/cursor/cursor-session-003.phpt
+++ b/tests/cursor/cursor-session-003.phpt
@@ -1,0 +1,67 @@
+--TEST--
+MongoDB\Driver\Cursor debug output for command cursor includes explicit session
+--SKIPIF--
+<?php require __DIR__ . "/" ."../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
+<?php NEEDS('STANDALONE'); ?>
+<?php NEEDS_ATLEAST_MONGODB_VERSION(STANDALONE, "3.6"); ?>
+<?php CLEANUP(STANDALONE); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(STANDALONE);
+
+$bulk = new MongoDB\Driver\BulkWrite;
+$bulk->insert(['_id' => 1]);
+$bulk->insert(['_id' => 2]);
+$bulk->insert(['_id' => 3]);
+$manager->executeBulkWrite(NS, $bulk);
+
+$command = new MongoDB\Driver\Command([
+    'aggregate' => COLLECTION_NAME,
+    'pipeline' => [['$match' => new stdClass]],
+    'cursor' => ['batchSize' => 2],
+]);
+$session = $manager->startSession();
+
+$cursor = $manager->executeCommand(DATABASE_NAME, $command, ['session' => $session]);
+
+$iterator = new IteratorIterator($cursor);
+$iterator->rewind();
+$iterator->next();
+
+printf("Cursor ID is zero: %s\n", (string) $cursor->getId() === '0' ? 'yes' : 'no');
+var_dump($cursor);
+
+$iterator->next();
+
+/* Per PHPC-1161, the Cursor will free a reference to the Session as soon as it
+ * is exhausted. While this is primarily done to ensure implicit sessions for
+ * command cursors are returned to the pool ASAP, it also applies to explicit
+ * sessions. */
+printf("\nCursor ID is zero: %s\n", (string) $cursor->getId() === '0' ? 'yes' : 'no');
+var_dump($cursor);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+Cursor ID is zero: no
+object(MongoDB\Driver\Cursor)#%d (%d) {
+  %a
+  ["session"]=>
+  object(MongoDB\Driver\Session)#%d (%d) {
+    %a
+  }
+  %a
+}
+
+Cursor ID is zero: yes
+object(MongoDB\Driver\Cursor)#%d (%d) {
+  %a
+  ["session"]=>
+  NULL
+  %a
+}
+===DONE===

--- a/tests/cursor/cursor-session-004.phpt
+++ b/tests/cursor/cursor-session-004.phpt
@@ -1,0 +1,66 @@
+--TEST--
+MongoDB\Driver\Cursor debug output for command cursor includes implicit session
+--SKIPIF--
+<?php require __DIR__ . "/" ."../utils/basic-skipif.inc"; ?>
+<?php NEEDS_CRYPTO(); ?>
+<?php NEEDS('STANDALONE'); ?>
+<?php NEEDS_ATLEAST_MONGODB_VERSION(STANDALONE, "3.6"); ?>
+<?php CLEANUP(STANDALONE); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(STANDALONE);
+
+$bulk = new MongoDB\Driver\BulkWrite;
+$bulk->insert(['_id' => 1]);
+$bulk->insert(['_id' => 2]);
+$bulk->insert(['_id' => 3]);
+$manager->executeBulkWrite(NS, $bulk);
+
+$command = new MongoDB\Driver\Command([
+    'aggregate' => COLLECTION_NAME,
+    'pipeline' => [['$match' => new stdClass]],
+    'cursor' => ['batchSize' => 2],
+]);
+
+$cursor = $manager->executeCommand(DATABASE_NAME, $command);
+
+$iterator = new IteratorIterator($cursor);
+$iterator->rewind();
+$iterator->next();
+
+printf("Cursor ID is zero: %s\n", (string) $cursor->getId() === '0' ? 'yes' : 'no');
+var_dump($cursor);
+
+$iterator->next();
+
+/* Unlike implicit sessions for query cursors, which are handled internally by
+ * libmongoc, PHPC-1152 emulates its own implicit sessions for command cursors
+ * in order to ensure that command cursors always share the same session as the
+ * originating command. */
+printf("\nCursor ID is zero: %s\n", (string) $cursor->getId() === '0' ? 'yes' : 'no');
+var_dump($cursor);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+Cursor ID is zero: no
+object(MongoDB\Driver\Cursor)#%d (%d) {
+  %a
+  ["session"]=>
+  object(MongoDB\Driver\Session)#%d (%d) {
+    %a
+  }
+  %a
+}
+
+Cursor ID is zero: yes
+object(MongoDB\Driver\Cursor)#%d (%d) {
+  %a
+  ["session"]=>
+  NULL
+  %a
+}
+===DONE===

--- a/tests/manager/manager-executeCommand-001.phpt
+++ b/tests/manager/manager-executeCommand-001.phpt
@@ -55,7 +55,7 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
   ["readPreference"]=>
   NULL
   ["session"]=>
-  NULL
+  %a
   ["isDead"]=>
   bool(false)
   ["currentIndex"]=>

--- a/tests/server/server-executeCommand-001.phpt
+++ b/tests/server/server-executeCommand-001.phpt
@@ -44,7 +44,7 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
   ["readPreference"]=>
   NULL
   ["session"]=>
-  NULL
+  %a
   ["isDead"]=>
   bool(false)
   ["currentIndex"]=>


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1152
https://jira.mongodb.org/browse/PHPC-1161

Tests for this patch depend on #811, although I've included a temporary commit with the patch (sans the full patch and tests in #811) to give this PR's own tests a chance at passing.