### PR TITLE
Improve error reporting in start-servers.php and fix 3.0 servers

### DIFF
--- a/scripts/presets/replicaset-30.json
+++ b/scripts/presets/replicaset-30.json
@@ -11,7 +11,7 @@
                 "journal": true,
                 "nssize": 1,
                 "port": 3100,
-                "bind_ip": "0.0.0.0,::",
+                "bind_ip": "::,0.0.0.0",
                 "smallfiles": true,
                 "setParameter": {"enableTestCommands": 1}
             },
@@ -33,7 +33,7 @@
                 "journal": true,
                 "nssize": 1,
                 "port": 3101,
-                "bind_ip": "0.0.0.0,::",
+                "bind_ip": "::,0.0.0.0",
                 "smallfiles": true,
                 "setParameter": {"enableTestCommands": 1}
             },
@@ -55,7 +55,7 @@
                 "journal": true,
                 "nssize": 1,
                 "port": 3102,
-                "bind_ip": "0.0.0.0,::",
+                "bind_ip": "::,0.0.0.0",
                 "smallfiles": true,
                 "setParameter": {"enableTestCommands": 1}
             },

--- a/scripts/presets/standalone-30.json
+++ b/scripts/presets/standalone-30.json
@@ -9,7 +9,7 @@
         "journal": true,
         "nssize": 1,
         "port": 2700,
-        "bind_ip": "0.0.0.0,::",
+        "bind_ip": "::,0.0.0.0",
         "smallfiles": true,
         "setParameter": {"enableTestCommands": 1}
     },

--- a/scripts/start-servers.php
+++ b/scripts/start-servers.php
@@ -47,20 +47,16 @@ function make_ctx($preset, $method = "POST") {
     return $ctx;
 }
 
-function failed($result) {
-    echo "\n\n";
-    echo join("\n", $result);
-    printf("Last operation took: %.2f secs\n", lap());
-    exit();
-}
-
 function mo_http_request($uri, $context) {
     global $http_response_header;
 
     $result = file_get_contents($uri, false, $context);
 
     if ($result === false) {
-        failed($http_response_header);
+        printf("HTTP request to %s failed:\n", $uri);
+        var_dump($http_response_header);
+        printf("Last operation took: %.2f secs\n", lap());
+        exit(1);
     }
 
     return $result;
@@ -109,7 +105,8 @@ foreach($PRESETS["standalone"] as $preset) {
     $decode = json_decode_or_fail($result, true);
 
     if (!isset($decode["id"])) {
-        failed($decode);
+        printf("\"id\" field not found in server response:\n%s\n", $decode);
+        exit(1);
     }
 
     $SERVERS[$decode["id"]] = isset($decode["mongodb_auth_uri"]) ? $decode["mongodb_auth_uri"] : $decode["mongodb_uri"];
@@ -126,8 +123,10 @@ foreach($PRESETS["replicasets"] as $preset) {
     $decode = json_decode_or_fail($result, true);
 
     if (!isset($decode["id"])) {
-        failed($decode);
+        printf("\"id\" field not found in replica set response:\n%s\n", $decode);
+        exit(1);
     }
+
     $SERVERS[$decode["id"]] = isset($decode["mongodb_auth_uri"]) ? $decode["mongodb_auth_uri"] : $decode["mongodb_uri"];
     printf("'%s'\t(took: %.2f secs)\n", $SERVERS[$decode["id"]], lap());
 }

--- a/scripts/start-servers.php
+++ b/scripts/start-servers.php
@@ -47,6 +47,12 @@ function make_ctx($preset, $method = "POST") {
     return $ctx;
 }
 
+function failed()
+{
+    printf("\nLast operation took: %.2f secs\n", lap());
+    exit(1);
+}
+
 function mo_http_request($uri, $context) {
     global $http_response_header;
 
@@ -55,21 +61,20 @@ function mo_http_request($uri, $context) {
     if ($result === false) {
         printf("HTTP request to %s failed:\n", $uri);
         var_dump($http_response_header);
-        printf("Last operation took: %.2f secs\n", lap());
-        exit(1);
+        failed();
     }
 
     return $result;
 }
 
-function json_decode_or_fail(/* json_decode() args */)
+function json_decode_or_fail(...$args)
 {
-    $decoded = call_user_func_array('json_decode', func_get_args());
+    $decoded = json_decode(...$args);
 
     if ($decoded === NULL && json_last_error() !== JSON_ERROR_NONE) {
         printf("\njson_decode() failed: %s\n", json_last_error_msg());
         var_dump(func_get_arg(0));
-        exit(1);
+        failed();
     }
 
     return $decoded;
@@ -106,7 +111,7 @@ foreach($PRESETS["standalone"] as $preset) {
 
     if (!isset($decode["id"])) {
         printf("\"id\" field not found in server response:\n%s\n", $decode);
-        exit(1);
+        failed();
     }
 
     $SERVERS[$decode["id"]] = isset($decode["mongodb_auth_uri"]) ? $decode["mongodb_auth_uri"] : $decode["mongodb_uri"];
@@ -124,7 +129,7 @@ foreach($PRESETS["replicasets"] as $preset) {
 
     if (!isset($decode["id"])) {
         printf("\"id\" field not found in replica set response:\n%s\n", $decode);
-        exit(1);
+        failed();
     }
 
     $SERVERS[$decode["id"]] = isset($decode["mongodb_auth_uri"]) ? $decode["mongodb_auth_uri"] : $decode["mongodb_uri"];


### PR DESCRIPTION
Improves error reporting for failures in `start-servers.php`.

Also fixes an issue that prevented 3.0 servers from starting successfully after `bind_ip` was added in https://github.com/mongodb/mongo-php-driver/commit/0f2e38730bc68f700fa4cc69543b44fe0ca5f12f (#850). See [SERVER-35705](https://jira.mongodb.org/browse/SERVER-35705) for more info.