### PR TITLE
PHPC-1195: BulkWrite::update() should append arrayFilters as array

### DIFF
--- a/src/MongoDB/BulkWrite.c
+++ b/src/MongoDB/BulkWrite.c
@@ -139,13 +139,13 @@ static bool php_phongo_bulkwrite_opts_append_array(bson_t* opts, const char* key
 
 /* Appends a document field for the given opts document and key. Returns true on
  * success; otherwise, false is returned and an exception is thrown. */
-static bool php_phongo_bulkwrite_opts_append_document(bson_t* opts, const char* opts_key, zval* zarr, const char* zarr_key TSRMLS_DC) /* {{{ */
+static bool php_phongo_bulkwrite_opts_append_document(bson_t* opts, const char* key, zval* zarr TSRMLS_DC) /* {{{ */
 {
-	zval*  value = php_array_fetch(zarr, zarr_key);
+	zval*  value = php_array_fetch(zarr, key);
 	bson_t b     = BSON_INITIALIZER;
 
 	if (Z_TYPE_P(value) != IS_OBJECT && Z_TYPE_P(value) != IS_ARRAY) {
-		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Expected \"%s\" option to be array or object, %s given", zarr_key, zend_get_type_by_const(Z_TYPE_P(value)));
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Expected \"%s\" option to be array or object, %s given", key, zend_get_type_by_const(Z_TYPE_P(value)));
 		return false;
 	}
 
@@ -156,8 +156,8 @@ static bool php_phongo_bulkwrite_opts_append_document(bson_t* opts, const char* 
 		return false;
 	}
 
-	if (!BSON_APPEND_DOCUMENT(opts, opts_key, &b)) {
-		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Error appending \"%s\" option", opts_key);
+	if (!BSON_APPEND_DOCUMENT(opts, key, &b)) {
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Error appending \"%s\" option", key);
 		bson_destroy(&b);
 		return false;
 	}
@@ -185,11 +185,11 @@ static bool php_phongo_bulkwrite_opts_append_document(bson_t* opts, const char* 
 		}                                                                                   \
 	}
 
