### PR TITLE
Don't check for specific error string in test

### DIFF
--- a/tests/manager/manager-executeCommand_error-003.phpt
+++ b/tests/manager/manager-executeCommand_error-003.phpt
@@ -17,5 +17,5 @@ echo throws(function() use($manager, $command) {
 <?php exit(0); ?>
 --EXPECTF--
 OK: Got MongoDB\Driver\Exception\ConnectionTimeoutException
-No suitable servers found (`serverSelectionTryOnce` set): [connection refused calling ismaster on '%s']
+No suitable servers found (`serverSelectionTryOnce` set): %s
 ===DONE===


### PR DESCRIPTION
Test checks for a specific error string that may vary between systems,

This patch brings the test into line with several other tests that check for timeout exceptions, e.g. https://github.com/mongodb/mongo-php-driver/blob/master/tests/standalone/bug0655.phpt