### PR TITLE
 PHPC-1166: Update zend array recursion protection for PHP 7.3 

### DIFF
--- a/phongo_compat.c
+++ b/phongo_compat.c
@@ -32,6 +32,58 @@ void phongo_add_exception_prop(const char* prop, int prop_len, zval* value TSRML
 	}
 }
 
+#ifdef ZEND_HASH_GET_APPLY_COUNT /* PHP 7.2 or earlier recursion protection */
+inline zend_bool php_phongo_zend_hash_apply_protection_begin(HashTable* ht)
+{
+	if (!ht) {
+		return 1;
+	}
+	if (ZEND_HASH_GET_APPLY_COUNT(ht) > 0) {
+		return 0;
+	}
+	if (ZEND_HASH_APPLY_PROTECTION(ht)) {
+		ZEND_HASH_INC_APPLY_COUNT(ht);
+	}
+	return 1;
+}
+
+inline zend_bool php_phongo_zend_hash_apply_protection_end(HashTable* ht)
+{
+	if (!ht) {
+		return 1;
+	}
+	if (ZEND_HASH_GET_APPLY_COUNT(ht) == 0) {
+		return 0;
+	}
+	if (ZEND_HASH_APPLY_PROTECTION(ht)) {
+		ZEND_HASH_DEC_APPLY_COUNT(ht);
+	}
+	return 1;
+}
+#else /* PHP 7.3 or later */
+inline zend_bool php_phongo_zend_hash_apply_protection_begin(zend_array* ht)
+{
+	if (GC_IS_RECURSIVE(ht)) {
+		return 0;
+	}
+	if (!(GC_FLAGS(ht) & GC_IMMUTABLE)) {
+		GC_PROTECT_RECURSION(ht);
+	}
+	return 1;
+}
+
+inline zend_bool php_phongo_zend_hash_apply_protection_end(zend_array* ht)
+{
+	if (!GC_IS_RECURSIVE(ht)) {
+		return 0;
+	}
+	if (!(GC_FLAGS(ht) & GC_IMMUTABLE)) {
+		GC_UNPROTECT_RECURSION(ht);
+	}
+	return 1;
+}
+#endif
+
 /*
  * Local variables:
  * tab-width: 4

--- a/phongo_compat.h
+++ b/phongo_compat.h
@@ -178,7 +178,9 @@
 #error Unsupported architecture (integers are neither 32-bit nor 64-bit)
 #endif
 
-void phongo_add_exception_prop(const char* prop, int prop_len, zval* value TSRMLS_DC);
+void      phongo_add_exception_prop(const char* prop, int prop_len, zval* value TSRMLS_DC);
+zend_bool php_phongo_zend_hash_apply_protection_begin(HashTable* ht);
+zend_bool php_phongo_zend_hash_apply_protection_end(HashTable* ht);
 
 #endif /* PHONGO_COMPAT_H */
 

--- a/src/bson-encode.c
+++ b/src/bson-encode.c
@@ -353,15 +353,11 @@ try_again:
 				bson_t     child;
 				HashTable* tmp_ht = HASH_OF(entry);
 
-				if (tmp_ht && ZEND_HASH_GET_APPLY_COUNT(tmp_ht) > 0) {
+				if (!php_phongo_zend_hash_apply_protection_begin(tmp_ht)) {
 					char* path_string = php_phongo_field_path_as_string(field_path);
 					phongo_throw_exception(PHONGO_ERROR_UNEXPECTED_VALUE TSRMLS_CC, "Detected recursion for field path \"%s\"", path_string);
 					efree(path_string);
 					break;
-				}
-
-				if (tmp_ht && ZEND_HASH_APPLY_PROTECTION(tmp_ht)) {
-					ZEND_HASH_INC_APPLY_COUNT(tmp_ht);
 				}
 
 				bson_append_array_begin(bson, key, key_len, &child);
@@ -371,9 +367,7 @@ try_again:
 				field_path->size--;
 				bson_append_array_end(bson, &child);
 
-				if (tmp_ht && ZEND_HASH_APPLY_PROTECTION(tmp_ht)) {
-					ZEND_HASH_DEC_APPLY_COUNT(tmp_ht);
-				}
+				php_phongo_zend_hash_apply_protection_end(tmp_ht);
 				break;
 			}
 			PHONGO_BREAK_INTENTIONALLY_MISSING
