### PR TITLE
$changeStream requires WiredTiger storage engine

### DIFF
--- a/tests/command/cursor-tailable-001.phpt
+++ b/tests/command/cursor-tailable-001.phpt
@@ -5,6 +5,7 @@ MongoDB\Driver\Command tailable cursor iteration with maxAwaitTimeMS option
 <?php skip_if_not_replica_set(); ?>
 <?php skip_if_not_clean(); ?>
 <?php skip_if_server_version('<', '3.2'); ?>
+<?php skip_if_not_server_storage_engine('wiredTiger'); ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";

--- a/tests/cursor/bug1050-001.phpt
+++ b/tests/cursor/bug1050-001.phpt
@@ -5,6 +5,7 @@ PHPC-1050: Command cursor should not invoke getMore at execution
 <?php skip_if_not_replica_set(); ?>
 <?php skip_if_not_clean(); ?>
 <?php skip_if_server_version('<', '3.2'); ?>
+<?php skip_if_not_server_storage_engine('wiredTiger'); ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";

--- a/tests/cursor/bug1050-002.phpt
+++ b/tests/cursor/bug1050-002.phpt
@@ -5,6 +5,7 @@ PHPC-1050: Command cursor should not invoke getMore at execution (rewind omitted
 <?php skip_if_not_replica_set(); ?>
 <?php skip_if_not_clean(); ?>
 <?php skip_if_server_version('<', '3.2'); ?>
+<?php skip_if_not_server_storage_engine('wiredTiger'); ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";


### PR DESCRIPTION
Per [Open A Change Stream](https://docs.mongodb.com/manual/changeStreams/#open-a-change-stream):

> You can only open a change stream against replica sets or sharded clusters. For a sharded cluster, you must issue the open change stream operation against the mongos.
>
> The replica set or the sharded cluster must use replica set protocol version 1 (pv1) and WiredTiger storage engine (can be encrypted).