### PR TITLE
Catch CommandException before calling getResultDocument()

### DIFF
--- a/tests/session/transaction-integration-001.phpt
+++ b/tests/session/transaction-integration-001.phpt
@@ -58,7 +58,7 @@ while (true) {
 
         $session->commitTransaction();
         echo "Transaction committed.\n";break;
-    } catch (\MongoDB\Driver\Exception\Exception $e) {
+    } catch (\MongoDB\Driver\Exception\CommandException $e) {
         $rd = $e->getResultDocument();
 
         if (isset($rd->errorLabels) && in_array('TransientTransactionError', $rd->errorLabels)) {


### PR DESCRIPTION
`transaction-integration-002.phpt` rightfully catches CommandException, but it looks like that was missed in the first test.