### PR TITLE
PHPC-1290: Fix build failures on appveyor and Evergreen

### DIFF
--- a/tests/manager/manager-executeBulkWrite_error-009.phpt
+++ b/tests/manager/manager-executeBulkWrite_error-009.phpt
@@ -2,6 +2,7 @@
 MongoDB\Driver\Manager::executeBulkWrite() with invalid options
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_not_live(); ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";

--- a/tests/manager/manager-executeQuery_error-002.phpt
+++ b/tests/manager/manager-executeQuery_error-002.phpt
@@ -1,7 +1,5 @@
 --TEST--
 MongoDB\Driver\Manager::executeQuery() with invalid options
---SKIPIF--
-<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";

--- a/tests/server/server-executeBulkWrite_error-002.phpt
+++ b/tests/server/server-executeBulkWrite_error-002.phpt
@@ -2,6 +2,7 @@
 MongoDB\Driver\Server::executeBulkWrite() with invalid options
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_not_live(); ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";

--- a/tests/server/server-executeQuery_error-001.phpt
+++ b/tests/server/server-executeQuery_error-001.phpt
@@ -2,6 +2,7 @@
 MongoDB\Driver\Server::executeQuery() with invalid options
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_not_live(); ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";

--- a/tests/session/session-commitTransaction-001.phpt
+++ b/tests/session/session-commitTransaction-001.phpt
@@ -3,8 +3,7 @@ MongoDB\Driver\Session::commitTransaction() applies w:majority when retrying
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_not_libmongoc_crypto() ?>
-<?php skip_if_not_replica_set_or_mongos_with_replica_set(); ?>
-<?php skip_if_server_version('<', '4.0'); ?>
+<?php skip_if_no_transactions(); ?>
 <?php skip_if_not_clean(); ?>
 --FILE--
 <?php

--- a/tests/session/session-endSession-001.phpt
+++ b/tests/session/session-endSession-001.phpt
@@ -3,8 +3,7 @@ MongoDB\Driver\Session::endSession() Calling methods after session has been ende
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_not_libmongoc_crypto(); ?>
-<?php skip_if_not_replica_set_or_mongos_with_replica_set(); ?>
-<?php skip_if_server_version('<', '4.0'); ?>
+<?php skip_if_no_transactions(); ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";

--- a/tests/session/session-isInTransaction-001.phpt
+++ b/tests/session/session-isInTransaction-001.phpt
@@ -3,8 +3,7 @@ MongoDB\Driver\Session::isInTransaction()
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_not_libmongoc_crypto() ?>
-<?php skip_if_not_replica_set_or_mongos_with_replica_set(); ?>
-<?php skip_if_server_version('<', '4.0'); ?>
+<?php skip_if_no_transactions(); ?>
 <?php skip_if_not_clean(); ?>
 --FILE--
 <?php

--- a/tests/session/session-startTransaction-001.phpt
+++ b/tests/session/session-startTransaction-001.phpt
@@ -3,8 +3,7 @@ MongoDB\Driver\Session::startTransaction() ensure that methods can be called
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_not_libmongoc_crypto() ?>
-<?php skip_if_not_replica_set_or_mongos_with_replica_set(); ?>
-<?php skip_if_server_version('<', '4.0'); ?>
+<?php skip_if_no_transactions(); ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";

--- a/tests/session/session-startTransaction_error-001.phpt
+++ b/tests/session/session-startTransaction_error-001.phpt
@@ -3,8 +3,7 @@ MongoDB\Driver\Session::startTransaction() twice
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_not_libmongoc_crypto() ?>
-<?php skip_if_not_replica_set_or_mongos_with_replica_set(); ?>
-<?php skip_if_server_version('<', '4.0'); ?>
+<?php skip_if_no_transactions(); ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";

--- a/tests/session/session-startTransaction_error-002.phpt
+++ b/tests/session/session-startTransaction_error-002.phpt
@@ -3,8 +3,7 @@ MongoDB\Driver\Session::startTransaction() with wrong values in options array
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_not_libmongoc_crypto() ?>
-<?php skip_if_not_replica_set_or_mongos_with_replica_set(); ?>
-<?php skip_if_server_version('<', '4.0'); ?>
+<?php skip_if_no_transactions(); ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";

