### PR TITLE
PHPC-1163: Ignore exception in causal consistency test

### DIFF
--- a/tests/causal-consistency/causal-consistency-010.phpt
+++ b/tests/causal-consistency/causal-consistency-010.phpt
@@ -17,7 +17,12 @@ var_dump($session->getOperationTime());
 $bulk = new MongoDB\Driver\BulkWrite;
 $bulk->insert(['x' => 1]);
 $writeConcern = new MongoDB\Driver\WriteConcern(0);
-$manager->executeBulkWrite(NS, $bulk, ['session' => $session, 'writeConcern' => $writeConcern]);
+
+/* Ignore the InvalidArgumentException for trying to combine an unacknowledged
+ * write concern with an explicit session. */
+try {
+    $manager->executeBulkWrite(NS, $bulk, ['session' => $session, 'writeConcern' => $writeConcern]);
+} catch (MongoDB\Driver\Exception\InvalidArgumentException $e) {}
 
 echo "\nOperation time after unacknowledged write:\n";
 var_dump($session->getOperationTime());


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1163

Missed this in https://github.com/mongodb/mongo-php-driver/pull/814. Although Travis is using 3.6 now, I believe it still doesn't use replica sets and therefore skipped this.