### PR TITLE
PHPC-966: Explicitly initialize fields for internal class structs

### DIFF
--- a/php_phongo.c
+++ b/php_phongo.c
@@ -293,11 +293,13 @@ static void phongo_cursor_init(zval* return_value, mongoc_client_t* client, mong
 
 	object_init_ex(return_value, php_phongo_cursor_ce);
 
-	intern            = Z_CURSOR_OBJ_P(return_value);
-	intern->cursor    = cursor;
-	intern->server_id = mongoc_cursor_get_hint(cursor);
-	intern->client    = client;
-	intern->advanced  = false;
+	intern               = Z_CURSOR_OBJ_P(return_value);
+	intern->cursor       = cursor;
+	intern->server_id    = mongoc_cursor_get_hint(cursor);
+	intern->client       = client;
+	intern->advanced     = false;
+	intern->got_iterator = false;
+	intern->current      = 0;
 
 	if (readPreference) {
 #if PHP_VERSION_ID >= 70000
@@ -421,6 +423,7 @@ zend_bool phongo_writeconcernerror_init(zval* return_value, bson_t* bson TSRMLS_
 	object_init_ex(return_value, php_phongo_writeconcernerror_ce);
 
 	intern = Z_WRITECONCERNERROR_OBJ_P(return_value);
+	intern->code = 0;
 
 	if (bson_iter_init_find(&iter, bson, "code") && BSON_ITER_HOLDS_INT32(&iter)) {
 		intern->code = bson_iter_int32(&iter);
@@ -458,6 +461,8 @@ zend_bool phongo_writeerror_init(zval* return_value, bson_t* bson TSRMLS_DC) /* 
 	object_init_ex(return_value, php_phongo_writeerror_ce);
 
 	intern = Z_WRITEERROR_OBJ_P(return_value);
+	intern->code  = 0;
+	intern->index = 0;
 
 	if (bson_iter_init_find(&iter, bson, "code") && BSON_ITER_HOLDS_INT32(&iter)) {
 		intern->code = bson_iter_int32(&iter);

--- a/src/MongoDB/BulkWrite.c
+++ b/src/MongoDB/BulkWrite.c
@@ -301,10 +301,11 @@ static PHP_METHOD(BulkWrite, __construct)
 		ordered = php_array_fetchc_bool(options, "ordered");
 	}
 
-	intern->bulk    = mongoc_bulk_operation_new(ordered);
-	intern->ordered = ordered;
-	intern->bypass  = PHONGO_BULKWRITE_BYPASS_UNSET;
-	intern->num_ops = 0;
+	intern->bulk     = mongoc_bulk_operation_new(ordered);
+	intern->ordered  = ordered;
+	intern->bypass   = PHONGO_BULKWRITE_BYPASS_UNSET;
+	intern->num_ops  = 0;
+	intern->executed = false;
 
 	if (options && php_array_existsc(options, "bypassDocumentValidation")) {
 		zend_bool bypass = php_array_fetchc_bool(options, "bypassDocumentValidation");

--- a/src/MongoDB/Command.c
+++ b/src/MongoDB/Command.c
@@ -62,7 +62,9 @@ static bool php_phongo_command_init(php_phongo_command_t* intern, zval* filter, 
 	bson_iter_t iter;
 	bson_iter_t sub_iter;
 
-	intern->bson = bson_new();
+	intern->bson              = bson_new();
+	intern->batch_size        = 0;
+	intern->max_await_time_ms = 0;
 
 	php_phongo_zval_to_bson(filter, PHONGO_BSON_NONE, intern->bson, NULL TSRMLS_CC);
 

--- a/src/MongoDB/Query.c
+++ b/src/MongoDB/Query.c
@@ -250,8 +250,9 @@ static bool php_phongo_query_init(php_phongo_query_t* intern, zval* filter, zval
 {
 	zval* modifiers = NULL;
 
-	intern->filter = bson_new();
-	intern->opts   = bson_new();
+	intern->filter            = bson_new();
+	intern->opts              = bson_new();
+	intern->max_await_time_ms = 0;
 
 	php_phongo_zval_to_bson(filter, PHONGO_BSON_NONE, intern->filter, NULL TSRMLS_CC);
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-966

I've gone through the structs in `phongo_structs.h` and initialised all scalar fields that weren't initialised. Pointers were left untouched.