### PR TITLE
PHPC-578: phongo_execute_command() should still throw ExecutionTimeoutException

### DIFF
--- a/php_phongo.c
+++ b/php_phongo.c
@@ -865,7 +865,11 @@ int phongo_execute_command(mongoc_client_t* client, php_phongo_command_type_t ty
 			return false;
 	}
 	if (!result) {
-		if (error.domain == MONGOC_ERROR_SERVER || error.domain == MONGOC_ERROR_WRITE_CONCERN) {
+		/* Server errors (other than ExceededTimeLimit) and write concern errors
+		 * may use CommandException and report the result document for the
+		 * failed command. For BC, ExceededTimeLimit errors will continue to use
+		 * ExcecutionTimeoutException and omit the result document. */
+		if ((error.domain == MONGOC_ERROR_SERVER && error.code != PHONGO_SERVER_ERROR_EXCEEDED_TIME_LIMIT) || error.domain == MONGOC_ERROR_WRITE_CONCERN) {
 #if PHP_VERSION_ID >= 70000
 			zval zv;
 #else

--- a/php_phongo.c
+++ b/php_phongo.c
@@ -143,7 +143,7 @@ zend_class_entry* phongo_exception_from_mongoc_domain(uint32_t /* mongoc_error_d
 	}
 
 	if (domain == MONGOC_ERROR_SERVER) {
-		if (code == 50) {
+		if (code == PHONGO_SERVER_ERROR_EXCEEDED_TIME_LIMIT) {
 			return php_phongo_executiontimeoutexception_ce;
 		}
 

--- a/php_phongo.h
+++ b/php_phongo.h
@@ -93,6 +93,10 @@ typedef enum {
 	PHONGO_ERROR_LOGIC             = 9
 } php_phongo_error_domain_t;
 
+/* This constant is used for determining if a server error for an exceeded query
+ * or command should select ExecutionTimeoutException. */
+#define PHONGO_SERVER_ERROR_EXCEEDED_TIME_LIMIT 50
+
 zend_class_entry* phongo_exception_from_mongoc_domain(uint32_t /* mongoc_error_domain_t */ domain, uint32_t /* mongoc_error_code_t */ code);
 zend_class_entry* phongo_exception_from_phongo_domain(php_phongo_error_domain_t domain);
 void              phongo_throw_exception(php_phongo_error_domain_t domain TSRMLS_DC, const char* format, ...)


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-578

This fixes an inadvertent side effect of 4b70d9b, which caused test failures for [standalone/executiontimeoutexception-002.phpt](https://github.com/mongodb/mongo-php-driver/blob/master/tests/standalone/executiontimeoutexception-002.phpt).

@kvwalker: Before you review this, please see if that test fails or is skipped on your local environment. I imagine it might have been skipped for some reason (it certainly is on Travis, as the MongoDB servers there don't start with test command enabled).