### PR TITLE
 PHPC-1382: Allow applications to set maxTimeMS for commitTransaction

### DIFF
--- a/tests/session/session-startTransaction_error-002.phpt
+++ b/tests/session/session-startTransaction_error-002.phpt
@@ -13,13 +13,14 @@ $manager = new MongoDB\Driver\Manager(URI);
 $session = $manager->startSession();
 
 $options = [
-    [ 'readConcern' => 42 ], 
+    [ 'maxCommitTimeMS' => -1 ],
+    [ 'readConcern' => 42 ],
     [ 'readConcern' => new stdClass ],
     [ 'readConcern' => new \MongoDB\Driver\WriteConcern( 2 ) ],
-    [ 'readPreference' => 42 ], 
+    [ 'readPreference' => 42 ],
     [ 'readPreference' => new stdClass ],
     [ 'readPreference' => new \MongoDB\Driver\ReadConcern( \MongoDB\Driver\ReadConcern::LOCAL ) ],
-    [ 'writeConcern' => 42 ], 
+    [ 'writeConcern' => 42 ],
     [ 'writeConcern' => new stdClass ],
     [ 'writeConcern' => new \MongoDB\Driver\ReadPreference( \MongoDB\Driver\ReadPreference::RP_SECONDARY ) ],
 
@@ -43,10 +44,16 @@ foreach ($options as $txnOptions) {
     }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 }
 
+echo raises(function() use ($session) {
+    $session->startTransaction([ 'maxCommitTimeMS' => new stdClass ]);
+}, E_NOTICE), "\n";
+
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "maxCommitTimeMS" option to be >= 0, -1 given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected "readConcern" option to be MongoDB\Driver\ReadConcern, int%S given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
@@ -71,4 +78,6 @@ OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected "writeConcern" option to be MongoDB\Driver\WriteConcern, MongoDB\Driver\ReadPreference given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected "writeConcern" option to be MongoDB\Driver\WriteConcern, MongoDB\Driver\ReadPreference given
+OK: Got E_NOTICE
+Object of class stdClass could not be converted to int
 ===DONE===

--- a/tests/session/session_error-001.phpt
+++ b/tests/session/session_error-001.phpt
@@ -7,13 +7,14 @@ require_once __DIR__ . "/../utils/basic.inc";
 $manager = new MongoDB\Driver\Manager();
 
 $options = [
-    [ 'readConcern' => 42 ], 
+    [ 'maxCommitTimeMS' => -1 ],
+    [ 'readConcern' => 42 ],
     [ 'readConcern' => new stdClass ],
     [ 'readConcern' => new \MongoDB\Driver\WriteConcern( 2 ) ],
-    [ 'readPreference' => 42 ], 
+    [ 'readPreference' => 42 ],
     [ 'readPreference' => new stdClass ],
     [ 'readPreference' => new \MongoDB\Driver\ReadConcern( \MongoDB\Driver\ReadConcern::LOCAL ) ],
-    [ 'writeConcern' => 42 ], 
+    [ 'writeConcern' => 42 ],
     [ 'writeConcern' => new stdClass ],
     [ 'writeConcern' => new \MongoDB\Driver\ReadPreference( \MongoDB\Driver\ReadPreference::RP_SECONDARY ) ],
 
@@ -36,16 +37,24 @@ $options = [
 
 foreach ($options as $txnOptions) {
     echo throws(function() use ($manager, $txnOptions) {
-        $session = $manager->startSession([
+        $manager->startSession([
             'defaultTransactionOptions' => $txnOptions
         ]);
     }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 }
 
+echo raises(function() use ($manager) {
+    $manager->startSession([
+        'defaultTransactionOptions' => [ 'maxCommitTimeMS' => new stdClass ]
+    ]);
+}, E_NOTICE), "\n";
+
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "maxCommitTimeMS" option to be >= 0, -1 given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected "readConcern" option to be MongoDB\Driver\ReadConcern, int%S given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
@@ -74,4 +83,6 @@ OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected "defaultTransactionOptions" option to be an array, int%S given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected "defaultTransactionOptions" option to be an array, stdClass given
+OK: Got E_NOTICE
+Object of class stdClass could not be converted to int
 ===DONE===

--- a/tests/utils/tools.php
+++ b/tests/utils/tools.php
@@ -518,6 +518,8 @@ function severityToString($type) {
     switch($type) {
     case E_WARNING:
         return "E_WARNING";
+    case E_NOTICE:
+        return "E_NOTICE";
     default:
         return "Some other #_$type";
     }
@@ -531,6 +533,8 @@ function raises($function, $type, $infunction = null) {
     try {
         $function();
     } catch(Exception $e) {
+        $exceptionname = get_class($e);
+
         if ($e instanceof ErrorException && $e->getSeverity() & $type) {
             if ($infunction) {
                 $trace = $e->getTrace();
@@ -551,7 +555,7 @@ function raises($function, $type, $infunction = null) {
         return $e->getMessage();
     }
 
-    echo "FAILED: Expected $exceptionname thrown!\n";
+    printf("FAILED: Expected %s thrown!\n", ErrorException::class);
     restore_error_handler();
 }
 function throws($function, $exceptionname, $infunction = null) {


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1382

I chose to duplicate the checks in place for the `maxAwaitTimeMS` option on cursors and check for negative and overflowing values, along with a sanity check that the user actually gave us an int for the option.

@jmikola docs are still missing for this PR. While I have my PHP VCS account set up, I'd rather go through the process of writing/publishing docs on php.net with you before adding code there.