### PR TITLE
PHPC-1346: Do not allow empty string for username

### DIFF
--- a/tests/connect/bug1045.phpt
+++ b/tests/connect/bug1045.phpt
@@ -2,27 +2,21 @@
 PHPC-1045: Segfault if username is not provided for SCRAM-SHA-1 authMechanism
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
-<?php skip_if_not_libmongoc_ssl(); ?>
-<?php skip_if_not_live(); ?>
-<?php skip_if_auth(); ?>
-<?php skip_if_not_clean(); ?>
+<?php skip_if_not_libmongoc_crypto(); ?>
 --FILE--
 <?php
 
 require_once __DIR__ . "/../utils/basic.inc";
 
-// URI may or may not support auth, but that is not necessary for the test
-$m = new MongoDB\Driver\Manager(URI, ['authMechanism' => 'SCRAM-SHA-1']);
-
-// Execute a basic ping command to trigger connection initialization
-echo throws(function() use ($m) {
-    $m->executeCommand('admin', new MongoDB\Driver\Command(['ping'=>1]));
-}, 'MongoDB\Driver\Exception\RuntimeException'), "\n";
+echo throws(function() {
+    // URI may or may not support auth, but that is not necessary for the test
+    new MongoDB\Driver\Manager('mongodb://127.0.0.1/', ['authMechanism' => 'SCRAM-SHA-1']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-OK: Got MongoDB\Driver\Exception\RuntimeException
-SCRAM Failure: username is not set
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Failed to parse URI options: 'SCRAM-SHA-1' authentication mechanism requires username.
 ===DONE===

--- a/tests/manager/manager-ctor-auth_mechanism-001.phpt
+++ b/tests/manager/manager-ctor-auth_mechanism-001.phpt
@@ -5,9 +5,11 @@ MongoDB\Driver\Manager::__construct(): authMechanism option
 
 $tests = [
     ['mongodb://username@127.0.0.1/?authMechanism=MONGODB-X509', []],
+    ['mongodb://127.0.0.1/?authMechanism=MONGODB-X509', []],
     ['mongodb://username@127.0.0.1/?authMechanism=GSSAPI', []],
+    [null, ['authMechanism' => 'MONGODB-X509', 'username' => 'username']],
     [null, ['authMechanism' => 'MONGODB-X509']],
-    [null, ['authMechanism' => 'GSSAPI']],
+    [null, ['authMechanism' => 'GSSAPI', 'username' => 'username']],
 ];
 
 foreach ($tests as $test) {

--- a/tests/manager/manager-ctor-auth_mechanism-002.phpt
+++ b/tests/manager/manager-ctor-auth_mechanism-002.phpt
@@ -5,12 +5,12 @@ MongoDB\Driver\Manager::__construct(): authMechanismProperties option
 
 $tests = [
     ['mongodb://username@127.0.0.1/?authMechanism=GSSAPI&authMechanismProperties=CANONICALIZE_HOST_NAME:true,SERVICE_NAME:foo,SERVICE_REALM:bar', []],
-    [null, ['authMechanism' => 'GSSAPI', 'authMechanismProperties' => ['CANONICALIZE_HOST_NAME' => 'true', 'SERVICE_NAME' => 'foo', 'SERVICE_REALM' => 'bar']]],
+    [null, ['username' => 'username', 'authMechanism' => 'GSSAPI', 'authMechanismProperties' => ['CANONICALIZE_HOST_NAME' => 'true', 'SERVICE_NAME' => 'foo', 'SERVICE_REALM' => 'bar']]],
     // Options are case-insensitive
     ['mongodb://username@127.0.0.1/?authMechanism=GSSAPI&authMechanismProperties=canonicalize_host_name:TRUE,service_name:foo,service_realm:bar', []],
-    [null, ['authMechanism' => 'GSSAPI', 'authMechanismProperties' => ['canonicalize_host_name' => 'TRUE', 'service_name' => 'foo', 'service_realm' => 'bar']]],
+    [null, ['username' => 'username', 'authMechanism' => 'GSSAPI', 'authMechanismProperties' => ['canonicalize_host_name' => 'TRUE', 'service_name' => 'foo', 'service_realm' => 'bar']]],
     // Boolean true "CANONICALIZE_HOST_NAME" value is converted to "true"
-    [null, ['authMechanism' => 'GSSAPI', 'authMechanismProperties' => ['canonicalize_host_name' => true]]],
+    [null, ['username' => 'username', 'authMechanism' => 'GSSAPI', 'authMechanismProperties' => ['canonicalize_host_name' => true]]],
 ];
 
 foreach ($tests as $test) {

--- a/tests/manager/manager-ctor-auth_mechanism-error-001.phpt
+++ b/tests/manager/manager-ctor-auth_mechanism-error-001.phpt
@@ -1,0 +1,54 @@
+--TEST--
+MongoDB\Driver\Manager::__construct(): authentication options are validated
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/tools.php';
+
+echo throws(function() {
+    new MongoDB\Driver\Manager('mongodb://localhost:27017/?authMechanism=GSSAPI&authSource=admin');
+}, "MongoDB\Driver\Exception\InvalidArgumentException"), "\n";
+
+echo throws(function() {
+    new MongoDB\Driver\Manager('mongodb://localhost:27017/', ['authMechanism' => 'GSSAPI', 'authSource' => 'admin']);
+}, "MongoDB\Driver\Exception\InvalidArgumentException"), "\n";
+
+echo throws(function() {
+    new MongoDB\Driver\Manager('mongodb://localhost:27017/?authMechanism=MONGODB-X509&authSource=admin');
+}, "MongoDB\Driver\Exception\InvalidArgumentException"), "\n";
+
+echo throws(function() {
+    new MongoDB\Driver\Manager('mongodb://localhost:27017/', ['authMechanism' => 'MONGODB-X509', 'authSource' => 'admin']);
+}, "MongoDB\Driver\Exception\InvalidArgumentException"), "\n";
+
+echo throws(function() {
+    new MongoDB\Driver\Manager('mongodb://@localhost:27017/?authMechanism=SCRAM-SHA-1');
+}, "MongoDB\Driver\Exception\InvalidArgumentException"), "\n";
+
+echo throws(function() {
+    new MongoDB\Driver\Manager('mongodb://localhost:27017/', ['username' => '', 'authMechanism' => 'SCRAM-SHA-1']);
+}, "MongoDB\Driver\Exception\InvalidArgumentException"), "\n";
+
+echo throws(function() {
+    new MongoDB\Driver\Manager('mongodb://localhost:27017/', ['password' => 'password', 'authMechanism' => 'MONGODB-X509']);
+}, "MongoDB\Driver\Exception\InvalidArgumentException"), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Failed to parse MongoDB URI: 'mongodb://localhost:27017/?authMechanism=GSSAPI&authSource=admin'. GSSAPI and X509 require "$external" authSource.
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Failed to parse URI options: GSSAPI and X509 require "$external" authSource.
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Failed to parse MongoDB URI: 'mongodb://localhost:27017/?authMechanism=MONGODB-X509&authSource=admin'. GSSAPI and X509 require "$external" authSource.
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Failed to parse URI options: GSSAPI and X509 require "$external" authSource.
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Failed to parse MongoDB URI: 'mongodb://@localhost:27017/?authMechanism=SCRAM-SHA-1'. 'SCRAM-SHA-1' authentication mechanism requires username.
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Failed to parse URI options: 'SCRAM-SHA-1' authentication mechanism requires username.
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Failed to parse URI options: X509 authentication mechanism does not accept a password.
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1346

Since libmongoc does validation in `mongoc_uri_parse`, passing a username as `option` in `MongoDB\Driver\Manager::construct` effectively bypasses sanity checks on the authentication options. Since the check can't be done in `mongoc_uri_set_username` because the authentication options may change later, we have to replicate the sanity checks from `mongoc_uri_finalize_auth` here.