### PR TITLE
[WIP] Test PHP 7.3 on Evergreen and AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,23 +13,33 @@ environment:
   SDK_BRANCH: php-sdk-2.1.1
 
   matrix:
-    - PHP_REL: 7.2
+    - PHP_REL: 7.3
       ARCHITECTURE: x64
       ZTS_STATE: enable
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       PHP_BUILD_CRT: vc15
-    - PHP_REL: 7.2
+    - PHP_REL: 7.3
       ARCHITECTURE: x64
       ZTS_STATE: disable
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       PHP_BUILD_CRT: vc15
-    - PHP_REL: 7.2
+    - PHP_REL: 7.3
       ARCHITECTURE: x86
       ZTS_STATE: enable
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       PHP_BUILD_CRT: vc15
-    - PHP_REL: 7.2
+    - PHP_REL: 7.3
       ARCHITECTURE: x86
+      ZTS_STATE: disable
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      PHP_BUILD_CRT: vc15
+    - PHP_REL: 7.2
+      ARCHITECTURE: x64
+      ZTS_STATE: enable
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      PHP_BUILD_CRT: vc15
+    - PHP_REL: 7.2
+      ARCHITECTURE: x64
       ZTS_STATE: disable
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       PHP_BUILD_CRT: vc15

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -594,6 +594,10 @@ axes:
   - id: php-versions
     display_name: PHP Version
     values:
+      - id: "7.3"
+        display_name: "PHP 7.3"
+        variables:
+          PHP_VERSION: "7.3.7"
       - id: "7.2"
         display_name: "PHP 7.2"
         variables:
@@ -674,7 +678,7 @@ buildvariants:
      - name: "test-replicaset-auth"
 
 - matrix_name: "tests-php7"
-  matrix_spec: {"os-php7": "*", "versions": "4.2", "php-versions": ["7.0","7.1","7.2"] }
+  matrix_spec: {"os-php7": "*", "versions": "4.2", "php-versions": ["7.0","7.1","7.2","7.3"] }
   display_name: "All: ${versions}/${php-versions} — ${os-php7}"
   tasks:
      - name: "test-standalone-ssl"
@@ -690,9 +694,9 @@ buildvariants:
      - name: "test-replicaset-old"
 
 - matrix_name: "mongo-30-php7"
-  matrix_spec: {"os-php7": "*", "versions": ["3.0", "3.2", "3.4"], "php-versions": "7.2" }
-  # Pending PHPC-1372, restore exclude_spec: {"os-php7": "ubuntu1604-arm64", "versions": ["3.0", "3.2"], "php-versions": "7.2"}
-  exclude_spec: [ {"os-php7": "rhel71-power8", "versions": "3.0", "php-versions": "7.2"}, {"os-php7": "rhel74-zseries", "versions": ["3.0", "3.2"], "php-versions": "7.2"} ]
+  matrix_spec: {"os-php7": "*", "versions": ["3.0", "3.2", "3.4"], "php-versions": "7.3" }
+  # Pending PHPC-1372, restore exclude_spec: {"os-php7": "ubuntu1604-arm64", "versions": ["3.0", "3.2"], "php-versions": "7.3"}
+  exclude_spec: [ {"os-php7": "rhel71-power8", "versions": "3.0", "php-versions": "7.3"}, {"os-php7": "rhel74-zseries", "versions": ["3.0", "3.2"], "php-versions": "7.3"} ]
   display_name: "${versions}/${php-versions} — ${os-php7}"
   tasks:
      - name: "test-standalone-old"
@@ -708,7 +712,7 @@ buildvariants:
      - name: "test-replicaset-auth"
 
 - matrix_name: "mongo-36-php7"
-  matrix_spec: {"os-php7": "*", "versions": ["3.6"], "php-versions": "7.2" }
+  matrix_spec: {"os-php7": "*", "versions": ["3.6"], "php-versions": "7.3" }
   display_name: "${versions}/${php-versions} — ${os-php7}"
   tasks:
      - name: "test-standalone"
@@ -730,9 +734,9 @@ buildvariants:
      - name: "test-sharded-rs"
 
 - matrix_name: "mongo-40-php7"
-  matrix_spec: {"os-php7": "*", "versions": ["4.0", "4.2", "latest"], "php-versions": "7.2" }
+  matrix_spec: {"os-php7": "*", "versions": ["4.0", "4.2", "latest"], "php-versions": "7.3" }
   exclude_spec:
-     - {"os-php7": "rhel74-zseries", "versions": ["4.0", "4.2", "latest"], "php-versions": "7.2"}
+     - {"os-php7": "rhel74-zseries", "versions": ["4.0", "4.2", "latest"], "php-versions": "7.3"}
   display_name: "${versions}/${php-versions} — ${os-php7}"
   tasks:
      - name: "test-standalone"
@@ -745,7 +749,7 @@ buildvariants:
      - name: "test-sharded-rs"
 
 - matrix_name: "mongo-40-php7-nossl"
-  matrix_spec: {"os-php7": "rhel74-zseries", "versions": ["4.0", "4.2", "latest"], "php-versions": "7.2"}
+  matrix_spec: {"os-php7": "rhel74-zseries", "versions": ["4.0", "4.2", "latest"], "php-versions": "7.3"}
   display_name: "${versions}/${php-versions} — ${os-php7}"
   tasks:
      - name: "test-standalone"
@@ -757,13 +761,13 @@ buildvariants:
      - name: "test-sharded-rs"
 
 - matrix_name: "mongo-42-storage-engines"
-  matrix_spec: {"os-php7": "debian92-test", "versions": "4.2", "php-versions": "7.2", "storage-engine": ["wiredtiger", "inmemory"]}
+  matrix_spec: {"os-php7": "debian92-test", "versions": "4.2", "php-versions": "7.3", "storage-engine": ["wiredtiger", "inmemory"]}
   display_name: "${versions}/${php-versions}/${os-php7} — ${storage-engine}"
   tasks:
      - name: "test-standalone"
 
 - matrix_name: "mongo-40-storage-engines"
-  matrix_spec: {"os-php7": "debian92-test", "versions": "4.0", "php-versions": "7.2", "storage-engine": "mmapv1"}
+  matrix_spec: {"os-php7": "debian92-test", "versions": "4.0", "php-versions": "7.3", "storage-engine": "mmapv1"}
   display_name: "${versions}/${php-versions}/${os-php7} — ${storage-engine}"
   tasks:
      - name: "test-standalone"


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1418
https://jira.mongodb.org/browse/PHPC-1390

Currently investigating whether we already have access to PHP 7.3 on Evergreen or if we need to have the tooling adapted. This also adds AppVeyor builds for PHP 7.3. Depending on the Evergreen build result the latter might be split into a separate pull request to not hold it up.