### PR TITLE
Temporarily disable ARM64 hosts in Evergreen

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -638,9 +638,10 @@ axes:
       - id: rhel74-zseries
         display_name: "RHEL 7.4 zSeries"
         run_on: rhel72-zseries-test
-      - id: ubuntu1604-arm64
-        display_name: "Ubuntu 16.04 ARM64"
-        run_on: ubuntu1604-arm64-large
+      # Pending re-installation of PHP toolchain on ARM64 (see: BUILD-8395)
+      #- id: ubuntu1604-arm64
+      #  display_name: "Ubuntu 16.04 ARM64"
+      #  run_on: ubuntu1604-arm64-large
       # Pending installation of PHP toolchain on macOS hosts (see: PHPC-869)
       # - id: macos-1014
       #   display_name: "Mac OS 10.14"


### PR DESCRIPTION
ARM64 hosts currently do not have the PHP toolchain installed. This can be reverted once the toolchain is restored (see: [PHPC-1372](https://jira.mongodb.org/browse/PHPC-1372)).