### PR TITLE
PHPC-1174: Upgrade bundled libmongoc to 1.10.0

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -300,7 +300,7 @@ if test "$PHP_MONGODB" != "no"; then
     dnl Generated with: find src/libmongoc/src/libbson/src/jsonsl -name '*.c' -print0 | cut -sz -d / -f 7- | sort -z | tr '\000' ' '
     PHP_MONGODB_JSONSL_SOURCES="jsonsl.c"
 
-    dnl Generated with: find src/libmongoc/src/mongoc -name '*.c' -print0 | cut -sz -d / -f 5- | sort -z | tr '\000' ' '
+    dnl Generated with: find src/libmongoc/src/libmongoc/src/mongoc -name '*.c' -print0 | cut -sz -d / -f 7- | sort -z | tr '\000' ' '
     PHP_MONGODB_MONGOC_SOURCES="mongoc-apm.c mongoc-array.c mongoc-async.c mongoc-async-cmd.c mongoc-buffer.c mongoc-bulk-operation.c mongoc-change-stream.c mongoc-client.c mongoc-client-pool.c mongoc-client-session.c mongoc-cluster.c mongoc-cluster-cyrus.c mongoc-cluster-gssapi.c mongoc-cluster-sasl.c mongoc-cluster-sspi.c mongoc-cmd.c mongoc-collection.c mongoc-compression.c mongoc-counters.c mongoc-crypto.c mongoc-crypto-cng.c mongoc-crypto-common-crypto.c mongoc-crypto-openssl.c mongoc-cursor-array.c mongoc-cursor.c mongoc-cursor-cmd.c mongoc-cursor-cmd-deprecated.c mongoc-cursor-find.c mongoc-cursor-find-cmd.c mongoc-cursor-find-opquery.c mongoc-cursor-legacy.c mongoc-cyrus.c mongoc-database.c mongoc-find-and-modify.c mongoc-gridfs.c mongoc-gridfs-file.c mongoc-gridfs-file-list.c mongoc-gridfs-file-page.c mongoc-gssapi.c mongoc-handshake.c mongoc-host-list.c mongoc-index.c mongoc-init.c mongoc-libressl.c mongoc-linux-distro-scanner.c mongoc-list.c mongoc-log.c mongoc-matcher.c mongoc-matcher-op.c mongoc-memcmp.c mongoc-openssl.c mongoc-opts.c mongoc-opts-helpers.c mongoc-queue.c mongoc-rand-cng.c mongoc-rand-common-crypto.c mongoc-rand-openssl.c mongoc-read-concern.c mongoc-read-prefs.c mongoc-rpc.c mongoc-sasl.c mongoc-scram.c mongoc-secure-channel.c mongoc-secure-transport.c mongoc-server-description.c mongoc-server-stream.c mongoc-set.c mongoc-socket.c mongoc-ssl.c mongoc-sspi.c mongoc-stream-buffered.c mongoc-stream.c mongoc-stream-file.c mongoc-stream-gridfs.c mongoc-stream-socket.c mongoc-stream-tls.c mongoc-stream-tls-libressl.c mongoc-stream-tls-openssl-bio.c mongoc-stream-tls-openssl.c mongoc-stream-tls-secure-channel.c mongoc-stream-tls-secure-transport.c mongoc-topology.c mongoc-topology-description-apm.c mongoc-topology-description.c mongoc-topology-scanner.c mongoc-uri.c mongoc-util.c mongoc-version-functions.c mongoc-write-command.c mongoc-write-command-legacy.c mongoc-write-concern.c"
 
     dnl Generated with: find src/libmongoc/src/zlib-1.2.11 -maxdepth 1 -name '*.c' -print0 | cut -sz -d / -f 5- | sort -z | tr '\000' ' '
