### PR TITLE
PHPC-1180: Ensure STANDALONE_SSL tests run

### DIFF
--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -16,7 +16,7 @@ OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 
 export REPORT_EXIT_STATUS=1
 
-if [ "$SSL" == "yes" ]; then
+if [ "$SSL" = "yes" ]; then
    MONGODB_URI="${MONGODB_URI}/?ssl=true"
 fi
 

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -17,7 +17,7 @@ OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 export REPORT_EXIT_STATUS=1
 
 if [ "$SSL" = "yes" ]; then
-   MONGODB_URI="${MONGODB_URI}/?ssl=true"
+   MONGODB_URI="${MONGODB_URI}/?ssl=true&sslallowinvalidcertificates=true"
 fi
 
 echo "Running $AUTH tests, connecting to $MONGODB_URI"

--- a/.travis.scripts/setup_mo.sh
+++ b/.travis.scripts/setup_mo.sh
@@ -25,7 +25,7 @@ case $DEPLOYMENT in
     ;;
   STANDALONE_SSL)
     ${TRAVIS_BUILD_DIR}/.travis.scripts/mo.sh ${TRAVIS_BUILD_DIR}/scripts/presets/travis/standalone/standalone-ssl.json start > /tmp/mo-result.json
-    cat /tmp/mo-result.json | tail -n 1 | php -r 'echo json_decode(file_get_contents("php://stdin"))->mongodb_uri, "/?ssl=true";' > /tmp/uri.txt
+    cat /tmp/mo-result.json | tail -n 1 | php -r 'echo json_decode(file_get_contents("php://stdin"))->mongodb_uri, "/?ssl=true&sslallowinvalidcertificates=true";' > /tmp/uri.txt
     ;;
   REPLICASET)
     ${TRAVIS_BUILD_DIR}/.travis.scripts/mo.sh ${TRAVIS_BUILD_DIR}/scripts/presets/travis/replica_sets/replicaset.json start > /tmp/mo-result.json

--- a/tests/manager/manager-ctor-wireversion.phpt
+++ b/tests/manager/manager-ctor-wireversion.phpt
@@ -10,7 +10,7 @@ $command = new MongoDB\Driver\Command(['ping' => 1]);
 try {
     $manager->executeCommand("test", $command);
 } catch (\MongoDB\Driver\Exception\ConnectionException $e) {
-    if ($e->getCode() == 15) { // Bad Wire Version
+    if ($e->getCode() == 15) { // MONGOC_ERROR_PROTOCOL_BAD_WIRE_VERSION
         echo "Bad wire version detected: ", $e->getMessage(), "\n";
     }
 }


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1180

Cert validation failures were causing these tests to be skipped. This restores weak cert validation to allow those tests to run. This does not appear to conflict with the few tests we have that utilize strict validation (see: [this JIRA comment](https://jira.mongodb.org/browse/PHPC-1180?focusedCommentId=1992393&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1992393)), since those tests override the URI option we're specifying here.

Ultimately, we'll address the problem with not catching skipped tests in [PHPC-1343](https://jira.mongodb.org/browse/PHPC-1343).