@@ -381,15 +375,11 @@ try_again:
 		case IS_OBJECT: {
 			HashTable* tmp_ht = HASH_OF(entry);
 
-			if (tmp_ht && ZEND_HASH_GET_APPLY_COUNT(tmp_ht) > 0) {
+			if (!php_phongo_zend_hash_apply_protection_begin(tmp_ht)) {
 				char* path_string = php_phongo_field_path_as_string(field_path);
 				phongo_throw_exception(PHONGO_ERROR_UNEXPECTED_VALUE TSRMLS_CC, "Detected recursion for field path \"%s\"", path_string);
 				efree(path_string);
 				break;
-			}
-
-			if (tmp_ht && ZEND_HASH_APPLY_PROTECTION(tmp_ht)) {
-				ZEND_HASH_INC_APPLY_COUNT(tmp_ht);
 			}
 
 			php_phongo_field_path_write_type_at_current_level(field_path, PHONGO_FIELD_PATH_ITEM_DOCUMENT);
@@ -397,9 +387,7 @@ try_again:
 			php_phongo_bson_append_object(bson, field_path, flags, key, key_len, entry TSRMLS_CC);
 			field_path->size--;
 
-			if (tmp_ht && ZEND_HASH_APPLY_PROTECTION(tmp_ht)) {
-				ZEND_HASH_DEC_APPLY_COUNT(tmp_ht);
-			}
+			php_phongo_zend_hash_apply_protection_end(tmp_ht);
 			break;
 		}
 

--- a/tests/bson/bson-fromPHP_error-001.phpt
+++ b/tests/bson/bson-fromPHP_error-001.phpt
@@ -48,15 +48,15 @@ foreach ($invalidValues as $invalidValue) {
 --EXPECTF--
 Testing top-level objects
 Expected MyDocument::bsonSerialize() to return an array or stdClass, %r(null|NULL)%r given
-Expected MyDocument::bsonSerialize() to return an array or stdClass, integer given
+Expected MyDocument::bsonSerialize() to return an array or stdClass, int%S given
 Expected MyDocument::bsonSerialize() to return an array or stdClass, string given
-Expected MyDocument::bsonSerialize() to return an array or stdClass, boolean given
+Expected MyDocument::bsonSerialize() to return an array or stdClass, bool%S given
 Expected MyDocument::bsonSerialize() to return an array or stdClass, MyDocument given
 
 Testing nested objects
 Expected MyDocument::bsonSerialize() to return an array or stdClass, %r(null|NULL)%r given
-Expected MyDocument::bsonSerialize() to return an array or stdClass, integer given
+Expected MyDocument::bsonSerialize() to return an array or stdClass, int%S given
 Expected MyDocument::bsonSerialize() to return an array or stdClass, string given
-Expected MyDocument::bsonSerialize() to return an array or stdClass, boolean given
+Expected MyDocument::bsonSerialize() to return an array or stdClass, bool%S given
 Expected MyDocument::bsonSerialize() to return an array or stdClass, MyDocument given
 ===DONE===

--- a/tests/bson/bson-timestamp_error-006.phpt
+++ b/tests/bson/bson-timestamp_error-006.phpt
@@ -28,7 +28,7 @@ Expected increment to be an unsigned 32-bit integer or string, %r(null|NULL)%r g
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected increment to be an unsigned 32-bit integer or string, %r(double|float)%r given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected increment to be an unsigned 32-bit integer or string, boolean given
+Expected increment to be an unsigned 32-bit integer or string, bool%S given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected increment to be an unsigned 32-bit integer or string, array given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
@@ -38,7 +38,7 @@ Expected timestamp to be an unsigned 32-bit integer or string, %r(null|NULL)%r g
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected timestamp to be an unsigned 32-bit integer or string, %r(double|float)%r given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected timestamp to be an unsigned 32-bit integer or string, boolean given
+Expected timestamp to be an unsigned 32-bit integer or string, bool%S given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected timestamp to be an unsigned 32-bit integer or string, array given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException

--- a/tests/bson/bson-utcdatetime_error-004.phpt
+++ b/tests/bson/bson-utcdatetime_error-004.phpt
@@ -19,9 +19,9 @@ foreach ($invalidValues as $invalidValue) {
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECT--
+--EXPECTF--
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected integer or string, boolean given
+Expected integer or string, bool%S given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected integer or string, array given
 ===DONE===

--- a/tests/bulk/bulkwrite-delete_error-001.phpt
+++ b/tests/bulk/bulkwrite-delete_error-001.phpt
@@ -14,7 +14,7 @@ echo throws(function() use ($bulk) {
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECT--
+--EXPECTF--
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected "collation" option to be array or object, integer given
+Expected "collation" option to be array or object, int%S given
 ===DONE===

--- a/tests/bulk/bulkwrite-update_error-003.phpt
+++ b/tests/bulk/bulkwrite-update_error-003.phpt
@@ -22,13 +22,13 @@ echo throws(function() use ($bulk) {
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECT--
+--EXPECTF--
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Replacement document conflicts with true "multi" option
 
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected "collation" option to be array or object, integer given
+Expected "collation" option to be array or object, int%S given
 
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected "collation" option to be array or object, integer given
+Expected "collation" option to be array or object, int%S given
 ===DONE===

--- a/tests/query/query-ctor_error-001.phpt
+++ b/tests/query/query-ctor_error-001.phpt
@@ -25,13 +25,13 @@ foreach ($tests as $test) {
 <?php exit(0); ?>
 --EXPECTF--
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected "readConcern" option to be MongoDB\Driver\ReadConcern, integer given
+Expected "readConcern" option to be MongoDB\Driver\ReadConcern, int%S given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected "readConcern" option to be MongoDB\Driver\ReadConcern, %r(double|float)%r given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected "readConcern" option to be MongoDB\Driver\ReadConcern, string given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected "readConcern" option to be MongoDB\Driver\ReadConcern, boolean given
+Expected "readConcern" option to be MongoDB\Driver\ReadConcern, bool%S given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected "readConcern" option to be MongoDB\Driver\ReadConcern, array given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException

--- a/tests/query/query-ctor_error-002.phpt
+++ b/tests/query/query-ctor_error-002.phpt
@@ -30,44 +30,44 @@ foreach ($tests as $options) {
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECT--
+--EXPECTF--
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected "modifiers" option to be array, integer given
+Expected "modifiers" option to be array, int%S given
 
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected "collation" option to be array or object, integer given
+Expected "collation" option to be array or object, int%S given
 
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected "comment" option to be string, integer given
+Expected "comment" option to be string, int%S given
 
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected "hint" option to be string, array, or object, integer given
+Expected "hint" option to be string, array, or object, int%S given
 
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected "max" option to be array or object, integer given
+Expected "max" option to be array or object, int%S given
 
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected "min" option to be array or object, integer given
+Expected "min" option to be array or object, int%S given
 
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected "projection" option to be array or object, integer given
+Expected "projection" option to be array or object, int%S given
 
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected "sort" option to be array or object, integer given
+Expected "sort" option to be array or object, int%S given
 
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected "$comment" modifier to be string, integer given
+Expected "$comment" modifier to be string, int%S given
 
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected "$hint" modifier to be string, array, or object, integer given
+Expected "$hint" modifier to be string, array, or object, int%S given
 
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected "$max" modifier to be array or object, integer given
+Expected "$max" modifier to be array or object, int%S given
 
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected "$min" modifier to be array or object, integer given
+Expected "$min" modifier to be array or object, int%S given
 
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected "$orderby" modifier to be array or object, integer given
+Expected "$orderby" modifier to be array or object, int%S given
 
 ===DONE===

--- a/tests/writeConcern/writeconcern-ctor_error-002.phpt
+++ b/tests/writeConcern/writeconcern-ctor_error-002.phpt
@@ -26,7 +26,7 @@ foreach ($tests as $test) {
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected w to be integer or string, %r(double|float)%r given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected w to be integer or string, boolean given
+Expected w to be integer or string, bool%S given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected w to be integer or string, array given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException


### PR DESCRIPTION
http://jira.mongodb.org/browse/PHPC-1166
http://jira.mongodb.org/browse/PHPC-1175

And fixed some annoying test case changes too.