### PR TITLE
PHPC-1266: Empty deeply nested BSON document causes unallocated memory writes

### DIFF
--- a/src/bson.c
+++ b/src/bson.c
@@ -161,6 +161,8 @@ bool php_phongo_field_path_push(php_phongo_field_path* field_path, const char* e
 
 bool php_phongo_field_path_pop(php_phongo_field_path* field_path)
 {
+	php_phongo_field_path_ensure_allocation(field_path, field_path->size);
+
 	field_path->elements[field_path->size]      = NULL;
 	field_path->element_types[field_path->size] = PHONGO_FIELD_PATH_ITEM_NONE;
 

--- a/tests/bson/bug1266.phpt
+++ b/tests/bson/bug1266.phpt
@@ -1,0 +1,58 @@
+--TEST--
+Test for PHPC-1266: Empty deeply nested BSON document causes unallocated memory writes
+--FILE--
+<?php
+$a = <<<ENDJSON
+{
+    "value" : {     
+        "payload" : {
+            "PayloadMasterDataMeteringPointPartyEvent" : {
+                "MeteringPointPartyDetailMeteringPointPartyCharacteristic" : {
+                    "AdministrativePartyMPAdministrativeParty" : [
+                        {
+                            "AdministrativePartyAddressLocationAddress" : {
+                                "StreetCode" : {
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}   
+ENDJSON;
+
+$bson = MongoDB\BSON\fromJSON($a);
+var_dump(MongoDB\BSON\toPHP($bson));
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+object(stdClass)#%d (%d) {
+  ["value"]=>
+  object(stdClass)#%d (%d) {
+    ["payload"]=>
+    object(stdClass)#%d (%d) {
+      ["PayloadMasterDataMeteringPointPartyEvent"]=>
+      object(stdClass)#%d (%d) {
+        ["MeteringPointPartyDetailMeteringPointPartyCharacteristic"]=>
+        object(stdClass)#%d (%d) {
+          ["AdministrativePartyMPAdministrativeParty"]=>
+          array(%d) {
+            [0]=>
+            object(stdClass)#%d (%d) {
+              ["AdministrativePartyAddressLocationAddress"]=>
+              object(stdClass)#%d (%d) {
+                ["StreetCode"]=>
+                object(stdClass)#%d (%d) {
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1266