### PR TITLE
PHPC-1390: Add PHP 7.3 on AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,23 +13,33 @@ environment:
   SDK_BRANCH: php-sdk-2.1.1
 
   matrix:
-    - PHP_REL: 7.2
+    - PHP_REL: 7.3
       ARCHITECTURE: x64
       ZTS_STATE: enable
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       PHP_BUILD_CRT: vc15
-    - PHP_REL: 7.2
+    - PHP_REL: 7.3
       ARCHITECTURE: x64
       ZTS_STATE: disable
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       PHP_BUILD_CRT: vc15
-    - PHP_REL: 7.2
+    - PHP_REL: 7.3
       ARCHITECTURE: x86
       ZTS_STATE: enable
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       PHP_BUILD_CRT: vc15
-    - PHP_REL: 7.2
+    - PHP_REL: 7.3
       ARCHITECTURE: x86
+      ZTS_STATE: disable
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      PHP_BUILD_CRT: vc15
+    - PHP_REL: 7.2
+      ARCHITECTURE: x64
+      ZTS_STATE: enable
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      PHP_BUILD_CRT: vc15
+    - PHP_REL: 7.2
+      ARCHITECTURE: x64
       ZTS_STATE: disable
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       PHP_BUILD_CRT: vc15


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1390

Split off from #1002. Since we only test PHP 7.1 on 64-bit architectures, I've done the same for PHP 7.2. PHP 7.3 is tested on both x64 and x86 architectures.