### PR TITLE
PHPC-1370: Relax assertion for unknown modifier error

### DIFF
--- a/tests/manager/manager-executeBulkWrite_error-006.phpt
+++ b/tests/manager/manager-executeBulkWrite_error-006.phpt
@@ -30,7 +30,7 @@ try {
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-BulkWriteException: Unknown modifier: $foo
+BulkWriteException: Unknown modifier: $foo%S
 
 ===> WriteResult
 server: %s:%d
@@ -41,7 +41,7 @@ upsertedCount: 0
 deletedCount: 0
 object(MongoDB\Driver\WriteError)#%d (%d) {
   ["message"]=>
-  string(22) "Unknown modifier: $foo"
+  string(%d) "Unknown modifier: $foo%S"
   ["code"]=>
   int(9)
   ["index"]=>
@@ -49,6 +49,6 @@ object(MongoDB\Driver\WriteError)#%d (%d) {
   ["info"]=>
   NULL
 }
-writeError[0].message: Unknown modifier: $foo
+writeError[0].message: Unknown modifier: $foo%S
 writeError[0].code: 9
 ===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1370

Allow an optional suffix since MongoDB 4.1.x uses a more verbose error message.