### PR TITLE
Fix AC_CHECK_FUNC macro call syntax for rand_r

### DIFF
--- a/scripts/autotools/libbson/FindDependencies.m4
+++ b/scripts/autotools/libbson/FindDependencies.m4
@@ -73,7 +73,7 @@ AC_CHECK_FUNC(gmtime_r, [AC_SUBST(BSON_HAVE_GMTIME_R, 1)])
 
 # Check for rand_r()
 AC_SUBST(BSON_HAVE_RAND_R, 0)
-AC_CHECK_FUNC(rand_r, [AC_SUBST(BSON_HAVE_RAND_R, 1)], [], [#include <stdlib.h>])
+AC_CHECK_FUNC(rand_r, [AC_SUBST(BSON_HAVE_RAND_R, 1)])
 
 # Check for pthreads. We might need to make this better to handle mingw,
 # but I actually think it is okay to just check for it even though we will


### PR DESCRIPTION
The [AC_CHECK_FUNC](https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Generic-Functions.html) macro has only the following form:

```m4
AC_CHECK_FUNC(function, [action-if-found], [action-if-not-found])
````
In most cases adding more arguments to macro call don't cause errors, but it also doesn't have any functionality either, so spotting such typos is not obvious at first glance.

The second argument of the macro `[]`, can be also left out.