@@ -309,18 +309,18 @@ if test "$PHP_MONGODB" != "no"; then
     PHP_MONGODB_ADD_SOURCES([src/libmongoc/src/common/], $PHP_MONGODB_COMMON_SOURCES, $PHP_MONGODB_BUNDLED_CFLAGS)
     PHP_MONGODB_ADD_SOURCES([src/libmongoc/src/libbson/src/bson/], $PHP_MONGODB_BSON_SOURCES, $PHP_MONGODB_BUNDLED_CFLAGS)
     PHP_MONGODB_ADD_SOURCES([src/libmongoc/src/libbson/src/jsonsl/], $PHP_MONGODB_JSONSL_SOURCES, $PHP_MONGODB_BUNDLED_CFLAGS)
-    PHP_MONGODB_ADD_SOURCES([src/libmongoc/src/mongoc/], $PHP_MONGODB_MONGOC_SOURCES, $PHP_MONGODB_BUNDLED_CFLAGS)
+    PHP_MONGODB_ADD_SOURCES([src/libmongoc/src/libmongoc/src/mongoc/], $PHP_MONGODB_MONGOC_SOURCES, $PHP_MONGODB_BUNDLED_CFLAGS)
 
     PHP_MONGODB_ADD_INCLUDE([src/libmongoc/src/common/])
     PHP_MONGODB_ADD_INCLUDE([src/libmongoc/src/libbson/src/])
     PHP_MONGODB_ADD_INCLUDE([src/libmongoc/src/libbson/src/bson/])
     PHP_MONGODB_ADD_INCLUDE([src/libmongoc/src/libbson/src/jsonsl/])
-    PHP_MONGODB_ADD_INCLUDE([src/libmongoc/src/mongoc/])
+    PHP_MONGODB_ADD_INCLUDE([src/libmongoc/src/libmongoc/src/mongoc/])
 
     PHP_MONGODB_ADD_BUILD_DIR([src/libmongoc/src/common/])
     PHP_MONGODB_ADD_BUILD_DIR([src/libmongoc/src/libbson/src/bson/])
     PHP_MONGODB_ADD_BUILD_DIR([src/libmongoc/src/libbson/src/jsonsl/])
-    PHP_MONGODB_ADD_BUILD_DIR([src/libmongoc/src/mongoc/])
+    PHP_MONGODB_ADD_BUILD_DIR([src/libmongoc/src/libmongoc/src/mongoc/])
 
     dnl TODO: Use $ext_srcdir if we can move this after PHP_NEW_EXTENSION
     ac_config_dir=PHP_EXT_SRCDIR(mongodb)
@@ -328,8 +328,8 @@ if test "$PHP_MONGODB" != "no"; then
     AC_CONFIG_FILES([
       ${ac_config_dir}/src/libmongoc/src/libbson/src/bson/bson-config.h
       ${ac_config_dir}/src/libmongoc/src/libbson/src/bson/bson-version.h
-      ${ac_config_dir}/src/libmongoc/src/mongoc/mongoc-config.h
-      ${ac_config_dir}/src/libmongoc/src/mongoc/mongoc-version.h
+      ${ac_config_dir}/src/libmongoc/src/libmongoc/src/mongoc/mongoc-config.h
+      ${ac_config_dir}/src/libmongoc/src/libmongoc/src/mongoc/mongoc-version.h
     ])
 
     if test "x$bundled_zlib" = "xyes"; then

