### PR TITLE
PHPC-1159: Only run executeWriteCommand_error-003 on mongo version 3.4 or greater

### DIFF
--- a/tests/manager/manager-executeWriteCommand_error-003.phpt
+++ b/tests/manager/manager-executeWriteCommand_error-003.phpt
@@ -2,7 +2,7 @@
 MongoDB\Driver\Manager::executeWriteCommand() throws CommandException for unsupported update operator
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
-<?php NEEDS('STANDALONE'); ?>
+<?php NEEDS('STANDALONE'); NEEDS_ATLEAST_MONGODB_VERSION(STANDALONE, "3.4"); ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";


### PR DESCRIPTION
This is to fix errors on [Travis Build 2640](https://travis-ci.org/mongodb/mongo-php-driver/builds/367684798), which appear to be due to differences in responses between server versions.