### PR TITLE
Fix build against OpenSSL 1.1

### DIFF
--- a/scripts/autotools/libmongoc/CheckSSL.m4
+++ b/scripts/autotools/libmongoc/CheckSSL.m4
@@ -82,11 +82,24 @@ AS_IF([test "$PHP_MONGODB_SSL" = "openssl" -o "$PHP_MONGODB_SSL" = "auto"],[
                       [have_crypto_lib="yes"],
                       [have_crypto_lib="no"],
                       [$OPENSSL_LIBDIR_LDFLAG])
+
+    have_ssl_lib="no"
+
+    dnl OpenSSL < 1.1.0
     PHP_CHECK_LIBRARY([ssl],
                       [SSL_library_init],
                       [have_ssl_lib="yes"],
-                      [have_ssl_lib="no"],
+                      [],
                       [$OPENSSL_LIBDIR_LDFLAG -lcrypto])
+
+    dnl OpenSSL >= 1.1.0
+    if test "$have_ssl_lib" = "no"; then
+      PHP_CHECK_LIBRARY([ssl],
+                        [OPENSSL_init_ssl],
+                        [have_ssl_lib="yes"],
+                        [],
+                        [$OPENSSL_LIBDIR_LDFLAG -lcrypto])
+    fi
 
     if test "$have_ssl_lib" = "yes" -a "$have_crypto_lib" = "yes"; then
       PHP_ADD_LIBRARY([ssl],,[MONGODB_SHARED_LIBADD])


### PR DESCRIPTION
OpenSSL 1.1 [deprecates](https://www.openssl.org/docs/man1.1.0/ssl/SSL_library_init.html) the `SSL_library_init()` function in favour of `OPENSSL_init_ssl()`.

While backward-compatibility macros are provided so that programs will generally work, `AC_CHECK_LIB` does not find the function and configure time because it does not include the header with the macro definition.

This patch will let the configure script search for the new function if the old one is not found.

Specifically, this fixes building against [the openssl package for debian stretch](https://packages.debian.org/stretch/openssl).

*N.B. while this patch definitely fixes the build, I have not yet been able to run the test suite against the resulting binary, I will be able to do so next week, it may be best if this patch is not merged before I can confirm it works properly.*