--- a/config.w32
+++ b/config.w32
@@ -58,28 +58,33 @@ if (PHP_MONGODB != "no") {
   ADD_EXTENSION_DEP("mongodb", "openssl", false);
 
   var PHP_MONGODB_CFLAGS="\
-    /D BSON_COMPILATION /D MONGOC_COMPILATION /D MONGOC_TRACE \
+    /D BSON_COMPILATION /D MONGOC_COMPILATION \
     /I" + configure_module_dirname + " \
     /I" + configure_module_dirname + "/src/BSON \
     /I" + configure_module_dirname + "/src/MongoDB \
     /I" + configure_module_dirname + "/src/MongoDB/Exception \
     /I" + configure_module_dirname + "/src/contrib \
-    /I" + configure_module_dirname + "/src/libbson/src \
-    /I" + configure_module_dirname + "/src/libbson/src/bson \
-    /I" + configure_module_dirname + "/src/libmongoc/src/mongoc \
+    /I" + configure_module_dirname + "/src/libmongoc/src/common \
+    /I" + configure_module_dirname + "/src/libmongoc/src/libbson/src \
+    /I" + configure_module_dirname + "/src/libmongoc/src/libbson/src/bson \
+    /I" + configure_module_dirname + "/src/libmongoc/src/libbson/src/jsonsl \
+    /I" + configure_module_dirname + "/src/libmongoc/src/libmongoc/src/mongoc \
   ";
 
   // Condense whitespace in CFLAGS
   PHP_MONGODB_CFLAGS = PHP_MONGODB_CFLAGS.replace(/\s+/g, ' ');
 
-  // Generated with: find src/libbson/src/bson -name '*.c' -print0 | cut -sz -d / -f 5- | sort -z | tr '\000' ' '
+  // Generated with: find src/libmongoc/src/common -name '*.c' -print0 | cut -sz -d / -f 5- | sort -z | tr '\000' ' '
+  var PHP_MONGODB_COMMON_SOURCES="common-b64.c"
+
+  // Generated with: find src/libmongoc/src/libbson/src/bson -name '*.c' -print0 | cut -sz -d / -f 7- | sort -z | tr '\000' ' '
   var PHP_MONGODB_BSON_SOURCES="bcon.c bson-atomic.c bson.c bson-clock.c bson-context.c bson-decimal128.c bson-error.c bson-iso8601.c bson-iter.c bson-json.c bson-keys.c bson-md5.c bson-memory.c bson-oid.c bson-reader.c bson-string.c bson-timegm.c bson-utf8.c bson-value.c bson-version-functions.c bson-writer.c";
 
-  // Generated with: find src/libbson/src/jsonsl -name '*.c' -print0 | cut -sz -d / -f 5- | sort -z | tr '\000' ' '
+  // Generated with: find src/libmongoc/src/libbson/src/jsonsl -name '*.c' -print0 | cut -sz -d / -f 7- | sort -z | tr '\000' ' '
   var PHP_MONGODB_JSONSL_SOURCES="jsonsl.c";
 
-  // Generated with: find src/libmongoc/src/mongoc -name '*.c' -print0 | cut -sz -d / -f 4- | sort -z | tr '\000' ' '
-  var PHP_MONGODB_MONGOC_SOURCES="mongoc-apm.c mongoc-array.c mongoc-async.c mongoc-async-cmd.c mongoc-b64.c mongoc-buffer.c mongoc-bulk-operation.c mongoc-change-stream.c mongoc-client.c mongoc-client-pool.c mongoc-client-session.c mongoc-cluster.c mongoc-cluster-cyrus.c mongoc-cluster-gssapi.c mongoc-cluster-sasl.c mongoc-cluster-sspi.c mongoc-cmd.c mongoc-collection.c mongoc-compression.c mongoc-counters.c mongoc-crypto.c mongoc-crypto-cng.c mongoc-crypto-common-crypto.c mongoc-crypto-openssl.c mongoc-cursor-array.c mongoc-cursor.c mongoc-cursor-cursorid.c mongoc-cursor-transform.c mongoc-cyrus.c mongoc-database.c mongoc-find-and-modify.c mongoc-gridfs.c mongoc-gridfs-file.c mongoc-gridfs-file-list.c mongoc-gridfs-file-page.c mongoc-gssapi.c mongoc-handshake.c mongoc-host-list.c mongoc-index.c mongoc-init.c mongoc-libressl.c mongoc-linux-distro-scanner.c mongoc-list.c mongoc-log.c mongoc-matcher.c mongoc-matcher-op.c mongoc-memcmp.c mongoc-openssl.c mongoc-queue.c mongoc-rand-cng.c mongoc-rand-common-crypto.c mongoc-rand-openssl.c mongoc-read-concern.c mongoc-read-prefs.c mongoc-rpc.c mongoc-sasl.c mongoc-scram.c mongoc-secure-channel.c mongoc-secure-transport.c mongoc-server-description.c mongoc-server-stream.c mongoc-set.c mongoc-socket.c mongoc-ssl.c mongoc-sspi.c mongoc-stream-buffered.c mongoc-stream.c mongoc-stream-file.c mongoc-stream-gridfs.c mongoc-stream-socket.c mongoc-stream-tls.c mongoc-stream-tls-libressl.c mongoc-stream-tls-openssl-bio.c mongoc-stream-tls-openssl.c mongoc-stream-tls-secure-channel.c mongoc-stream-tls-secure-transport.c mongoc-topology.c mongoc-topology-description-apm.c mongoc-topology-description.c mongoc-topology-scanner.c mongoc-uri.c mongoc-util.c mongoc-version-functions.c mongoc-write-command.c mongoc-write-command-legacy.c mongoc-write-concern.c";
+  // Generated with: find src/libmongoc/src/libmongoc/src/mongoc -name '*.c' -print0 | cut -sz -d / -f 7- | sort -z | tr '\000' ' '
+  var PHP_MONGODB_MONGOC_SOURCES="mongoc-apm.c mongoc-array.c mongoc-async.c mongoc-async-cmd.c mongoc-buffer.c mongoc-bulk-operation.c mongoc-change-stream.c mongoc-client.c mongoc-client-pool.c mongoc-client-session.c mongoc-cluster.c mongoc-cluster-cyrus.c mongoc-cluster-gssapi.c mongoc-cluster-sasl.c mongoc-cluster-sspi.c mongoc-cmd.c mongoc-collection.c mongoc-compression.c mongoc-counters.c mongoc-crypto.c mongoc-crypto-cng.c mongoc-crypto-common-crypto.c mongoc-crypto-openssl.c mongoc-cursor-array.c mongoc-cursor.c mongoc-cursor-cmd.c mongoc-cursor-cmd-deprecated.c mongoc-cursor-find.c mongoc-cursor-find-cmd.c mongoc-cursor-find-opquery.c mongoc-cursor-legacy.c mongoc-cyrus.c mongoc-database.c mongoc-find-and-modify.c mongoc-gridfs.c mongoc-gridfs-file.c mongoc-gridfs-file-list.c mongoc-gridfs-file-page.c mongoc-gssapi.c mongoc-handshake.c mongoc-host-list.c mongoc-index.c mongoc-init.c mongoc-libressl.c mongoc-linux-distro-scanner.c mongoc-list.c mongoc-log.c mongoc-matcher.c mongoc-matcher-op.c mongoc-memcmp.c mongoc-openssl.c mongoc-opts.c mongoc-opts-helpers.c mongoc-queue.c mongoc-rand-cng.c mongoc-rand-common-crypto.c mongoc-rand-openssl.c mongoc-read-concern.c mongoc-read-prefs.c mongoc-rpc.c mongoc-sasl.c mongoc-scram.c mongoc-secure-channel.c mongoc-secure-transport.c mongoc-server-description.c mongoc-server-stream.c mongoc-set.c mongoc-socket.c mongoc-ssl.c mongoc-sspi.c mongoc-stream-buffered.c mongoc-stream.c mongoc-stream-file.c mongoc-stream-gridfs.c mongoc-stream-socket.c mongoc-stream-tls.c mongoc-stream-tls-libressl.c mongoc-stream-tls-openssl-bio.c mongoc-stream-tls-openssl.c mongoc-stream-tls-secure-channel.c mongoc-stream-tls-secure-transport.c mongoc-topology.c mongoc-topology-description-apm.c mongoc-topology-description.c mongoc-topology-scanner.c mongoc-uri.c mongoc-util.c mongoc-version-functions.c mongoc-write-command.c mongoc-write-command-legacy.c mongoc-write-concern.c";
 
   EXTENSION("mongodb", "php_phongo.c phongo_compat.c", null, PHP_MONGODB_CFLAGS);
   ADD_SOURCES(configure_module_dirname + "/src", "bson.c bson-encode.c", "mongodb");
@@ -87,14 +92,16 @@ if (PHP_MONGODB != "no") {
   ADD_SOURCES(configure_module_dirname + "/src/MongoDB", "BulkWrite.c Command.c Cursor.c CursorId.c Manager.c Query.c ReadConcern.c ReadPreference.c Server.c Session.c WriteConcern.c WriteConcernError.c WriteError.c WriteResult.c", "mongodb");
   ADD_SOURCES(configure_module_dirname + "/src/MongoDB/Exception", "AuthenticationException.c BulkWriteException.c CommandException.c ConnectionException.c ConnectionTimeoutException.c Exception.c ExecutionTimeoutException.c InvalidArgumentException.c LogicException.c RuntimeException.c ServerException.c SSLConnectionException.c UnexpectedValueException.c WriteException.c", "mongodb");
   ADD_SOURCES(configure_module_dirname + "/src/MongoDB/Monitoring", "CommandFailedEvent.c CommandStartedEvent.c CommandSubscriber.c CommandSucceededEvent.c Subscriber.c functions.c", "mongodb");
-  ADD_SOURCES(configure_module_dirname + "/src/libbson/src/bson", PHP_MONGODB_BSON_SOURCES, "mongodb");
-  ADD_SOURCES(configure_module_dirname + "/src/libbson/src/jsonsl", PHP_MONGODB_JSONSL_SOURCES, "mongodb");
-  ADD_SOURCES(configure_module_dirname + "/src/libmongoc/src/mongoc", PHP_MONGODB_MONGOC_SOURCES, "mongodb");
+  ADD_SOURCES(configure_module_dirname + "/src/libmongoc/src/common", PHP_MONGODB_COMMON_SOURCES, "mongodb");
+  ADD_SOURCES(configure_module_dirname + "/src/libmongoc/src/libbson/src/bson", PHP_MONGODB_BSON_SOURCES, "mongodb");
+  ADD_SOURCES(configure_module_dirname + "/src/libmongoc/src/libbson/src/jsonsl", PHP_MONGODB_JSONSL_SOURCES, "mongodb");
+  ADD_SOURCES(configure_module_dirname + "/src/libmongoc/src/libmongoc/src/mongoc", PHP_MONGODB_MONGOC_SOURCES, "mongodb");
 
   var bson_opts = {
     BSON_BYTE_ORDER: 1234,
     BSON_OS: 2,
     BSON_HAVE_STDBOOL_H: 0,
+    BSON_HAVE_STRINGS_H: 0,
     BSON_HAVE_ATOMIC_32_ADD_AND_FETCH: 0,
     BSON_HAVE_ATOMIC_64_ADD_AND_FETCH: 0,
     BSON_PTHREAD_ONCE_INIT_NEEDS_BRACES: 0,
@@ -116,15 +123,15 @@ if (PHP_MONGODB != "no") {
   }
 
   mongodb_generate_header(
-    configure_module_dirname + "/src/libbson/src/bson/bson-config.h.in",
-    configure_module_dirname + "/src/libbson/src/bson/bson-config.h",
+    configure_module_dirname + "/src/libmongoc/src/libbson/src/bson/bson-config.h.in",
+    configure_module_dirname + "/src/libmongoc/src/libbson/src/bson/bson-config.h",
     bson_opts
   );
 
   mongodb_generate_header(
-    configure_module_dirname + "/src/libbson/src/bson/bson-version.h.in",
-    configure_module_dirname + "/src/libbson/src/bson/bson-version.h",
-    mongodb_parse_version_file(configure_module_dirname + "/src/libbson/VERSION_CURRENT", "BSON_")
+    configure_module_dirname + "/src/libmongoc/src/libbson/src/bson/bson-version.h.in",
+    configure_module_dirname + "/src/libmongoc/src/libbson/src/bson/bson-version.h",
+    mongodb_parse_version_file(configure_module_dirname + "/src/libmongoc/VERSION_CURRENT", "BSON_")
   );
 
   var mongoc_opts = {
@@ -147,13 +154,17 @@ if (PHP_MONGODB != "no") {
     MONGOC_ENABLE_SASL_CYRUS: 0,
     MONGOC_ENABLE_SASL_GSSAPI: 0,
     MONGOC_ENABLE_SASL_SSPI: 0,
+    MONGOC_ENABLE_RDTSCP: 0,
+    MONGOC_ENABLE_SHM_COUNTERS: 0,
     MONGOC_HAVE_ASN1_STRING_GET0_DATA: 0,
     MONGOC_HAVE_SASL_CLIENT_DONE: 0,
+    MONGOC_HAVE_SCHED_GETCPU: 0,
     MONGOC_HAVE_SOCKLEN: 1,
     MONGOC_HAVE_WEAK_SYMBOLS: 0,
     MONGOC_NO_AUTOMATIC_GLOBALS: 1,
     MONGOC_SOCKET_ARG2: "struct sockaddr",
     MONGOC_SOCKET_ARG3: "socklen_t",
+    MONGOC_TRACE: 1,
     MONGOC_HAVE_DNSAPI: 0,
     MONGOC_HAVE_RES_NSEARCH: 0,
     MONGOC_HAVE_RES_NDESTROY: 0,
@@ -224,14 +235,14 @@ if (PHP_MONGODB != "no") {
    * do not expect CFLAGS or LDFLAGS to be customized at build time. */
 
   mongodb_generate_header(
-    configure_module_dirname + "/src/libmongoc/src/mongoc/mongoc-config.h.in",
-    configure_module_dirname + "/src/libmongoc/src/mongoc/mongoc-config.h",
+    configure_module_dirname + "/src/libmongoc/src/libmongoc/src/mongoc/mongoc-config.h.in",
+    configure_module_dirname + "/src/libmongoc/src/libmongoc/src/mongoc/mongoc-config.h",
     mongoc_opts
   );
 
   mongodb_generate_header(
-    configure_module_dirname + "/src/libmongoc/src/mongoc/mongoc-version.h.in",
-    configure_module_dirname + "/src/libmongoc/src/mongoc/mongoc-version.h",
+    configure_module_dirname + "/src/libmongoc/src/libmongoc/src/mongoc/mongoc-version.h.in",
+    configure_module_dirname + "/src/libmongoc/src/libmongoc/src/mongoc/mongoc-version.h",
     mongodb_parse_version_file(configure_module_dirname + "/src/libmongoc/VERSION_CURRENT", "MONGOC_")
   );
 }

--- a/config.w32
+++ b/config.w32
@@ -66,7 +66,6 @@ if (PHP_MONGODB != "no") {
     /I" + configure_module_dirname + "/src/contrib \
     /I" + configure_module_dirname + "/src/libbson/src \
     /I" + configure_module_dirname + "/src/libbson/src/bson \
-    /I" + configure_module_dirname + "/src/libbson/src/yajl \
     /I" + configure_module_dirname + "/src/libmongoc/src/mongoc \
   ";
 

--- a/scripts/autotools/libbson/Versions.m4
+++ b/scripts/autotools/libbson/Versions.m4
@@ -1,4 +1,4 @@
-BSON_CURRENT_FILE=[]PHP_EXT_SRCDIR(mongodb)[/src/libmongoc/src/libbson/VERSION_CURRENT]
+BSON_CURRENT_FILE=[]PHP_EXT_SRCDIR(mongodb)[/src/libmongoc/VERSION_CURRENT]
 BSON_VERSION=$(cat $BSON_CURRENT_FILE)
 
 dnl Ensure newline for "cut" implementations that need it, e.g. HP-UX.


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1174

This should address the [changes](https://github.com/mongodb/mongo-c-driver/compare/b824883...1.10.0) between our last submodule bump and 1.10. Also includes changes to `config.w32` for Windows builds.