### PR TITLE
PHPC-1166: Don't assume true is defined in phongo_compat.h

### DIFF
--- a/phongo_compat.h
+++ b/phongo_compat.h
@@ -138,7 +138,7 @@
 	} while (0)
 #define phongo_free_object_arg void
 #define phongo_zpp_char_len int
-#define ZEND_HASH_APPLY_PROTECTION(ht) true
+#define ZEND_HASH_APPLY_PROTECTION(ht) 1
 #define ZEND_HASH_GET_APPLY_COUNT(ht) ((ht)->nApplyCount)
 #define ZEND_HASH_DEC_APPLY_COUNT(ht) ((ht)->nApplyCount -= 1)
 #define ZEND_HASH_INC_APPLY_COUNT(ht) ((ht)->nApplyCount += 1)


### PR DESCRIPTION
http://jira.mongodb.org/browse/PHPC-1166

This fixes a build failure introduced by 197f3f7a8a73391cbe489bc900b9f1f1d47d3341 in #835.