### PR TITLE
PHPC-1222: Implement accessor for error labels on exception classes

### DIFF
--- a/src/MongoDB/Exception/RuntimeException.c
+++ b/src/MongoDB/Exception/RuntimeException.c
@@ -23,12 +23,88 @@
 
 #include "phongo_compat.h"
 #include "php_phongo.h"
+#include "php_array_api.h"
 
 zend_class_entry* php_phongo_runtimeexception_ce;
 
+static bool php_phongo_has_string_array_element(zval* labels, char* label TSRMLS_DC)
+{
+	HashTable* ht_data;
+
+	if (Z_TYPE_P(labels) != IS_ARRAY) {
+		return false;
+	}
+
+	ht_data = HASH_OF(labels);
+
+#if PHP_VERSION_ID >= 70000
+	{
+		zval* z_label;
+
+		ZEND_HASH_FOREACH_VAL(ht_data, z_label)
+		{
+			if ((Z_TYPE_P(z_label) == IS_STRING) && (strcmp(Z_STRVAL_P(z_label), label) == 0)) {
+				return true;
+			}
+		}
+		ZEND_HASH_FOREACH_END();
+	}
+#else
+	{
+		HashPosition pos;
+		zval** z_label;
+
+		for (
+			zend_hash_internal_pointer_reset_ex(ht_data, &pos);
+			zend_hash_get_current_data_ex(ht_data, (void**) &z_label, &pos) == SUCCESS;
+			zend_hash_move_forward_ex(ht_data, &pos)) {
+
+			if (Z_TYPE_PP(z_label) == IS_STRING) {
+				if (strcmp(Z_STRVAL_PP(z_label), label) == 0) {
+					return true;
+				}
+			}
+		}
+	}
+#endif
+
+	return false;
+}
+
+/* {{{ proto bool MongoDB\Driver\Exception\RuntimeException::hasErrorLabel(string $label)
+   Returns whether a specific error label has been set */
+static PHP_METHOD(RuntimeException, hasErrorLabel)
+{
+	char*                           label;
+	phongo_zpp_char_len             label_len;
+	zval*                           error_labels;
+#if PHP_VERSION_ID >= 70000
+	zval rv;
+#endif
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &label, &label_len) == FAILURE) {
+		return;
+	}
+
+#if PHP_VERSION_ID >= 70000
+	error_labels = zend_read_property(php_phongo_runtimeexception_ce, getThis(), ZEND_STRL("errorLabels"), 0, &rv TSRMLS_CC);
+#else
+	error_labels = zend_read_property(php_phongo_runtimeexception_ce, getThis(), ZEND_STRL("errorLabels"), 0 TSRMLS_CC);
+#endif
+
+	RETURN_BOOL(php_phongo_has_string_array_element(error_labels, label TSRMLS_CC));
+} /* }}} */
+
+ZEND_BEGIN_ARG_INFO_EX(ai_RuntimeException_hasErrorLabel, 0, 0, 1)
+	ZEND_ARG_INFO(0, label)
+ZEND_END_ARG_INFO()
+
 /* {{{ MongoDB\Driver\Exception\RuntimeException function entries */
 static zend_function_entry php_phongo_runtimeexception_me[] = {
+	/* clang-format off */
+	PHP_ME(RuntimeException, hasErrorLabel, ai_RuntimeException_hasErrorLabel, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_FE_END
+	/* clang-format on */
 };
 /* }}} */
 
@@ -43,6 +119,8 @@ void php_phongo_runtimeexception_init_ce(INIT_FUNC_ARGS) /* {{{ */
 	php_phongo_runtimeexception_ce = zend_register_internal_class_ex(&ce, spl_ce_RuntimeException, NULL TSRMLS_CC);
 #endif
 	zend_class_implements(php_phongo_runtimeexception_ce TSRMLS_CC, 1, php_phongo_exception_ce);
+
+	zend_declare_property_null(php_phongo_runtimeexception_ce, ZEND_STRL("errorLabels"), ZEND_ACC_PROTECTED TSRMLS_CC);
 } /* }}} */
 
 /*

--- a/tests/apm/overview.phpt
+++ b/tests/apm/overview.phpt
@@ -88,6 +88,8 @@ object(MongoDB\Driver\Monitoring\CommandFailedEvent)#%d (%d) {
     %a
     ["previous":"Exception":private]=>
     NULL
+    ["errorLabels":protected]=>
+    NULL
   }
   ["operationId"]=>
   string(%d) "%s"

--- a/tests/exception/bulkwriteexception-haserrorlabel-001.phpt
+++ b/tests/exception/bulkwriteexception-haserrorlabel-001.phpt
@@ -1,0 +1,24 @@
+--TEST--
+MongoDB\Driver\Exception\BulkWriteException::hasErrorLabel()
+--FILE--
+<?php
+
+$exception = new MongoDB\Driver\Exception\BulkWriteException();
+$labels = ['test', 'foo'];
+
+$reflection = new ReflectionClass($exception);
+
+$resultDocumentProperty = $reflection->getProperty('errorLabels');
+$resultDocumentProperty->setAccessible(true);
+$resultDocumentProperty->setValue($exception, $labels);
+
+var_dump($exception->hasErrorLabel('foo'));
+var_dump($exception->hasErrorLabel('bar'));
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+bool(true)
+bool(false)
+===DONE===

--- a/tests/exception/bulkwriteexception-haserrorlabel_error-001.phpt
+++ b/tests/exception/bulkwriteexception-haserrorlabel_error-001.phpt
@@ -1,0 +1,22 @@
+--TEST--
+MongoDB\Driver\Exception\BulkWriteException::hasErrorLabel() with non-array values
+--FILE--
+<?php
+
+$exception = new MongoDB\Driver\Exception\BulkWriteException();
+$labels = 'shouldBeAnArray';
+
+$reflection = new ReflectionClass($exception);
+
+$resultDocumentProperty = $reflection->getProperty('errorLabels');
+$resultDocumentProperty->setAccessible(true);
+$resultDocumentProperty->setValue($exception, $labels);
+
+var_dump($exception->hasErrorLabel('bar'));
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+bool(false)
+===DONE===

--- a/tests/exception/commandexception-haserrorlabel-001.phpt
+++ b/tests/exception/commandexception-haserrorlabel-001.phpt
@@ -1,0 +1,24 @@
+--TEST--
+MongoDB\Driver\Exception\CommandException::hasErrorLabel()
+--FILE--
+<?php
+
+$exception = new MongoDB\Driver\Exception\CommandException();
+$labels = ['test', 'foo'];
+
+$reflection = new ReflectionClass($exception);
+
+$resultDocumentProperty = $reflection->getProperty('errorLabels');
+$resultDocumentProperty->setAccessible(true);
+$resultDocumentProperty->setValue($exception, $labels);
+
+var_dump($exception->hasErrorLabel('foo'));
+var_dump($exception->hasErrorLabel('bar'));
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+bool(true)
+bool(false)
+===DONE===

--- a/tests/exception/commandexception-haserrorlabel_error-001.phpt
+++ b/tests/exception/commandexception-haserrorlabel_error-001.phpt
@@ -1,0 +1,22 @@
+--TEST--
+MongoDB\Driver\Exception\CommandException::hasErrorLabel() with non-array values
+--FILE--
+<?php
+
+$exception = new MongoDB\Driver\Exception\CommandException();
+$labels = 'shouldBeAnArray';
+
+$reflection = new ReflectionClass($exception);
+
+$resultDocumentProperty = $reflection->getProperty('errorLabels');
+$resultDocumentProperty->setAccessible(true);
+$resultDocumentProperty->setValue($exception, $labels);
+
+var_dump($exception->hasErrorLabel('bar'));
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+bool(false)
+===DONE===

--- a/tests/exception/runtimeexception-haserrorlabel-001.phpt
+++ b/tests/exception/runtimeexception-haserrorlabel-001.phpt
@@ -1,0 +1,24 @@
+--TEST--
+MongoDB\Driver\Exception\RuntimeException::hasErrorLabel()
+--FILE--
+<?php
+
+$exception = new MongoDB\Driver\Exception\RuntimeException();
+$labels = ['test', 'foo'];
+
+$reflection = new ReflectionClass($exception);
+
+$resultDocumentProperty = $reflection->getProperty('errorLabels');
+$resultDocumentProperty->setAccessible(true);
+$resultDocumentProperty->setValue($exception, $labels);
+
+var_dump($exception->hasErrorLabel('foo'));
+var_dump($exception->hasErrorLabel('bar'));
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+bool(true)
+bool(false)
+===DONE===

--- a/tests/exception/runtimeexception-haserrorlabel_error-001.phpt
+++ b/tests/exception/runtimeexception-haserrorlabel_error-001.phpt
@@ -1,0 +1,22 @@
+--TEST--
+MongoDB\Driver\Exception\RuntimeException::hasErrorLabel() with non-array values
+--FILE--
+<?php
+
+$exception = new MongoDB\Driver\Exception\RuntimeException();
+$labels = 'shouldBeAnArray';
+
+$reflection = new ReflectionClass($exception);
+
+$resultDocumentProperty = $reflection->getProperty('errorLabels');
+$resultDocumentProperty->setAccessible(true);
+$resultDocumentProperty->setValue($exception, $labels);
+
+var_dump($exception->hasErrorLabel('bar'));
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+bool(false)
+===DONE===

--- a/tests/session/transaction-integration-002.phpt
+++ b/tests/session/transaction-integration-002.phpt
@@ -61,9 +61,7 @@ try {
     ] );
     $manager->executeCommand(DATABASE_NAME, $cmd, ['session' => $sessionB]);
 } catch (MongoDB\Driver\Exception\CommandException $e) {
-    $rd = $e->getResultDocument();
-
-    echo (isset($rd->errorLabels) && in_array("TransientTransactionError", $rd->errorLabels)) ?
+    echo $e->hasErrorLabel('TransientTransactionError') ?
         "found a TransientTransactionError" : "did NOT get a TransientTransactionError", "\n";
 }
 ?>


### PR DESCRIPTION
Before we can merge this, we need to branch 1.5 from 1.6 of course. Just wanted your opinion on it. The second commit in this PR we can safely drop. I did the work so I can audit, but am now unsure whether it's wise to get rid of that older API that doesn't take a reply_t as well.