### PR TITLE
PHPC-1162: Add reference to currentDocument in debug info

### DIFF
--- a/src/MongoDB/Cursor.c
+++ b/src/MongoDB/Cursor.c
@@ -509,7 +509,7 @@ static HashTable *php_phongo_cursor_get_debug_info(zval *object, int *is_temp TS
 	if (!Z_ISUNDEF(intern->visitor_data.zchild)) {
 #if PHP_VERSION_ID >= 70000
 		ADD_ASSOC_ZVAL_EX(&retval, "currentDocument", &intern->visitor_data.zchild);
-		/*Z_ADDREF(intern->visitor_data.zchild);*/
+		Z_ADDREF(intern->visitor_data.zchild);
 #else
 		ADD_ASSOC_ZVAL_EX(&retval, "currentDocument", intern->visitor_data.zchild);
 		Z_ADDREF_P(intern->visitor_data.zchild);

--- a/tests/cursor/bug1162-001.phpt
+++ b/tests/cursor/bug1162-001.phpt
@@ -1,0 +1,43 @@
+--TEST--
+MongoDB\Driver\Cursor segfault dumping cursor while iterating with IteratorIterator
+--SKIPIF--
+<?php require __DIR__ . "/" ."../utils/basic-skipif.inc"; ?>
+<?php NEEDS('STANDALONE'); ?>
+<?php CLEANUP(STANDALONE); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(STANDALONE);
+
+$bulk = new MongoDB\Driver\BulkWrite;
+$bulk->insert(['_id' => 1]);
+$bulk->insert(['_id' => 2]);
+$bulk->insert(['_id' => 3]);
+$manager->executeBulkWrite(NS, $bulk);
+
+$query = new MongoDB\Driver\Query([], ['batchSize' => 2]);
+
+$cursor = $manager->executeQuery(NS, $query);
+
+$iterator = new IteratorIterator($cursor);
+$iterator->rewind();
+var_dump($cursor);
+
+$iterator->next();
+var_dump($cursor);
+
+$iterator->next();
+var_dump($cursor);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+object(MongoDB\Driver\Cursor)#%d (%d) {%A
+}
+object(MongoDB\Driver\Cursor)#%d (%d) {%A
+}
+object(MongoDB\Driver\Cursor)#%d (%d) {%A
+}
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1162

This fixes a segfault while dumping the cursor between iterations with IteratorIterator.