### PR TITLE
PHPC-1225: Add test to catch unsupported server wire protocol versions

### DIFF
--- a/php_phongo.c
+++ b/php_phongo.c
@@ -166,6 +166,10 @@ zend_class_entry* phongo_exception_from_mongoc_domain(uint32_t /* mongoc_error_d
 		return php_phongo_serverexception_ce;
 	}
 
+	if (domain == MONGOC_ERROR_PROTOCOL && code == MONGOC_ERROR_PROTOCOL_BAD_WIRE_VERSION) {
+		return php_phongo_connectionexception_ce;
+	}
+
 	return php_phongo_runtimeexception_ce;
 }
 void phongo_throw_exception(php_phongo_error_domain_t domain TSRMLS_DC, const char* format, ...)

--- a/tests/manager/manager-ctor-wireversion.phpt
+++ b/tests/manager/manager-ctor-wireversion.phpt
@@ -1,0 +1,20 @@
+--TEST--
+MongoDB\Driver\Manager::__construct(): wire version support
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new \MongoDB\Driver\Manager(URI);
+
+$command = new MongoDB\Driver\Command(['ping' => 1]);
+try {
+    $manager->executeCommand("test", $command);
+} catch (\MongoDB\Driver\Exception\ConnectionException $e) {
+    if ($e->getCode() == 15) { // Bad Wire Version
+        echo "Bad wire version detected: ", $e->getMessage(), "\n";
+    }
+}
+?>
+===DONE===
+--EXPECT--
+===DONE===


### PR DESCRIPTION
I'm also converting this error to a ConnectionException instead of a RuntimeException