### PR TITLE
PHPC-1166: Remove inline hint to fix linking issues on Windows

### DIFF
--- a/phongo_compat.c
+++ b/phongo_compat.c
@@ -33,7 +33,7 @@ void phongo_add_exception_prop(const char* prop, int prop_len, zval* value TSRML
 }
 
 #ifdef ZEND_HASH_GET_APPLY_COUNT /* PHP 7.2 or earlier recursion protection */
-inline zend_bool php_phongo_zend_hash_apply_protection_begin(HashTable* ht)
+zend_bool php_phongo_zend_hash_apply_protection_begin(HashTable* ht)
 {
 	if (!ht) {
 		return 1;
@@ -47,7 +47,7 @@ inline zend_bool php_phongo_zend_hash_apply_protection_begin(HashTable* ht)
 	return 1;
 }
 
-inline zend_bool php_phongo_zend_hash_apply_protection_end(HashTable* ht)
+zend_bool php_phongo_zend_hash_apply_protection_end(HashTable* ht)
 {
 	if (!ht) {
 		return 1;
@@ -61,7 +61,7 @@ inline zend_bool php_phongo_zend_hash_apply_protection_end(HashTable* ht)
 	return 1;
 }
 #else /* PHP 7.3 or later */
-inline zend_bool php_phongo_zend_hash_apply_protection_begin(zend_array* ht)
+zend_bool php_phongo_zend_hash_apply_protection_begin(zend_array* ht)
 {
 	if (GC_IS_RECURSIVE(ht)) {
 		return 0;
@@ -72,7 +72,7 @@ inline zend_bool php_phongo_zend_hash_apply_protection_begin(zend_array* ht)
 	return 1;
 }
 
-inline zend_bool php_phongo_zend_hash_apply_protection_end(zend_array* ht)
+zend_bool php_phongo_zend_hash_apply_protection_end(zend_array* ht)
 {
 	if (!GC_IS_RECURSIVE(ht)) {
 		return 0;


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1166

See:

 * http://forums.codeguru.com/showthread.php?253065-Inline-function-Unresolved-external&p=767447#post767447
 * https://stackoverflow.com/q/953710/162228

This should resolve Windows build issues I noticed in #836: https://ci.appveyor.com/project/derickr/mongo-php-driver/build/master.207