### PR TITLE
PHPC-1227: Add more tests for disallowed per-op read/write concerns in transactions

### DIFF
--- a/tests/session/transaction-integration_error-002.phpt
+++ b/tests/session/transaction-integration_error-002.phpt
@@ -1,5 +1,5 @@
 --TEST--
-MongoDB\Driver\Session: Setting per-op readConcern or writeConcern in transaction (executeCommand)
+MongoDB\Driver\Session: Setting per-op readConcern in transaction (executeReadCommand)
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_not_libmongoc_crypto(); ?>
@@ -30,30 +30,15 @@ $session->startTransaction( [
 
 echo throws(function() use ($manager, $session) {
     $cmd = new \MongoDB\Driver\Command( [
-        'update' => COLLECTION_NAME,
-        'updates' => [ [ 'q' => [ 'employee' => 3 ], 'u' => [ '$set' => [ 'status' => 'Inactive' ] ] ] ]
+        'count' => COLLECTION_NAME,
+        'query' => [ 'q' => [ 'employee' => 3 ] ]
     ] );
-    $manager->executeCommand(
+    $manager->executeReadCommand(
         DATABASE_NAME,
         $cmd,
         [
             'session' => $session,
             'readConcern' => new \MongoDB\Driver\ReadConcern( \MongoDB\Driver\ReadConcern::LOCAL )
-        ]
-    );
-}, "MongoDB\Driver\Exception\InvalidArgumentException"), "\n";
-
-echo throws(function() use ($manager, $session) {
-    $cmd = new \MongoDB\Driver\Command( [
-        'update' => COLLECTION_NAME,
-        'updates' => [ [ 'q' => [ 'employee' => 3 ], 'u' => [ '$set' => [ 'status' => 'Inactive' ] ] ] ]
-    ] );
-    $manager->executeCommand(
-        DATABASE_NAME,
-        $cmd,
-        [
-            'session' => $session,
-            'writeConcern' => new \MongoDB\Driver\WriteConcern( \MongoDB\Driver\WriteConcern::MAJORITY )
         ]
     );
 }, "MongoDB\Driver\Exception\InvalidArgumentException"), "\n";
@@ -64,6 +49,4 @@ echo throws(function() use ($manager, $session) {
 --EXPECT--
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Cannot set read concern after starting transaction
-OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Cannot set write concern after starting transaction
 ===DONE===

--- a/tests/session/transaction-integration_error-003.phpt
+++ b/tests/session/transaction-integration_error-003.phpt
@@ -1,5 +1,5 @@
 --TEST--
-MongoDB\Driver\Session: Setting per-op readConcern or writeConcern in transaction (executeCommand)
+MongoDB\Driver\Session: Setting per-op writeConcern in transaction (executeWriteCommand)
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_not_libmongoc_crypto(); ?>
@@ -33,22 +33,7 @@ echo throws(function() use ($manager, $session) {
         'update' => COLLECTION_NAME,
         'updates' => [ [ 'q' => [ 'employee' => 3 ], 'u' => [ '$set' => [ 'status' => 'Inactive' ] ] ] ]
     ] );
-    $manager->executeCommand(
-        DATABASE_NAME,
-        $cmd,
-        [
-            'session' => $session,
-            'readConcern' => new \MongoDB\Driver\ReadConcern( \MongoDB\Driver\ReadConcern::LOCAL )
-        ]
-    );
-}, "MongoDB\Driver\Exception\InvalidArgumentException"), "\n";
-
-echo throws(function() use ($manager, $session) {
-    $cmd = new \MongoDB\Driver\Command( [
-        'update' => COLLECTION_NAME,
-        'updates' => [ [ 'q' => [ 'employee' => 3 ], 'u' => [ '$set' => [ 'status' => 'Inactive' ] ] ] ]
-    ] );
-    $manager->executeCommand(
+    $manager->executeWriteCommand(
         DATABASE_NAME,
         $cmd,
         [
@@ -62,8 +47,6 @@ echo throws(function() use ($manager, $session) {
 ===DONE===
 <?php exit(0); ?>
 --EXPECT--
-OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Cannot set read concern after starting transaction
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Cannot set write concern after starting transaction
 ===DONE===

--- a/tests/session/transaction-integration_error-004.phpt
+++ b/tests/session/transaction-integration_error-004.phpt
@@ -1,5 +1,5 @@
 --TEST--
-MongoDB\Driver\Session: Setting per-op readConcern or writeConcern in transaction (executeCommand)
+MongoDB\Driver\Session: Setting per-op readConcern or writeConcern in transaction (executeReadWriteCommand)
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_not_libmongoc_crypto(); ?>
@@ -30,10 +30,10 @@ $session->startTransaction( [
 
 echo throws(function() use ($manager, $session) {
     $cmd = new \MongoDB\Driver\Command( [
-        'update' => COLLECTION_NAME,
-        'updates' => [ [ 'q' => [ 'employee' => 3 ], 'u' => [ '$set' => [ 'status' => 'Inactive' ] ] ] ]
+        'count' => COLLECTION_NAME,
+        'query' => [ 'q' => [ 'employee' => 3 ] ]
     ] );
-    $manager->executeCommand(
+    $manager->executeReadWriteCommand(
         DATABASE_NAME,
         $cmd,
         [
@@ -48,7 +48,7 @@ echo throws(function() use ($manager, $session) {
         'update' => COLLECTION_NAME,
         'updates' => [ [ 'q' => [ 'employee' => 3 ], 'u' => [ '$set' => [ 'status' => 'Inactive' ] ] ] ]
     ] );
-    $manager->executeCommand(
+    $manager->executeReadWriteCommand(
         DATABASE_NAME,
         $cmd,
         [


### PR DESCRIPTION
Added tests for ``executeReadCommand``, ``executeWriteCommand`` and ``executeReadWriteCommand`` too.