### PR TITLE
PHPC-1355: Add the ability to specify a pipeline to an update command

### DIFF
--- a/tests/bulk/bulkwrite-update-003.phpt
+++ b/tests/bulk/bulkwrite-update-003.phpt
@@ -1,0 +1,65 @@
+--TEST--
+MongoDB\Driver\BulkWrite::update() with pipeline option
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_not_live(); ?>
+<?php skip_if_server_version('<', '4.2'); ?>
+<?php skip_if_not_clean(); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(URI);
+
+$bulk = new MongoDB\Driver\BulkWrite();
+
+$bulk->insert([ '_id' => 1, 'x' => 1, 'y' => 1, 't' => [ 'u' => [ 'v' => 1 ] ] ]);
+$bulk->insert([ '_id' => 2, 'x' => 2, 'y' => 1]);
+
+$manager->executeBulkWrite(NS, $bulk);
+
+$updateBulk = new MongoDB\Driver\BulkWrite();
+
+$query = ['_id' => 1];
+$update = [
+    [
+        '$replaceRoot' => [ 'newRoot' => '$t' ],
+    ],
+    [
+        '$addFields' => [ 'foo' => 1 ],
+    ],
+];
+
+$updateBulk->update($query, $update);
+$manager->executeBulkWrite(NS, $updateBulk);
+
+$cursor = $manager->executeQuery(NS, new \MongoDB\Driver\Query([]));
+var_dump($cursor->toArray());
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+array(%d) {
+  [0]=>
+  object(stdClass)#%d (%d) {
+    ["_id"]=>
+    int(1)
+    ["u"]=>
+    object(stdClass)#%d (%d) {
+      ["v"]=>
+      int(1)
+    }
+    ["foo"]=>
+    int(1)
+  }
+  [1]=>
+  object(stdClass)#%d (%d) {
+    ["_id"]=>
+    int(2)
+    ["x"]=>
+    int(2)
+    ["y"]=>
+    int(1)
+  }
+}
+===DONE===

--- a/tests/session/session-startTransaction_error-002.phpt
+++ b/tests/session/session-startTransaction_error-002.phpt
@@ -13,13 +13,14 @@ $manager = new MongoDB\Driver\Manager(URI);
 $session = $manager->startSession();
 
 $options = [
-    [ 'readConcern' => 42 ], 
+    [ 'maxCommitTimeMS' => -1 ],
+    [ 'readConcern' => 42 ],
     [ 'readConcern' => new stdClass ],
     [ 'readConcern' => new \MongoDB\Driver\WriteConcern( 2 ) ],
-    [ 'readPreference' => 42 ], 
+    [ 'readPreference' => 42 ],
     [ 'readPreference' => new stdClass ],
     [ 'readPreference' => new \MongoDB\Driver\ReadConcern( \MongoDB\Driver\ReadConcern::LOCAL ) ],
-    [ 'writeConcern' => 42 ], 
+    [ 'writeConcern' => 42 ],
     [ 'writeConcern' => new stdClass ],
     [ 'writeConcern' => new \MongoDB\Driver\ReadPreference( \MongoDB\Driver\ReadPreference::RP_SECONDARY ) ],
 
@@ -43,10 +44,16 @@ foreach ($options as $txnOptions) {
     }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 }
 
+echo raises(function() use ($session) {
+    $session->startTransaction([ 'maxCommitTimeMS' => new stdClass ]);
+}, E_NOTICE), "\n";
+
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "maxCommitTimeMS" option to be >= 0, -1 given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected "readConcern" option to be MongoDB\Driver\ReadConcern, int%S given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
@@ -71,4 +78,6 @@ OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected "writeConcern" option to be MongoDB\Driver\WriteConcern, MongoDB\Driver\ReadPreference given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected "writeConcern" option to be MongoDB\Driver\WriteConcern, MongoDB\Driver\ReadPreference given
+OK: Got E_NOTICE
+Object of class stdClass could not be converted to int
 ===DONE===

--- a/tests/session/session_error-001.phpt
+++ b/tests/session/session_error-001.phpt
@@ -7,13 +7,14 @@ require_once __DIR__ . "/../utils/basic.inc";
 $manager = new MongoDB\Driver\Manager();
 
 $options = [
-    [ 'readConcern' => 42 ], 
+    [ 'maxCommitTimeMS' => -1 ],
+    [ 'readConcern' => 42 ],
     [ 'readConcern' => new stdClass ],
     [ 'readConcern' => new \MongoDB\Driver\WriteConcern( 2 ) ],
-    [ 'readPreference' => 42 ], 
+    [ 'readPreference' => 42 ],
     [ 'readPreference' => new stdClass ],
     [ 'readPreference' => new \MongoDB\Driver\ReadConcern( \MongoDB\Driver\ReadConcern::LOCAL ) ],
-    [ 'writeConcern' => 42 ], 
+    [ 'writeConcern' => 42 ],
     [ 'writeConcern' => new stdClass ],
     [ 'writeConcern' => new \MongoDB\Driver\ReadPreference( \MongoDB\Driver\ReadPreference::RP_SECONDARY ) ],
 
@@ -36,16 +37,24 @@ $options = [
 
 foreach ($options as $txnOptions) {
     echo throws(function() use ($manager, $txnOptions) {
-        $session = $manager->startSession([
+        $manager->startSession([
             'defaultTransactionOptions' => $txnOptions
         ]);
     }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 }
 
+echo raises(function() use ($manager) {
+    $manager->startSession([
+        'defaultTransactionOptions' => [ 'maxCommitTimeMS' => new stdClass ]
+    ]);
+}, E_NOTICE), "\n";
+
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "maxCommitTimeMS" option to be >= 0, -1 given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected "readConcern" option to be MongoDB\Driver\ReadConcern, int%S given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
@@ -74,4 +83,6 @@ OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected "defaultTransactionOptions" option to be an array, int%S given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected "defaultTransactionOptions" option to be an array, stdClass given
+OK: Got E_NOTICE
+Object of class stdClass could not be converted to int
 ===DONE===

--- a/tests/utils/tools.php
+++ b/tests/utils/tools.php
@@ -518,6 +518,8 @@ function severityToString($type) {
     switch($type) {
     case E_WARNING:
         return "E_WARNING";
+    case E_NOTICE:
+        return "E_NOTICE";
     default:
         return "Some other #_$type";
     }
@@ -531,6 +533,8 @@ function raises($function, $type, $infunction = null) {
     try {
         $function();
     } catch(Exception $e) {
+        $exceptionname = get_class($e);
+
         if ($e instanceof ErrorException && $e->getSeverity() & $type) {
             if ($infunction) {
                 $trace = $e->getTrace();
@@ -551,7 +555,7 @@ function raises($function, $type, $infunction = null) {
         return $e->getMessage();
     }
 
-    echo "FAILED: Expected $exceptionname thrown!\n";
+    printf("FAILED: Expected %s thrown!\n", ErrorException::class);
     restore_error_handler();
 }
 function throws($function, $exceptionname, $infunction = null) {


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1355

This PR changes update document checks in `\MongoDB\Driver\BulkWrite` to ensure updates with pipelines are treated as updates and not replacements. The detection logic for this is a direct copy from libmongoc since the function is not exposed to users of libmongoc. Even though we're duplicating logic, I don't think exposing the function to the outside is a good idea.