### PR TITLE
Replace obsolete AC_TRY_LINK with AC_LINK_IFELSE

### DIFF
--- a/scripts/autotools/libmongoc/CheckResolv.m4
+++ b/scripts/autotools/libmongoc/CheckResolv.m4
@@ -7,20 +7,20 @@ old_LIBS="$LIBS"
 LIBS="$LIBS -lresolv"
 
 dnl Thread-safe DNS query function for _mongoc_client_get_srv.
-dnl Could be a macro, not a function, so check with AC_TRY_LINK.
+dnl Could be a macro, not a function, so check with AC_LINK_IFELSE.
 AC_MSG_CHECKING([for res_nsearch])
-AC_TRY_LINK([
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[
    #include <sys/types.h>
    #include <netinet/in.h>
    #include <arpa/nameser.h>
    #include <resolv.h>
-],[
+]], [[
    int len;
    unsigned char reply[1024];
    res_state statep;
    len = res_nsearch(
       statep, "example.com", ns_c_in, ns_t_srv, reply, sizeof(reply));
-],[
+]])], [
    AC_MSG_RESULT([yes])
    AC_SUBST(MONGOC_HAVE_RES_SEARCH, 0)
    AC_SUBST(MONGOC_HAVE_RES_NSEARCH, 1)
@@ -28,15 +28,15 @@ AC_TRY_LINK([
 
    dnl We have res_nsearch. Call res_ndestroy (BSD/Mac) or res_nclose (Linux)?
    AC_MSG_CHECKING([for res_ndestroy])
-   AC_TRY_LINK([
+   AC_LINK_IFELSE([AC_LANG_PROGRAM([[
       #include <sys/types.h>
       #include <netinet/in.h>
       #include <arpa/nameser.h>
       #include <resolv.h>
-   ],[
+   ]], [[
       res_state statep;
       res_ndestroy(statep);
-   ], [
+   ]])], [
       AC_MSG_RESULT([yes])
       AC_SUBST(MONGOC_HAVE_RES_NDESTROY, 1)
       AC_SUBST(MONGOC_HAVE_RES_NCLOSE, 0)
@@ -44,15 +44,15 @@ AC_TRY_LINK([
       AC_MSG_RESULT([no])
       AC_SUBST(MONGOC_HAVE_RES_NDESTROY, 0)
       AC_MSG_CHECKING([for res_nclose])
-      AC_TRY_LINK([
+      AC_LINK_IFELSE([AC_LANG_PROGRAM([[
          #include <sys/types.h>
          #include <netinet/in.h>
          #include <arpa/nameser.h>
          #include <resolv.h>
-      ],[
+      ]], [[
          res_state statep;
          res_nclose(statep);
-      ], [
+      ]])], [
          AC_MSG_RESULT([yes])
          AC_SUBST(MONGOC_HAVE_RES_NCLOSE, 1)
       ], [
@@ -68,16 +68,16 @@ AC_TRY_LINK([
 
    dnl Thread-unsafe function.
    AC_MSG_CHECKING([for res_search])
-   AC_TRY_LINK([
+   AC_LINK_IFELSE([AC_LANG_PROGRAM([[
       #include <sys/types.h>
       #include <netinet/in.h>
       #include <arpa/nameser.h>
       #include <resolv.h>
-   ],[
+   ]], [[
       int len;
       unsigned char reply[1024];
       len = res_search("example.com", ns_c_in, ns_t_srv, reply, sizeof(reply));
-   ], [
+   ]])], [
       AC_MSG_RESULT([yes])
       AC_SUBST(MONGOC_HAVE_RES_SEARCH, 1)
       found_resolv="yes"


### PR DESCRIPTION
The `AC_TRY_LINK` macro has been made obsolete in Autoconf 2.50 in 2001. It should be replaced with `AC_LINK_IFELSE` instead.

Systems should by now well support this, since PHP 5.3 required Autoconf 2.13+ (released in 1999) or newer, PHP 5.4 required Autoconf 2.59+ (released in 2003), and since PHP 7.2, Autoconf 2.64+ (released in 2008) is required and for PHP 7.2 phpize the Autoconf 2.59+ is required.

Refs:
- https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/AC_005fACT_005fIFELSE-vs-AC_005fTRY_005fACT.html
- https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Obsolete-Macros.html