### PR TITLE
PHPC-1288: Implement Unified URI Options

### DIFF
--- a/tests/manager/manager-ctor-tls-error-001.phpt
+++ b/tests/manager/manager-ctor-tls-error-001.phpt
@@ -1,0 +1,36 @@
+--TEST--
+MongoDB\Driver\Manager::__construct(): tlsInsecure cannot be combined with tlsAllowInvalidHostnames
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/tools.php';
+
+echo throws(function() {
+    new MongoDB\Driver\Manager('mongodb://localhost:27017/?tlsInsecure=true&tlsAllowInvalidHostnames=true');
+}, "MongoDB\Driver\Exception\InvalidArgumentException"), "\n";
+
+echo throws(function() {
+    new MongoDB\Driver\Manager('mongodb://localhost:27017/', ['tlsInsecure' => true, 'tlsAllowInvalidHostnames' => true]);
+}, "MongoDB\Driver\Exception\InvalidArgumentException"), "\n";
+
+echo throws(function() {
+    new MongoDB\Driver\Manager('mongodb://localhost:27017/?tlsInsecure=true', ['tlsAllowInvalidHostnames' => true]);
+}, "MongoDB\Driver\Exception\InvalidArgumentException"), "\n";
+
+echo throws(function() {
+    new MongoDB\Driver\Manager('mongodb://localhost:27017/?tlsAllowInvalidHostnames=true', ['tlsInsecure' => true]);
+}, "MongoDB\Driver\Exception\InvalidArgumentException"), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Failed to parse MongoDB URI: 'mongodb://localhost:27017/?tlsInsecure=true&tlsAllowInvalidHostnames=true'. tlsinsecure may not be specified with tlsallowinvalidcertificates or tlsallowinvalidhostnames.
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Failed to parse URI options: tlsinsecure may not be combined with tlsallowinvalidcertificates or tlsallowinvalidhostnames.
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Failed to parse URI options: tlsinsecure may not be combined with tlsallowinvalidcertificates or tlsallowinvalidhostnames.
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Failed to parse URI options: tlsinsecure may not be combined with tlsallowinvalidcertificates or tlsallowinvalidhostnames.
+===DONE===

--- a/tests/manager/manager-ctor-tls-error-002.phpt
+++ b/tests/manager/manager-ctor-tls-error-002.phpt
@@ -1,0 +1,36 @@
+--TEST--
+MongoDB\Driver\Manager::__construct(): tlsInsecure cannot be combined with tlsAllowInvalidCertificates
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/tools.php';
+
+echo throws(function() {
+    new MongoDB\Driver\Manager('mongodb://localhost:27017/?tlsInsecure=true&tlsAllowInvalidCertificates=true');
+}, "MongoDB\Driver\Exception\InvalidArgumentException"), "\n";
+
+echo throws(function() {
+    new MongoDB\Driver\Manager('mongodb://localhost:27017/', ['tlsInsecure' => true, 'tlsAllowInvalidCertificates' => true]);
+}, "MongoDB\Driver\Exception\InvalidArgumentException"), "\n";
+
+echo throws(function() {
+    new MongoDB\Driver\Manager('mongodb://localhost:27017/?tlsInsecure=true', ['tlsAllowInvalidCertificates' => true]);
+}, "MongoDB\Driver\Exception\InvalidArgumentException"), "\n";
+
+echo throws(function() {
+    new MongoDB\Driver\Manager('mongodb://localhost:27017/?tlsAllowInvalidCertificates=true', ['tlsInsecure' => true]);
+}, "MongoDB\Driver\Exception\InvalidArgumentException"), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Failed to parse MongoDB URI: 'mongodb://localhost:27017/?tlsInsecure=true&tlsAllowInvalidCertificates=true'. tlsinsecure may not be specified with tlsallowinvalidcertificates or tlsallowinvalidhostnames.
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Failed to parse URI options: tlsinsecure may not be combined with tlsallowinvalidcertificates or tlsallowinvalidhostnames.
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Failed to parse URI options: tlsinsecure may not be combined with tlsallowinvalidcertificates or tlsallowinvalidhostnames.
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Failed to parse URI options: tlsinsecure may not be combined with tlsallowinvalidcertificates or tlsallowinvalidhostnames.
+===DONE===

--- a/tests/utils/tools.php
+++ b/tests/utils/tools.php
@@ -266,7 +266,7 @@ function is_auth($uri)
  */
 function is_ssl($uri)
 {
-    return stripos($uri, 'ssl=true') !== false;
+    return stripos($uri, 'ssl=true') !== false || stripos($uri, 'tls=true') !== false;
 }
 
 /**


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1288

Supersedes #948. This PR also contains a fix for an issue related to #1012. Setting TLS options after parsing the connection string bypasses validation, e.g. checking that the `tlsInsecure` option is not combined with the `tlsAllowInvalidCertificates` or `tlsAllowInvalidHostnames` options. This is now done after applying TLS options to the `mongoc_uri_t` object.