### PR TITLE
PHPC-1185: Revert GSSAPI support and fix sasl_client_done check

### DIFF
--- a/scripts/autotools/libmongoc/CheckSasl.m4
+++ b/scripts/autotools/libmongoc/CheckSasl.m4
@@ -30,6 +30,14 @@ AS_IF([test "$PHP_MONGODB_SASL" = "cyrus" -o "$PHP_MONGODB_SASL" = "auto"],[
     fi
   ])
 
+  if test "$found_cyrus" = "yes"; then
+    PHP_CHECK_LIBRARY([sasl2],
+                      [sasl_client_done],
+                      [have_sasl_client_done=yes],
+                      [have_sasl_client_done=no],
+                      $MONGODB_SHARED_LIBADD)
+  fi
+
   if test "$PHP_MONGODB_SASL" = "cyrus" -a "$found_cyrus" != "yes"; then
     AC_MSG_ERROR([Cyrus SASL libraries and development headers could not be found])
   fi


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1185
https://jira.mongodb.org/browse/PHPC-1142

Reverts support for building with GSS framework on macOS or krb5-gssapi, as libmongoc doesn't support those. Additionally, this fixes an issue with the check for `sasl_client_done`.