-#define PHONGO_BULKWRITE_OPT_DOCUMENT(opt)                                                            \
-	if (zoptions && php_array_existsc(zoptions, (opt))) {                                             \
-		if (!php_phongo_bulkwrite_opts_append_document(boptions, (opt), zoptions, (opt) TSRMLS_CC)) { \
-			return false;                                                                             \
-		}                                                                                             \
+#define PHONGO_BULKWRITE_OPT_DOCUMENT(opt)                                                     \
+	if (zoptions && php_array_existsc(zoptions, (opt))) {                                      \
+		if (!php_phongo_bulkwrite_opts_append_document(boptions, (opt), zoptions TSRMLS_CC)) { \
+			return false;                                                                      \
+		}                                                                                      \
 	}
 
 /* Applies options (including defaults) for an update operation. */

--- a/tests/bulk/bulkwrite-update-arrayFilters-001.phpt
+++ b/tests/bulk/bulkwrite-update-arrayFilters-001.phpt
@@ -1,15 +1,15 @@
 --TEST--
 MongoDB\Driver\BulkWrite::update with arrayFilters
---XFAIL--
-START() tests must be reimplemented (PHPC-1179)
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
-<?php START('THROWAWAY', ["version" => "36-release"]); CLEANUP(THROWAWAY); ?>
+<?php skip_if_not_live(); ?>
+<?php skip_if_server_version('<', '3.6'); ?>
+<?php skip_if_not_clean(); ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";
 
-$manager = new MongoDB\Driver\Manager(THROWAWAY);
+$manager = new MongoDB\Driver\Manager(URI);
 
 $bulk = new MongoDB\Driver\BulkWrite();
 
@@ -35,11 +35,7 @@ $cursor = $manager->executeQuery( DATABASE_NAME . '.' . COLLECTION_NAME, new \Mo
 var_dump($cursor->toArray());
 ?>
 ===DONE===
-<?php DELETE("THROWAWAY"); ?>
 <?php exit(0); ?>
---CLEAN--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
-<?php DELETE("THROWAWAY"); ?>
 --EXPECTF--
 array(%d) {
   [0]=>

--- a/tests/bulk/bulkwrite-update_error-003.phpt
+++ b/tests/bulk/bulkwrite-update_error-003.phpt
@@ -17,6 +17,14 @@ echo throws(function() use ($bulk) {
 
 echo throws(function() use ($bulk) {
     $bulk->update(['x' => 1], ['$set' => ['y' => 1]], ['collation' => 1]);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n\n";
+
+echo throws(function() use ($bulk) {
+    $bulk->update(['x' => 1], ['$set' => ['y' => 1]], ['arrayFilters' => 1]);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n\n";
+
+echo throws(function() use ($bulk) {
+    $bulk->update(['x' => 1], ['$set' => ['y' => 1]], ['arrayFilters' => ['foo' => 'bar']]);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
 ?>
@@ -31,4 +39,10 @@ Expected "collation" option to be array or object, int%S given
 
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected "collation" option to be array or object, int%S given
+
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "arrayFilters" option to be array or object, int%S given
+
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+"arrayFilters" option has invalid keys for a BSON array
 ===DONE===

--- a/tests/command/findAndModify-001.phpt
+++ b/tests/command/findAndModify-001.phpt
@@ -1,15 +1,15 @@
 --TEST--
 MongoDB\Driver\Command with findAndModify and arrayFilters
---XFAIL--
-START() tests must be reimplemented (PHPC-1179)
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
-<?php START('THROWAWAY', ["version" => "36-release"]); CLEANUP(THROWAWAY); ?>
+<?php skip_if_not_live(); ?>
+<?php skip_if_server_version('<', '3.6'); ?>
+<?php skip_if_not_clean(); ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";
 
-$manager = new MongoDB\Driver\Manager(THROWAWAY);
+$manager = new MongoDB\Driver\Manager(URI);
 
 $bulk = new MongoDB\Driver\BulkWrite();
 
@@ -35,11 +35,7 @@ $cursor = $manager->executeQuery( DATABASE_NAME . '.' . COLLECTION_NAME, new \Mo
 var_dump($cursor->toArray());
 ?>
 ===DONE===
-<?php DELETE("THROWAWAY"); ?>
 <?php exit(0); ?>
---CLEAN--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
-<?php DELETE("THROWAWAY"); ?>
 --EXPECTF--
 array(%d) {
   [0]=>

--- a/tests/command/update-001.phpt
+++ b/tests/command/update-001.phpt
@@ -1,15 +1,15 @@
 --TEST--
 MongoDB\Driver\Command with update and arrayFilters
---XFAIL--
-START() tests must be reimplemented (PHPC-1179)
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
-<?php START('THROWAWAY', ["version" => "36-release"]); CLEANUP(THROWAWAY); ?>
+<?php skip_if_not_live(); ?>
+<?php skip_if_server_version('<', '3.6'); ?>
+<?php skip_if_not_clean(); ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";
 
-$manager = new MongoDB\Driver\Manager(THROWAWAY);
+$manager = new MongoDB\Driver\Manager(URI);
 
 $bulk = new MongoDB\Driver\BulkWrite();
 
@@ -35,11 +35,7 @@ $cursor = $manager->executeQuery( DATABASE_NAME . '.' . COLLECTION_NAME, new \Mo
 var_dump($cursor->toArray());
 ?>
 ===DONE===
-<?php DELETE("THROWAWAY"); ?>
 <?php exit(0); ?>
---CLEAN--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
-<?php DELETE("THROWAWAY"); ?>
 --EXPECTF--
 array(%d) {
   [0]=>


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1195

Note: this is waiting on [CDRIVER-2661](https://jira.mongodb.org/browse/CDRIVER-2661). Once that is merged, this PR can be updated to bump the libmongoc submodule to 1.10-dev (assuming the issue is also backported to  the `r1.10` branch).