### PR TITLE
 PHPC-1179: Reimplement tests that start servers with Mongo Orchestration 

### DIFF
--- a/tests/cursor/cursor-getmore-005.phpt
+++ b/tests/cursor/cursor-getmore-005.phpt
@@ -1,15 +1,20 @@
 --TEST--
 MongoDB\Driver\Cursor query result iteration with getmore failure
---XFAIL--
-START() tests must be reimplemented (PHPC-1179)
 --SKIPIF--
 <?php require __DIR__ . "/" ."../utils/basic-skipif.inc"; ?>
-<?php START("THROWAWAY", ["version" => "30-release"]); CLEANUP(THROWAWAY); ?>
+<?php
+/* This test spins up its own mongod instance, so only run this in the most default "standalone, no
+ * auth" configurations. This way, we can test on multiple server versions, but not waste resources
+ * on f.e. Travis. */
+?>
+<?php skip_if_not_standalone(); ?>
+<?php skip_if_auth(); ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";
 
-$manager = new MongoDB\Driver\Manager(THROWAWAY);
+$uri = createTemporaryMongoInstance();
+$manager = new MongoDB\Driver\Manager($uri);
 
 $bulkWrite = new MongoDB\Driver\BulkWrite;
 
@@ -30,14 +35,13 @@ throws(function() use ($cursor) {
         printf("%d => {_id: %d}\n", $i, $document->_id);
     }
 }, "MongoDB\Driver\Exception\ConnectionException");
-
 ?>
 ===DONE===
-<?php DELETE("THROWAWAY"); ?>
+<?php destroyTemporaryMongoInstance(); ?>
 <?php exit(0); ?>
 --CLEAN--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
-<?php DELETE("THROWAWAY"); ?>
+<?php destroyTemporaryMongoInstance(); ?>
 --EXPECT--
 Inserted: 5
 0 => {_id: 0}

--- a/tests/cursor/cursor-getmore-005.phpt
+++ b/tests/cursor/cursor-getmore-005.phpt
@@ -7,7 +7,9 @@ MongoDB\Driver\Cursor query result iteration with getmore failure
  * auth" configurations. This way, we can test on multiple server versions, but not waste resources
  * on f.e. Travis. */
 ?>
+<?php skip_if_not_live(); ?>
 <?php skip_if_not_standalone(); ?>
+<?php skip_if_no_getmore_failpoint(); ?>
 <?php skip_if_auth(); ?>
 --FILE--
 <?php

--- a/tests/cursor/cursor-getmore-006.phpt
+++ b/tests/cursor/cursor-getmore-006.phpt
@@ -9,6 +9,7 @@ MongoDB\Driver\Cursor command result iteration with getmore failure
 ?>
 <?php skip_if_not_live(); ?>
 <?php skip_if_not_standalone(); ?>
+<?php skip_if_server_version(">=", "3.6"); ?>
 <?php skip_if_no_getmore_failpoint(); ?>
 <?php skip_if_auth(); ?>
 --FILE--

--- a/tests/cursor/cursor-getmore-006.phpt
+++ b/tests/cursor/cursor-getmore-006.phpt
@@ -7,7 +7,9 @@ MongoDB\Driver\Cursor command result iteration with getmore failure
  * auth" configurations. This way, we can test on multiple server versions, but not waste resources
  * on f.e. Travis. */
 ?>
+<?php skip_if_not_live(); ?>
 <?php skip_if_not_standalone(); ?>
+<?php skip_if_no_getmore_failpoint(); ?>
 <?php skip_if_auth(); ?>
 --FILE--
 <?php

--- a/tests/cursor/cursor-getmore-006.phpt
+++ b/tests/cursor/cursor-getmore-006.phpt
@@ -1,15 +1,20 @@
 --TEST--
 MongoDB\Driver\Cursor command result iteration with getmore failure
---XFAIL--
-START() tests must be reimplemented (PHPC-1179)
 --SKIPIF--
 <?php require __DIR__ . "/" ."../utils/basic-skipif.inc"; ?>
