### PR TITLE
[WAIT] PHPC-1076: Expose result document for failed commands via CommandFailedEvent

### DIFF
--- a/php_phongo.c
+++ b/php_phongo.c
@@ -2214,11 +2214,13 @@ static void php_phongo_command_failed(const mongoc_apm_command_failed_t* event)
 	p_event->operation_id    = mongoc_apm_command_failed_get_operation_id(event);
 	p_event->request_id      = mongoc_apm_command_failed_get_request_id(event);
 	p_event->duration_micros = mongoc_apm_command_failed_get_duration(event);
+	p_event->reply           = bson_copy(mongoc_apm_command_failed_get_reply(event));
 
 	/* We need to process and convert the error right here, otherwise
 	 * debug_info will turn into a recursive loop, and with the wrong trace
 	 * locations */
 	mongoc_apm_command_failed_get_error(event, &tmp_error);
+
 	{
 #if PHP_VERSION_ID < 70000
 		MAKE_STD_ZVAL(p_event->z_error);
@@ -2229,6 +2231,7 @@ static void php_phongo_command_failed(const mongoc_apm_command_failed_t* event)
 		object_init_ex(&p_event->z_error, phongo_exception_from_mongoc_domain(tmp_error.domain, tmp_error.code));
 		zend_update_property_string(default_exception_ce, &p_event->z_error, ZEND_STRL("message"), tmp_error.message TSRMLS_CC);
 		zend_update_property_long(default_exception_ce, &p_event->z_error, ZEND_STRL("code"), tmp_error.code TSRMLS_CC);
+
 #endif
 	}
 

--- a/php_phongo_structs.h
+++ b/php_phongo_structs.h
@@ -248,6 +248,7 @@ typedef struct {
 	uint64_t           operation_id;
 	uint64_t           request_id;
 	uint64_t           duration_micros;
+	bson_t*            reply;
 	PHONGO_STRUCT_ZVAL z_error;
 	PHONGO_ZEND_OBJECT_POST
 } php_phongo_commandfailedevent_t;

--- a/tests/apm/monitoring-commandFailed-003.phpt
+++ b/tests/apm/monitoring-commandFailed-003.phpt
@@ -1,0 +1,59 @@
+--TEST--
+MongoDB\Driver\Monitoring\CommandFailedEvent
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php NEEDS('STANDALONE'); NEEDS_ATLEAST_MONGODB_VERSION(STANDALONE, "3.4"); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(STANDALONE);
+
+class MySubscriber implements MongoDB\Driver\Monitoring\CommandSubscriber
+{
+    public function commandStarted( \MongoDB\Driver\Monitoring\CommandStartedEvent $event )
+    {
+        echo "started: ", $event->getCommandName(), "\n";
+    }
+
+    public function commandSucceeded( \MongoDB\Driver\Monitoring\CommandSucceededEvent $event )
+    {
+      var_dump($event);
+    }
+
+    public function commandFailed( \MongoDB\Driver\Monitoring\CommandFailedEvent $event )
+    {
+        echo "failed: ", $event->getCommandName(), "\n";
+        var_dump($event->getReply());
+    }
+}
+
+$subscriber = new MySubscriber;
+
+MongoDB\Driver\Monitoring\addSubscriber( $subscriber );
+
+$command = new MongoDB\Driver\Command([
+  'findAndModify' => COLLECTION_NAME,
+  'query' => ['_id' => 'foo'],
+  'upsert' => true,
+  'new' => true,
+]);
+
+try {
+    $manager->executeWriteCommand(DATABASE_NAME, $command);
+} catch (MongoDB\Driver\Exception\CommandException $e) {}
+
+?>
+--EXPECTF--
+started: findAndModify
+failed: findAndModify
+object(stdClass)#%d (4) {
+  ["ok"]=>
+  float(0)
+  ["errmsg"]=>
+  string(49) "Either an update or remove=true must be specified"
+  ["code"]=>
+  int(9)
+  ["codeName"]=>
+  string(13) "FailedToParse"
+}


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1076

These changes depend on libmongoc 1.10.0, but I was able to test them locally and verify that they work.