### PR TITLE
 PHPC-1241: OpenSSL 1.1 not found if pkg-config is not available 

### DIFF
--- a/scripts/autotools/libmongoc/CheckSSL.m4
+++ b/scripts/autotools/libmongoc/CheckSSL.m4
@@ -83,22 +83,21 @@ AS_IF([test "$PHP_MONGODB_SSL" = "openssl" -o "$PHP_MONGODB_SSL" = "auto"],[
                       [have_crypto_lib="no"],
                       [$OPENSSL_LIBDIR_LDFLAG])
 
-    have_ssl_lib="no"
 
-    dnl OpenSSL < 1.1.0
+    AC_MSG_NOTICE([checking whether OpenSSL >= 1.1.0 is available])
     PHP_CHECK_LIBRARY([ssl],
-                      [SSL_library_init],
+                      [OPENSSL_init_ssl],
                       [have_ssl_lib="yes"],
-                      [],
+                      [have_ssl_lib="no"],
                       [$OPENSSL_LIBDIR_LDFLAG -lcrypto])
 
-    dnl OpenSSL >= 1.1.0
     if test "$have_ssl_lib" = "no"; then
-      PHP_CHECK_LIBRARY([ssl],
-                        [OPENSSL_init_ssl],
-                        [have_ssl_lib="yes"],
-                        [],
-                        [$OPENSSL_LIBDIR_LDFLAG -lcrypto])
+        AC_MSG_NOTICE([checking whether OpenSSL < 1.1.0 is available])
+        PHP_CHECK_LIBRARY([ssl],
+                          [SSL_library_init],
+                          [have_ssl_lib="yes"],
+                          [have_ssl_lib="no"],
+                          [$OPENSSL_LIBDIR_LDFLAG -lcrypto])
     fi
 
     if test "$have_ssl_lib" = "yes" -a "$have_crypto_lib" = "yes"; then

--- a/scripts/autotools/libmongoc/CheckSSL.m4
+++ b/scripts/autotools/libmongoc/CheckSSL.m4
@@ -82,11 +82,24 @@ AS_IF([test "$PHP_MONGODB_SSL" = "openssl" -o "$PHP_MONGODB_SSL" = "auto"],[
                       [have_crypto_lib="yes"],
                       [have_crypto_lib="no"],
                       [$OPENSSL_LIBDIR_LDFLAG])
+
+    have_ssl_lib="no"
+
+    dnl OpenSSL < 1.1.0
     PHP_CHECK_LIBRARY([ssl],
                       [SSL_library_init],
                       [have_ssl_lib="yes"],
-                      [have_ssl_lib="no"],
+                      [],
                       [$OPENSSL_LIBDIR_LDFLAG -lcrypto])
+
+    dnl OpenSSL >= 1.1.0
+    if test "$have_ssl_lib" = "no"; then
+      PHP_CHECK_LIBRARY([ssl],
+                        [OPENSSL_init_ssl],
+                        [have_ssl_lib="yes"],
+                        [],
+                        [$OPENSSL_LIBDIR_LDFLAG -lcrypto])
+    fi
 
     if test "$have_ssl_lib" = "yes" -a "$have_crypto_lib" = "yes"; then
       PHP_ADD_LIBRARY([ssl],,[MONGODB_SHARED_LIBADD])


### PR DESCRIPTION
I've taking @DaveRandom 's patch from #875 and added the conditional check for OpenSSL < 1.1 from @jmikola's comment on that. I did switch the order of the checking, to check for >= 1.1 before checking for < 1.1. I've tested this locally with 1. pkg-config available, 2. pkg-config unavailable and OpenSSL 1.0.2, and 3. pkg-config unavailable and OpenSSL 1.1.