### PR TITLE
PHPC-1387: Consider error document for cursor exceptions

### DIFF
--- a/php_phongo.c
+++ b/php_phongo.c
@@ -190,7 +190,7 @@ void phongo_throw_exception_from_bson_error_t(bson_error_t* error TSRMLS_DC)
 	zend_throw_exception(phongo_exception_from_mongoc_domain(error->domain, error->code), error->message, error->code TSRMLS_CC);
 }
 
-void phongo_throw_exception_from_bson_error_and_reply_t(bson_error_t* error, bson_t* reply TSRMLS_DC)
+void phongo_throw_exception_from_bson_error_t_and_reply(bson_error_t* error, bson_t* reply TSRMLS_DC)
 {
 	/* Server errors (other than ExceededTimeLimit) and write concern errors
 	 * may use CommandException and report the result document for the
@@ -966,7 +966,7 @@ bool phongo_execute_command(mongoc_client_t* client, php_phongo_command_type_t t
 	free_reply = true;
 
 	if (!result) {
-		phongo_throw_exception_from_bson_error_and_reply_t(&error, &reply TSRMLS_CC);
+		phongo_throw_exception_from_bson_error_t_and_reply(&error, &reply TSRMLS_CC);
 		goto cleanup;
 	}
 

--- a/php_phongo.h
+++ b/php_phongo.h
@@ -111,7 +111,7 @@ void              phongo_throw_exception(php_phongo_error_domain_t domain TSRMLS
 #endif /* PHP_VERSION_ID < 70000 */
 	;
 void phongo_throw_exception_from_bson_error_t(bson_error_t* error TSRMLS_DC);
-void phongo_throw_exception_from_bson_error_t_and_reply(bson_error_t* error, bson_t* reply TSRMLS_DC);
+void phongo_throw_exception_from_bson_error_t_and_reply(bson_error_t* error, const bson_t* reply TSRMLS_DC);
 
 /* This enum is used for processing options in phongo_execute_parse_options and
  * selecting a libmongoc function to use in phongo_execute_command. The values

--- a/php_phongo.h
+++ b/php_phongo.h
@@ -111,7 +111,7 @@ void              phongo_throw_exception(php_phongo_error_domain_t domain TSRMLS
 #endif /* PHP_VERSION_ID < 70000 */
 	;
 void phongo_throw_exception_from_bson_error_t(bson_error_t* error TSRMLS_DC);
-void phongo_throw_exception_from_bson_error_and_reply_t(bson_error_t* error, bson_t* reply TSRMLS_DC);
+void phongo_throw_exception_from_bson_error_t_and_reply(bson_error_t* error, bson_t* reply TSRMLS_DC);
 
 /* This enum is used for processing options in phongo_execute_parse_options and
  * selecting a libmongoc function to use in phongo_execute_command. The values

--- a/src/MongoDB/Session.c
+++ b/src/MongoDB/Session.c
@@ -361,7 +361,7 @@ static PHP_METHOD(Session, commitTransaction)
 	}
 
 	if (!mongoc_client_session_commit_transaction(intern->client_session, &reply, &error)) {
-		phongo_throw_exception_from_bson_error_and_reply_t(&error, &reply TSRMLS_CC);
+		phongo_throw_exception_from_bson_error_t_and_reply(&error, &reply TSRMLS_CC);
 		bson_destroy(&reply);
 	}
 } /* }}} */

--- a/tests/manager/manager-executeQuery_error-003.phpt
+++ b/tests/manager/manager-executeQuery_error-003.phpt
@@ -1,0 +1,30 @@
+--TEST--
+MongoDB\Driver\Manager::executeQuery() exposes error document via CommandException
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_not_live(); ?>
+<?php skip_if_server_version('<', '3.2'); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(URI);
+$query = new MongoDB\Driver\Query(['$foo' => 1]);
+
+try {
+    $manager->executeQuery(NS, $query);
+} catch (\MongoDB\Driver\Exception\CommandException $e) {
+    printf("%s(%d): %s\n", get_class($e), $e->getCode(), $e->getMessage());
+    $doc = $e->getResultDocument();
+    var_dump($doc->errmsg === $e->getMessage());
+    var_dump($doc->code === $e->getCode());
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+MongoDB\Driver\Exception\CommandException(2): unknown top level operator: $foo
+bool(true)
+bool(true)
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1387

This allows executeQuery() to throw a CommandException, which exposes the error document.

In 1.6+, it will also ensure that error labels are set on any RuntimeException thrown during cursor iteration, which is relevant for transactions.