--- a/tests/session/session-startTransaction_error-003.phpt
+++ b/tests/session/session-startTransaction_error-003.phpt
@@ -3,8 +3,7 @@ MongoDB\Driver\Session::startTransaction() with wrong argument for options array
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_not_libmongoc_crypto() ?>
-<?php skip_if_not_replica_set_or_mongos_with_replica_set(); ?>
-<?php skip_if_server_version('<', '4.0'); ?>
+<?php skip_if_no_transactions(); ?>
 <?php skip_if_php_version('>=', '7.0.0'); ?>
 --FILE--
 <?php

--- a/tests/session/session-startTransaction_error-004.phpt
+++ b/tests/session/session-startTransaction_error-004.phpt
@@ -3,8 +3,7 @@ MongoDB\Driver\Session::startTransaction() with wrong argument for options array
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_not_libmongoc_crypto() ?>
-<?php skip_if_not_replica_set(); ?>
-<?php skip_if_server_version('<', '4.0'); ?>
+<?php skip_if_no_transactions(); ?>
 <?php skip_if_php_version('<', '7.0.0'); ?>
 --FILE--
 <?php

--- a/tests/session/session-startTransaction_error-005.phpt
+++ b/tests/session/session-startTransaction_error-005.phpt
@@ -1,11 +1,10 @@
 --TEST--
-MongoDB\Driver\Session::startTransaction() with wrong argument for options array on PHP 7.0
+MongoDB\Driver\Session::startTransaction() with wrong argument for options array on PHP 7
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_not_libmongoc_crypto() ?>
 <?php skip_if_no_transactions(); ?>
