### PR TITLE
Test suite compatibility with server 4.0.0-rc5

### DIFF
--- a/tests/apm/monitoring-commandFailed-003.phpt
+++ b/tests/apm/monitoring-commandFailed-003.phpt
@@ -48,7 +48,7 @@ try {
 --EXPECTF--
 started: findAndModify
 failed: findAndModify
-object(stdClass)#%d (%d) {
+object(stdClass)#%d (%d) {%A
   ["ok"]=>
   float(0)
   ["errmsg"]=>

--- a/tests/apm/overview.phpt
+++ b/tests/apm/overview.phpt
@@ -92,7 +92,7 @@ object(MongoDB\Driver\Monitoring\CommandFailedEvent)#%d (%d) {
   ["operationId"]=>
   string(%d) "%s"
   ["reply"]=>
-  object(stdClass)#%d (%d) {
+  object(stdClass)#%d (%d) {%A
     ["ok"]=>
     float(0)
     ["errmsg"]=>

--- a/tests/bulk/write-0001.phpt
+++ b/tests/bulk/write-0001.phpt
@@ -116,7 +116,7 @@ object(MongoDB\Driver\BulkWrite)#%d (%d) {
   ["executed"]=>
   bool(true)
   ["server_id"]=>
-  int(1)
+  int(%r[1-9]\d*%r)
   ["write_concern"]=>
   NULL
 }

--- a/tests/bulk/write-0002.phpt
+++ b/tests/bulk/write-0002.phpt
@@ -64,7 +64,7 @@ object(MongoDB\Driver\BulkWrite)#%d (%d) {
   ["executed"]=>
   bool(true)
   ["server_id"]=>
-  int(1)
+  int(%r[1-9]\d*%r)
   ["write_concern"]=>
   array(%d) {
     ["w"]=>

--- a/tests/command/cursor-tailable-001.phpt
+++ b/tests/command/cursor-tailable-001.phpt
@@ -67,5 +67,5 @@ object(stdClass)#%d (%d) {
 Waited for 0.%d seconds
 Awaiting results...
 NULL
-Waited for 0.5%d seconds
+Waited for 0.%r(4|5)\d*%r seconds
 ===DONE===

--- a/tests/manager/manager-executeWriteCommand_error-002.phpt
+++ b/tests/manager/manager-executeWriteCommand_error-002.phpt
@@ -22,44 +22,11 @@ try {
     $manager->executeWriteCommand(DATABASE_NAME, $command, ['writeConcern' => new MongoDB\Driver\WriteConcern("undefined")]);
 } catch (MongoDB\Driver\Exception\CommandException $e) {
     printf("%s(%d): %s\n", get_class($e), $e->getCode(), $e->getMessage());
-    var_dump($e->getResultDocument());
 }
 
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECTF--
+--EXPECT--
 MongoDB\Driver\Exception\CommandException(79): Write Concern error: No write concern mode named 'undefined' found in replica set configuration
-object(stdClass)#%d (%d) {
-  ["lastErrorObject"]=>
-  object(stdClass)#%d (3) {
-    ["n"]=>
-    int(1)
-    ["updatedExisting"]=>
-    bool(false)
-    ["upserted"]=>
-    string(3) "foo"
-  }
-  ["value"]=>
-  object(stdClass)#%d (2) {
-    ["_id"]=>
-    string(3) "foo"
-    ["foo"]=>
-    array(1) {
-      [0]=>
-      string(3) "bar"
-    }
-  }
-  ["writeConcernError"]=>
-  object(stdClass)#%d (3) {
-    ["code"]=>
-    int(79)
-    ["codeName"]=>
-    string(23) "UnknownReplWriteConcern"
-    ["errmsg"]=>
-    string(74) "No write concern mode named 'undefined' found in replica set configuration"
-  }
-  ["ok"]=>
-  float(1)%A
-}
 ===DONE===

--- a/tests/manager/manager-executeWriteCommand_error-003.phpt
+++ b/tests/manager/manager-executeWriteCommand_error-003.phpt
@@ -21,22 +21,11 @@ try {
     $manager->executeWriteCommand(DATABASE_NAME, $command);
 } catch (MongoDB\Driver\Exception\CommandException $e) {
     printf("%s(%d): %s\n", get_class($e), $e->getCode(), $e->getMessage());
-    var_dump($e->getResultDocument());
 }
 
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECTF--
+--EXPECT--
 MongoDB\Driver\Exception\CommandException(9): Either an update or remove=true must be specified
-object(stdClass)#%d (%d) {
-  ["ok"]=>
-  float(0)
-  ["errmsg"]=>
-  string(49) "Either an update or remove=true must be specified"
-  ["code"]=>
-  int(9)
-  ["codeName"]=>
-  string(13) "FailedToParse"%A
-}
 ===DONE===


### PR DESCRIPTION
Various fixes for test failures encountered whilst running against 4.0.0-rc5 in both standalone and replica set modes.

Note: I punted on updating tests that still relied on replica set configurations used by the MO Vagrant enivironment. This includes expectations for particular hosts, ports, number of replica set members, and replica set tags.