### PR TITLE
Do not re-execute BulkWrite in WriteResult::getServer() test

### DIFF
--- a/tests/replicaset/writeresult-getserver-002.phpt
+++ b/tests/replicaset/writeresult-getserver-002.phpt
@@ -47,10 +47,6 @@ foreach($result as $document) {
 $cmd = new MongoDB\Driver\Command(array("drop" => "examples"));
 $server3->executeCommand("local", $cmd);
 
-throws(function() use ($server3, $bulk) {
-    $result = $server3->executeBulkWrite(NS, $bulk);
-}, "MongoDB\\Driver\\Exception\\RuntimeException");
-
 ?>
 ===DONE===
 <?php exit(0); ?>
@@ -93,5 +89,4 @@ object(stdClass)#%d (2) {
   ["example"]=>
   string(8) "document"
 }
-OK: Got MongoDB\Driver\Exception\RuntimeException
 ===DONE===


### PR DESCRIPTION
bulkwrite_error-002.phpt already covers this case.

Furthermore, this was never the correct exception class. The class in 1.4 and previous versions is is BulkWriteException, which just so happens to be an instance of RuntimeException and satisfy `throws()`; however, https://github.com/mongodb/mongo-php-driver/pull/797 changes the class to InvalidArgumentException in 1.5.