### PR TITLE
Fix port via parse_url() when default URI is used

### DIFF
--- a/tests/server/server-construct-001.phpt
+++ b/tests/server/server-construct-001.phpt
@@ -18,8 +18,11 @@ $bulk = new \MongoDB\Driver\BulkWrite();
 $bulk->insert(array('foo' => 'bar'));
 $server = $manager->executeBulkWrite(NS, $bulk)->getServer();
 
-var_dump($server->getHost() == $parsed["host"]);
-var_dump($server->getPort() == $parsed["port"]);
+$expectedHost = $parsed['host'];
+$expectedPort = (integer) (isset($parsed['port']) ? $parsed['port'] : 27017);
+
+var_dump($server->getHost() == $expectedHost);
+var_dump($server->getPort() == $expectedPort);
 ?>
 ===DONE===
 <?php exit(0); ?>


### PR DESCRIPTION
The default URI is "mongodb://127.0.0.1/" and does not include a port. Since parse_url() will not yield a "port" index in that case we should fill in the default (i.e. 27017).

This is related to dd5e9e9b734059d756d1c8089bb94b8eb09f9161 (https://github.com/mongodb/mongo-php-driver/pull/907).