### PR TITLE
Fix variable name in test

### DIFF
--- a/tests/standalone/bug0357.phpt
+++ b/tests/standalone/bug0357.phpt
@@ -7,7 +7,7 @@ PHPC-357: The exception for "invalid namespace" does not list the broken name
 <?php
 require_once __DIR__ . "/../utils/basic.inc";
 
-$manager = new MongoDB\Driver\Manager(STANDALONE);
+$m = new MongoDB\Driver\Manager(STANDALONE);
 $c = new MongoDB\Driver\Query(array());
 
 echo throws(function() use($m, $c) {


### PR DESCRIPTION
This fixes a typo introduced in 4967eff7561fec1b5b9219120b8d35601ec85568.