### PR TITLE
Test against PHP 7.4 on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,64 +12,95 @@ env:
     - TEST_PHP_ARGS="-q -s output.txt -g XFAIL,FAIL,BORK,WARN,LEAK,SKIP -x --show-diff"
     - REPORT_EXIT_STATUS=1
     - SERVER_DISTRO=ubuntu1604
-    - SERVER_VERSION=4.0.6
+    - SERVER_VERSION=4.2.0
     - DEPLOYMENT=STANDALONE
 
-matrix:
+jobs:
   include:
-    - php: 7.3
+
+    - stage: Smoke Testing
+      php: 7.3
+
+    # Test remaining PHP versions
+    - stage: Test
+      php: 5.6
+    - stage: Test
+      php: 7.0
+    - stage: Test
+      php: 7.1
+    - stage: Test
+      php: 7.2
+    - stage: Test
+      php: 7.4snapshot
+
+    # Test against various server topologies
+    - stage: Test
+      php: 7.3
       env:
         - TESTS=tests/atlas.phpt
         - TEST_PHP_ARGS="-q -s output.txt -x --show-diff"
-    - php: 5.6
-    - php: 7.0
-    - php: 7.1
-    - php: 7.2
-    - php: 7.3
-    - php: 7.3
+    - stage: Test
+      php: 7.3
       env:
         - DEPLOYMENT=STANDALONE_SSL
-    - php: 7.3
+    - stage: Test
+      php: 7.3
       env:
         - DEPLOYMENT=SHARDED_CLUSTER
-    - php: 7.3
+    - stage: Test
+      php: 7.3
       env:
         - DEPLOYMENT=SHARDED_CLUSTER_RS
-    - php: 7.3
+    - stage: Test
+      php: 7.3
       env:
         - DEPLOYMENT=STANDALONE_AUTH
-    - php: 7.3
+    - stage: Test
+      php: 7.3
       env:
         - DEPLOYMENT=REPLICASET
-    - php: 7.3
+    - stage: Test
+      php: 7.3
       env:
         - DEPLOYMENT=REPLICASET_SINGLE
-    - php: 7.3
+    - stage: Test
+      php: 7.3
       env:
         - DEPLOYMENT=REPLICASET_AUTH
-    - php: 7.1
+
+    # Test against older server versions
+    - stage: Test
+      php: 7.1
       dist: trusty
       env:
         - SERVER_DISTRO=ubuntu1404
         - SERVER_VERSION=3.0.15
         - DEPLOYMENT=REPLICASET_OLD
-    - php: 7.1
+    - stage: Test
+      php: 7.1
       dist: trusty
       env:
         - SERVER_DISTRO=ubuntu1404
         - SERVER_VERSION=3.0.15
         - DEPLOYMENT=STANDALONE_OLD
-    - php: 7.1
+    - stage: Test
+      php: 7.3
       env:
         - SERVER_VERSION=3.2.22
         - DEPLOYMENT=STANDALONE_OLD
-    - php: 7.1
+    - stage: Test
+      php: 7.3
       env:
         - SERVER_VERSION=3.4.19
         - DEPLOYMENT=STANDALONE_OLD
-    - php: 7.1
+    - stage: Test
+      php: 7.3
       env:
         - SERVER_VERSION=3.6.10
+    - stage: Test
+      php: 7.1
+      env:
+        - SERVER_VERSION=4.0.12
 
 before_install:
   - openssl aes-256-cbc -K $encrypted_b354efda2943_key -iv $encrypted_b354efda2943_iv -in .travis.scripts/atlas-uris.txt.enc -out .travis.scripts/atlas-uris.txt -d || true

--- a/tests/cursor/cursor-tailable-001.phpt
+++ b/tests/cursor/cursor-tailable-001.phpt
@@ -22,7 +22,7 @@ function insert(MongoDB\Driver\Manager $manager, $from, $to = null)
 
     $writeResult = $manager->executeBulkWrite(NS, $bulkWrite);
 
-    printf("Inserted %d document(s): %s\n", $writeResult->getInsertedCount(), implode(range($from, $to), ', '));
+    printf("Inserted %d document(s): %s\n", $writeResult->getInsertedCount(), implode(', ', range($from, $to)));
 }
 
 $manager = new MongoDB\Driver\Manager(URI);

--- a/tests/cursor/cursor-tailable-002.phpt
+++ b/tests/cursor/cursor-tailable-002.phpt
@@ -23,7 +23,7 @@ function insert(MongoDB\Driver\Manager $manager, $from, $to = null)
 
     $writeResult = $manager->executeBulkWrite(NS, $bulkWrite);
 
-    printf("Inserted %d document(s): %s\n", $writeResult->getInsertedCount(), implode(range($from, $to), ', '));
+    printf("Inserted %d document(s): %s\n", $writeResult->getInsertedCount(), implode(', ', range($from, $to)));
 }
 
 $manager = new MongoDB\Driver\Manager(URI);

--- a/tests/cursor/cursor-tailable_error-001.phpt
+++ b/tests/cursor/cursor-tailable_error-001.phpt
@@ -22,7 +22,7 @@ function insert(MongoDB\Driver\Manager $manager, $from, $to = null)
 
     $writeResult = $manager->executeBulkWrite(NS, $bulkWrite);
 
-    printf("Inserted %d document(s): %s\n", $writeResult->getInsertedCount(), implode(range($from, $to), ', '));
+    printf("Inserted %d document(s): %s\n", $writeResult->getInsertedCount(), implode(', ', range($from, $to)));
 }
 
 $manager = new MongoDB\Driver\Manager(URI);

--- a/tests/cursor/cursor-tailable_error-002.phpt
+++ b/tests/cursor/cursor-tailable_error-002.phpt
@@ -23,7 +23,7 @@ function insert(MongoDB\Driver\Manager $manager, $from, $to = null)
 
     $writeResult = $manager->executeBulkWrite(NS, $bulkWrite);
 
-    printf("Inserted %d document(s): %s\n", $writeResult->getInsertedCount(), implode(range($from, $to), ', '));
+    printf("Inserted %d document(s): %s\n", $writeResult->getInsertedCount(), implode(', ', range($from, $to)));
 }
 
 $manager = new MongoDB\Driver\Manager(URI);


### PR DESCRIPTION
Until we can get PHP 7.4 on evergreen, we'll use travis-ci to ensure the extension compiles and tests pass.

This PR also runs a single job as smoke test to avoid using excessive travis-ci build resources. Other versions and topologies will only be tested if this initial smoke test succeeds. This helps save build resources.