-<?php skip_if_php_version('<', '7.0.0'); ?>
-<?php skip_if_php_version('>=', '7.1.0'); ?>
+<?php skip_if_php_version('<', '7.1.0'); ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";
@@ -29,7 +28,7 @@ foreach ($options as $txnOptions) {
 <?php exit(0); ?>
 --EXPECTF--
 OK: Got TypeError
-Argument 1 passed to MongoDB\Driver\Session::startTransaction() must be of the type array, int%S given
+Argument 1 passed to MongoDB\Driver\Session::startTransaction() must be of the type array or null, int%S given
 OK: Got TypeError
-Argument 1 passed to MongoDB\Driver\Session::startTransaction() must be of the type array, object given
+Argument 1 passed to MongoDB\Driver\Session::startTransaction() must be of the type array or null, object given
 ===DONE===

--- a/tests/session/transaction-integration-001.phpt
+++ b/tests/session/transaction-integration-001.phpt
@@ -3,8 +3,7 @@ MongoDB\Driver\Session::startTransaction() Committing a transaction with example
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_not_libmongoc_crypto(); ?>
-<?php skip_if_not_replica_set_or_mongos_with_replica_set(); ?>
-<?php skip_if_server_version('<', '4.0'); ?>
+<?php skip_if_no_transactions(); ?>
 <?php skip_if_not_clean(DATABASE_NAME, COLLECTION_NAME . '_employees'); ?>
 <?php skip_if_not_clean(DATABASE_NAME, COLLECTION_NAME . '_events'); ?>
 --FILE--

--- a/tests/session/transaction-integration-002.phpt
+++ b/tests/session/transaction-integration-002.phpt
@@ -3,8 +3,7 @@ MongoDB\Driver\Session::startTransaction() Transient Error Test
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_not_libmongoc_crypto(); ?>
-<?php skip_if_not_replica_set_or_mongos_with_replica_set(); ?>
-<?php skip_if_server_version('<', '4.0'); ?>
+<?php skip_if_no_transactions(); ?>
 <?php skip_if_not_clean(); ?>
 --FILE--
 <?php

--- a/tests/session/transaction-integration-003.phpt
+++ b/tests/session/transaction-integration-003.phpt
@@ -3,8 +3,7 @@ MongoDB\Driver\Session::startTransaction() Transient Error Test
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_not_libmongoc_crypto(); ?>
-<?php skip_if_not_replica_set_or_mongos_with_replica_set(); ?>
-<?php skip_if_server_version('<', '4.0'); ?>
+<?php skip_if_no_transactions(); ?>
 <?php skip_if_not_clean(); ?>
 --FILE--
 <?php

--- a/tests/session/transaction-integration_error-001.phpt
+++ b/tests/session/transaction-integration_error-001.phpt
@@ -3,8 +3,7 @@ MongoDB\Driver\Session: Setting per-op readConcern or writeConcern in transactio
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_not_libmongoc_crypto(); ?>
-<?php skip_if_not_replica_set_or_mongos_with_replica_set(); ?>
-<?php skip_if_server_version('<', '4.0'); ?>
+<?php skip_if_no_transactions(); ?>
 <?php skip_if_not_clean(); ?>
 --FILE--
 <?php

--- a/tests/session/transaction-integration_error-002.phpt
+++ b/tests/session/transaction-integration_error-002.phpt
@@ -3,8 +3,7 @@ MongoDB\Driver\Session: Setting per-op readConcern in transaction (executeReadCo
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_not_libmongoc_crypto(); ?>
-<?php skip_if_not_replica_set_or_mongos_with_replica_set(); ?>
-<?php skip_if_server_version('<', '4.0'); ?>
+<?php skip_if_no_transactions(); ?>
 <?php skip_if_not_clean(); ?>
 --FILE--
 <?php

--- a/tests/session/transaction-integration_error-003.phpt
+++ b/tests/session/transaction-integration_error-003.phpt
@@ -3,8 +3,7 @@ MongoDB\Driver\Session: Setting per-op writeConcern in transaction (executeWrite
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_not_libmongoc_crypto(); ?>
-<?php skip_if_not_replica_set_or_mongos_with_replica_set(); ?>
-<?php skip_if_server_version('<', '4.0'); ?>
+<?php skip_if_no_transactions(); ?>
 <?php skip_if_not_clean(); ?>
 --FILE--
 <?php

--- a/tests/session/transaction-integration_error-004.phpt
+++ b/tests/session/transaction-integration_error-004.phpt
@@ -3,8 +3,7 @@ MongoDB\Driver\Session: Setting per-op readConcern or writeConcern in transactio
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_not_libmongoc_crypto(); ?>
-<?php skip_if_not_replica_set_or_mongos_with_replica_set(); ?>
-<?php skip_if_server_version('<', '4.0'); ?>
+<?php skip_if_no_transactions(); ?>
 <?php skip_if_not_clean(); ?>
 --FILE--
 <?php

--- a/tests/utils/skipif.php
+++ b/tests/utils/skipif.php
@@ -77,6 +77,17 @@ function skip_if_not_replica_set_or_mongos_with_replica_set()
     is_replica_set(URI) or is_mongos_with_replica_set(URI) or exit('skip topology is not a replica set or sharded cluster with replica set');
 }
 
+function skip_if_no_transactions()
+{
+    if (is_mongos_with_replica_set(URI)) {
+        skip_if_server_version('<', '4.2');
+    } elseif (is_replica_set(URI)) {
+        skip_if_server_version('<', '4.0');
+    } else {
+        exit('skip topology does not support transactions');
+    }
+}
+
 /**
  * Skips the test if the topology has no arbiter.
  */


### PR DESCRIPTION
I was a bit trigger-happy with the merge of #1014. Turns out that while all tests pass on travis-ci, they don't pass on appveyor (three failures because of no running MongoDB) and fail on evergreen as well since we test sharded clusters on MongoDB < 4.2, which breaks the assumption that we can run sharded transactions. This PR introduces a new helper that checks for MongoDB version support depending on what topology we detected: for replicasets, 4.0 is required while we require 4.2 for sharded clusters backed by replica sets.