### PR TITLE
PHPC-870: Use ZEND_HASH_FOREACH indirect macros where applicable

### DIFF
--- a/php_phongo.c
+++ b/php_phongo.c
@@ -1307,7 +1307,7 @@ void php_phongo_read_preference_prep_tagsets(zval* tagSets TSRMLS_DC) /* {{{ */
 	{
 		zval* tagSet;
 
-		ZEND_HASH_FOREACH_VAL(ht_data, tagSet)
+		ZEND_HASH_FOREACH_VAL_IND(ht_data, tagSet)
 		{
 			ZVAL_DEREF(tagSet);
 			if (Z_TYPE_P(tagSet) == IS_ARRAY) {
@@ -2300,7 +2300,7 @@ static void php_phongo_dispatch_handlers(const char* name, zval* z_event)
 #if PHP_VERSION_ID >= 70000
 	zval* value;
 
-	ZEND_HASH_FOREACH_VAL(MONGODB_G(subscribers), value)
+	ZEND_HASH_FOREACH_VAL_IND(MONGODB_G(subscribers), value)
 	{
 		if (EG(exception)) {
 			break;

--- a/src/MongoDB/Exception/RuntimeException.c
+++ b/src/MongoDB/Exception/RuntimeException.c
@@ -41,7 +41,7 @@ static bool php_phongo_has_string_array_element(zval* labels, char* label TSRMLS
 	{
 		zval* z_label;
 
-		ZEND_HASH_FOREACH_VAL(ht_data, z_label)
+		ZEND_HASH_FOREACH_VAL_IND(ht_data, z_label)
 		{
 			if ((Z_TYPE_P(z_label) == IS_STRING) && (strcmp(Z_STRVAL_P(z_label), label) == 0)) {
 				return true;

--- a/src/MongoDB/Manager.c
+++ b/src/MongoDB/Manager.c
@@ -114,7 +114,7 @@ static void php_phongo_manager_prep_authmechanismproperties(zval* properties TSR
 		zend_ulong   num_key    = 0;
 		zval*        property;
 
-		ZEND_HASH_FOREACH_KEY_VAL(ht_data, num_key, string_key, property)
+		ZEND_HASH_FOREACH_KEY_VAL_IND(ht_data, num_key, string_key, property)
 		{
 			if (!string_key) {
 				continue;
@@ -193,7 +193,7 @@ static void php_phongo_manager_prep_uri_options(zval* options TSRMLS_DC) /* {{{ 
 		zend_ulong   num_key    = 0;
 		zval*        option;
 
-		ZEND_HASH_FOREACH_KEY_VAL(ht_data, num_key, string_key, option)
+		ZEND_HASH_FOREACH_KEY_VAL_IND(ht_data, num_key, string_key, option)
 		{
 			if (!string_key) {
 				continue;

--- a/src/bson-encode.c
+++ b/src/bson-encode.c
@@ -399,10 +399,6 @@ try_again:
 		}
 
 #if PHP_VERSION_ID >= 70000
-		case IS_INDIRECT:
-			php_phongo_bson_append(bson, field_path, flags, key, key_len, Z_INDIRECT_P(entry) TSRMLS_DC);
-			break;
-
 		case IS_REFERENCE:
 			ZVAL_DEREF(entry);
 			goto try_again;
@@ -515,7 +511,7 @@ static void php_phongo_zval_to_bson_internal(zval* data, php_phongo_field_path* 
 		zend_ulong   num_key    = 0;
 		zval*        value;
 
-		ZEND_HASH_FOREACH_KEY_VAL(ht_data, num_key, string_key, value)
+		ZEND_HASH_FOREACH_KEY_VAL_IND(ht_data, num_key, string_key, value)
 		{
 			if (string_key) {
 				if (ht_data_from_properties) {


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-870

While strictly speaking the only loop that needs updating us in bson-encode.c (the only one that calls `php_phongo_bson_append`, I thought it was sensible to use indirect macros wherever we check the type of the ZVAL at the current iterator position.