### PR TITLE
Replace AC_HELP_STRING with AS_HELP_STRING

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -1,7 +1,7 @@
 dnl config.m4 for extension mongodb
 PHP_ARG_ENABLE([mongodb],
                [whether to enable MongoDB support],
-               [AC_HELP_STRING([--enable-mongodb],
+               [AS_HELP_STRING([--enable-mongodb],
                                [Enable MongoDB support])])
 
 if test "$PHP_MONGODB" != "no"; then
@@ -26,7 +26,7 @@ if test "$PHP_MONGODB" != "no"; then
 
   PHP_ARG_ENABLE([mongodb-developer-flags],
                  [whether to enable developer build flags],
-                 [AC_HELP_STRING([--enable-mongodb-developer-flags],
+                 [AS_HELP_STRING([--enable-mongodb-developer-flags],
                                  [MongoDB: Enable developer flags [default=no]])],
                  [no],
                  [no])
@@ -82,7 +82,7 @@ if test "$PHP_MONGODB" != "no"; then
 
   PHP_ARG_ENABLE([mongodb-coverage],
                  [whether to enable code coverage],
-                 [AC_HELP_STRING([--enable-mongodb-coverage],
+                 [AS_HELP_STRING([--enable-mongodb-coverage],
                                  [MongoDB: Enable developer code coverage information [default=no]])],
                  [no],
                  [no])

--- a/scripts/autotools/libmongoc/CheckSSL.m4
+++ b/scripts/autotools/libmongoc/CheckSSL.m4
@@ -7,7 +7,7 @@ PHP_ARG_WITH([mongodb-ssl],
 
 PHP_ARG_WITH([openssl-dir],
              [deprecated option for OpenSSL library path],
-             [AC_HELP_STRING([--with-openssl-dir=@<:@auto/DIR@:>@],
+             [AS_HELP_STRING([--with-openssl-dir=@<:@auto/DIR@:>@],
                              [MongoDB: OpenSSL library path (deprecated for pkg-config) [default=auto]])],
              [auto],
              [no])
@@ -219,14 +219,14 @@ fi
 
 PHP_ARG_ENABLE([mongodb-crypto-system-profile],
                [whether to use system crypto profile],
-               [AC_HELP_STRING([--enable-mongodb-crypto-system-profile],
+               [AS_HELP_STRING([--enable-mongodb-crypto-system-profile],
                                [MongoDB: Use system crypto profile (OpenSSL only) [default=no]])],
                [no],
                [no])
 
 PHP_ARG_WITH([system-ciphers],
              [deprecated option for whether to use system crypto profile],
-             AC_HELP_STRING([--enable-system-ciphers],
+             AS_HELP_STRING([--enable-system-ciphers],
                             [MongoDB: whether to use system crypto profile (deprecated for --enable-mongodb-crypto-system-profile) [default=no]]),
              [no],
              [no])


### PR DESCRIPTION
Hello,

The `AC_HELP_STRING` has been made obsolete since Autoconf 2.58 somewhere in 2003. The new AS_HELP_STRING macro has been since recommended to be used and should be today supported on most systems out there. The `phpize` script for PHP 7.2+ requires Autoconf 2.59 and PHP requires 2.64.

This patch has been made with the help of the `autoupdate` script.

Autoconf changelog:
- http://git.savannah.gnu.org/cgit/autoconf.git/tree/ChangeLog.3

Thanks.