-<?php START("THROWAWAY", ["version" => "30-release"]); CLEANUP(THROWAWAY); ?>
+<?php
+/* This test spins up its own mongod instance, so only run this in the most default "standalone, no
+ * auth" configurations. This way, we can test on multiple server versions, but not waste resources
+ * on f.e. Travis. */
+?>
+<?php skip_if_not_standalone(); ?>
+<?php skip_if_auth(); ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";
 
-$manager = new MongoDB\Driver\Manager(THROWAWAY);
+$uri = createTemporaryMongoInstance();
+$manager = new MongoDB\Driver\Manager($uri);
 
 $bulkWrite = new MongoDB\Driver\BulkWrite;
 
@@ -40,11 +45,11 @@ throws(function() use ($cursor) {
 
 ?>
 ===DONE===
-<?php DELETE("THROWAWAY"); ?>
+<?php destroyTemporaryMongoInstance(); ?>
 <?php exit(0); ?>
 --CLEAN--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
-<?php DELETE("THROWAWAY"); ?>
+<?php destroyTemporaryMongoInstance(); ?>
 --EXPECT--
 Inserted: 5
 0 => {_id: 0}

--- a/tests/cursor/cursor-getmore-007.phpt
+++ b/tests/cursor/cursor-getmore-007.phpt
@@ -9,7 +9,7 @@ MongoDB\Driver\Cursor query result iteration with getmore failure
 ?>
 <?php skip_if_not_live(); ?>
 <?php skip_if_not_standalone(); ?>
-<?php skip_if_server_version(">=", "3.6"); ?>
+<?php skip_if_server_version("<", "3.6"); ?>
 <?php skip_if_no_getmore_failpoint(); ?>
 <?php skip_if_auth(); ?>
 --FILE--
@@ -37,7 +37,7 @@ throws(function() use ($cursor) {
     foreach ($cursor as $i => $document) {
         printf("%d => {_id: %d}\n", $i, $document->_id);
     }
-}, "MongoDB\Driver\Exception\ConnectionException");
+}, "MongoDB\Driver\Exception\ServerException");
 ?>
 ===DONE===
 <?php destroyTemporaryMongoInstance(); ?>
@@ -49,5 +49,5 @@ throws(function() use ($cursor) {
 Inserted: 5
 0 => {_id: 0}
 1 => {_id: 1}
-OK: Got MongoDB\Driver\Exception\ConnectionException
+OK: Got MongoDB\Driver\Exception\ServerException
 ===DONE===

--- a/tests/utils/basic.inc
+++ b/tests/utils/basic.inc
@@ -3,6 +3,7 @@
 require_once __DIR__ . "/" . "tools.php";
 
 define('URI', getenv('MONGODB_URI') ?: 'mongodb://127.0.0.1/');
+define('MONGO_ORCHESTRATION_URI', getenv('MONGO_ORCHESTRATION_URI') ?: 'http://localhost:8889/v1');
 define('DATABASE_NAME', getenv('MONGODB_DATABASE') ?: 'phongo');
 define('COLLECTION_NAME', makeCollectionNameFromFilename($_SERVER['SCRIPT_FILENAME']));
 define('NS', DATABASE_NAME . '.' . COLLECTION_NAME);

--- a/tests/utils/skipif.php
+++ b/tests/utils/skipif.php
@@ -226,3 +226,15 @@ function skip_if_not_clean($databaseName = DATABASE_NAME, $collectionName = COLL
         exit("skip Could not drop '$databaseName.$collectionName': " . $e->getMessage());
     }
 }
+
+function skip_if_no_getmore_failpoint()
+{
+    $serverVersion = get_server_version(URI);
+
+    if (
+        version_compare($serverVersion, '3.2', '>=') &&
+        version_compare($serverVersion, '4.0', '<')
+    ) {
+        exit("skip Server version '$serverVersion' does not support a getMore failpoint'");
+    }
+}

--- a/tests/utils/tools.php
+++ b/tests/utils/tools.php
@@ -148,6 +148,21 @@ function get_server_storage_engine($uri)
 }
 
 /**
+ * Helper to return the version of a specific server.
+ *
+ * @param MongoDB\Driver\Server $server
+ * @return string
+ * @throws RuntimeException
+ */
+function get_server_version_from_server(MongoDB\Driver\Server $server)
+{
+    $command = new Command(['buildInfo' => 1]);
+    $cursor = $server->executeCommand('admin', $command);
+
+    return current($cursor->toArray())->version;
+}
+
+/**
  * Returns the version of the primary server.
  *
  * @param string $uri Connection string
@@ -157,10 +172,7 @@ function get_server_storage_engine($uri)
 function get_server_version($uri)
 {
     $server = get_primary_server($uri);
-    $command = new Command(['buildInfo' => 1]);
-    $cursor = $server->executeCommand('admin', $command);
-
-    return current($cursor->toArray())->version;
+    return get_server_version_from_server($server);
 }
 
 /**
@@ -441,11 +453,19 @@ function loadFixtures(\MongoDB\Driver\Manager $manager, $dbname = DATABASE_NAME,
     }
 }
 
-function START($id, array $options = array()) {
-    /* starting/stopping servers only works using the Vagrant setup */
-    PREDICTABLE();
-
-    $options += array("name" => "mongod", "id" => $id);
+function createTemporaryMongoInstance(array $options = [])
+{
+    $id = 'mo_' . COLLECTION_NAME;
+    $options += [
+        "name" => "mongod",
+        "id" => $id,
+        'procParams' => [
+            'dbpath' => "/tmp/phongo/{$id}",
+            'logpath' => "/tmp/phongo/{$id}.log",
+            'ipv6' => true,
+            'setParameter' => [ 'enableTestCommands' => 1 ],
+        ],
+    ];
     $opts = array(
         "http" => array(
             "timeout" => 60,
@@ -457,24 +477,24 @@ function START($id, array $options = array()) {
         ),
     );
     $ctx = stream_context_create($opts);
-    $json = file_get_contents(getMOUri() . "/servers/$id", false, $ctx);
+    $json = file_get_contents(MONGO_ORCHESTRATION_URI . "/servers/$id", false, $ctx);
     $result = json_decode($json, true);
 
     /* Failed -- or was already started */
     if (!isset($result["mongodb_uri"])) {
-        DELETE($id);
-        define($id, false);
+        destroyTemporaryMongoInstance($id);
+        throw new Exception("Could not start temporary server instance\n");
     } else {
-        define($id, $result["mongodb_uri"]);
-        $FILENAME = sys_get_temp_dir() . "/PHONGO-SERVERS.json";
-
-        $json = file_get_contents($FILENAME);
-        $config = json_decode($json, true);
-        $config[$id] = constant($id);
-        file_put_contents($FILENAME, json_encode($config, JSON_PRETTY_PRINT));
+        return $result['mongodb_uri'];
     }
 }
-function DELETE($id) {
+
+function destroyTemporaryMongoInstance($id = NULL)
+{
+    if ($id == NULL) {
+        $id = 'mo_' . COLLECTION_NAME;
+    }
+
     $opts = array(
         "http" => array(
             "timeout" => 60,
@@ -484,14 +504,9 @@ function DELETE($id) {
         ),
     );
     $ctx = stream_context_create($opts);
-    $json = file_get_contents(getMOUri() . "/servers/$id", false, $ctx);
-        $FILENAME = sys_get_temp_dir() . "/PHONGO-SERVERS.json";
-
-        $json = file_get_contents($FILENAME);
-        $config = json_decode($json, true);
-        unset($config[$id]);
-        file_put_contents($FILENAME, json_encode($config, JSON_PRETTY_PRINT));
+    $json = file_get_contents(MONGO_ORCHESTRATION_URI . "/servers/$id", false, $ctx);
 }
+
 function severityToString($type) {
     switch($type) {
     case E_WARNING:
@@ -629,41 +644,23 @@ function def($arr) {
     }
 }
 
-function configureFailPoint(MongoDB\Driver\Manager $manager, $failPoint, $mode, $data = array()) {
-
+function configureFailPoint(MongoDB\Driver\Manager $manager, $failPoint, $mode, array $data = [])
+{
     $doc = array(
-        "configureFailPoint" => $failPoint,
-        "mode"               => $mode,
+        'configureFailPoint' => $failPoint,
+        'mode'               => $mode,
     );
     if ($data) {
-        $doc["data"] = $data;
+        $doc['data'] = $data;
     }
 
     $cmd = new MongoDB\Driver\Command($doc);
-    $result = $manager->executeCommand("admin", $cmd);
-    $arr = current($result->toArray());
-    if (empty($arr->ok)) {
-        var_dump($result);
-        throw new RuntimeException("Failpoint failed");
-    }
-    return true;
+    $manager->executeCommand('admin', $cmd);
 }
 
-function failMaxTimeMS(MongoDB\Driver\Manager $manager) {
-    return configureFailPoint($manager, "maxTimeAlwaysTimeOut", array("times" => 1));
-}
-
-function getMOUri() {
-    if (!($HOST = getenv("MONGODB_ORCHESTRATION_HOST"))) {
-        $HOST = "192.168.112.10";
-    }
-
-    if (!($PORT = getenv("MONGODB_ORCHESTRATION_PORT"))) {
-        $PORT = "8889";
-    }
-    $MO = "http://$HOST:$PORT/v1";
-
-    return $MO;
+function failMaxTimeMS(MongoDB\Driver\Manager $manager)
+{
+    configureFailPoint($manager, 'maxTimeAlwaysTimeOut', [ 'times' => 1 ]);
 }
 
 function getMOPresetBase() {
@@ -695,6 +692,26 @@ function fromJSON($var) {
 
 /* Note: this fail point may terminate the mongod process, so you may want to
  * use this in conjunction with a throwaway server. */
-function failGetMore(MongoDB\Driver\Manager $manager) {
-    return configureFailPoint($manager, "failReceivedGetmore", "alwaysOn");
+function failGetMore(MongoDB\Driver\Manager $manager)
+{
+    /* We need to do version detection here */
+    $primary = $manager->selectServer(new ReadPreference('primary'));
+    $version = get_server_version_from_server($primary);
+
+    if (version_compare($version, "3.2", "<")) {
+        configureFailPoint($manager, 'failReceivedGetmore', 'alwaysOn');
+        return;
+    }
+
+    if (version_compare($version, "4.0", ">=")) {
+        /* We use 237 here, as that's the same original code that MongoD would
+         * throw if a cursor had already gone by the time we call getMore. This
+         * allows us to make things consistent with the getMore OP behaviour
+         * from previous mongod versions. An errorCode is required here for the
+         * failPoint to work. */
+        configureFailPoint($manager, 'failCommand', 'alwaysOn', [ 'errorCode' => 237, 'failCommands' => ['getMore'] ]);
+        return;
+    }
+
+    throw new Exception("Trying to configure a getMore fail point for a server version ($version) that doesn't support it");
 }


### PR DESCRIPTION
These tests could not have worked since we moved from a Wire Protocol getMore OP to the OP_COMMAND style of calling ``getMore``. Beats me how we didn't manage to detect this.

The second commit isn't strictly necessary, but it updates the code to be able to throw a ``ConnectionException`` if getMore fails.

Previously, the ``getMore`` tests use a failPoint for the getMore OP, where the driver would then (through ``libmongoc``) throw a ``ConnectionException``.  With the shift to the command-based failPoint, ``libmongoc``/the driver now converted that to a ``ServerException``. This second commit restores that behaviour. Alternatively, we can just update the test to check for a ``ServerException`` instead.