### PR TITLE
PHPC-1074: Refactor php_phongo_bson_state struct initialization for debug output

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -37,6 +37,16 @@ functions:
         working_dir: "src"
         script: |
            git submodule update --init
+    # Switch to a different version of libmongoc
+    - command: shell.exec
+      params:
+        working_dir: "src/src/libmongoc"
+        script: |
+           if [ -n "$LIBMONGOC_VERSION" ]; then
+              git fetch
+              git checkout $LIBMONGOC_VERSION
+              ../../build/calc_release_version.py
+           fi
     # Applies the submitted patch, if any
     # Deprecated. Should be removed. But still needed for certain agents (ZAP)
     - command: git.apply_patch
@@ -668,6 +678,18 @@ axes:
         variables:
            STORAGE_ENGINE: "inmemory"
 
+  - id: libmongoc-version
+    display_name: libmongoc version
+    values:
+      - id: "1.15-latest"
+        display_name: "1.15 latest"
+        variables:
+          LIBMONGOC_VERSION: "r1.15"
+      - id: "master"
+        display_name: "Upcoming release (master)"
+        variables:
+          LIBMONGOC_VERSION: "master"
+
 
 buildvariants:
 
@@ -772,3 +794,11 @@ buildvariants:
   display_name: "${versions}/${php-versions}/${os-php7} — ${storage-engine}"
   tasks:
      - name: "test-standalone"
+
+- matrix_name: "libmongoc-versions-php7"
+  matrix_spec: {"os-php7": "debian92-test", "versions": "4.2", "php-versions": "7.2", "libmongoc-version": "*"}
+  display_name: "${versions}/${php-versions}/${os-php7} — libmongoc ${libmongoc-version}"
+  tasks:
+     - name: "test-standalone"
+     - name: "test-replicaset"
+     - name: "test-sharded-rs"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -229,6 +229,16 @@ if $PKG_CONFIG libmongoc-1.0 --atleast-version 1.15.0; then
 AC_MSG_ERROR(system libmongoc must be upgraded to version >= 1.15.0)
 ```
 
+### Update tested versions in evergreen configuration
+
+Evergreen tests against multiple versions of libmongoc. When updating to a newer
+libmongoc version, make sure to update the `libmongoc-version` build axis in
+`.evergreen/config.yml`. In general, we test against two additional versions of
+libmongoc:
+- The upcoming patch release of the current libmongoc minor version (e.g. the
+  `r1.x` branch)
+- The upcoming minor release of libmongoc (e.g. the `master` branch)
+
 ### Update sources in PECL package generation script
 
 If either libmongoc or libbson introduce a new source directory, that may also

--- a/php_bson.h
+++ b/php_bson.h
@@ -83,17 +83,16 @@ typedef struct {
 	php_phongo_field_path*  field_path;
 } php_phongo_bson_state;
 
-#if PHP_VERSION_ID >= 70000
-#define PHONGO_BSON_STATE_INITIALIZER                                                                              \
-	{                                                                                                              \
-		{ { 0 } }, { PHONGO_TYPEMAP_NONE, NULL, PHONGO_TYPEMAP_NONE, NULL, PHONGO_TYPEMAP_NONE, NULL }, NULL, NULL \
-	}
-#else
-#define PHONGO_BSON_STATE_INITIALIZER                                                                         \
-	{                                                                                                         \
-		NULL, { PHONGO_TYPEMAP_NONE, NULL, PHONGO_TYPEMAP_NONE, NULL, PHONGO_TYPEMAP_NONE, NULL }, NULL, NULL \
-	}
-#endif
+#define PHONGO_BSON_INIT_STATE(s)                       \
+	do {                                                \
+		memset(&(s), 0, sizeof(php_phongo_bson_state)); \
+	} while (0)
+#define PHONGO_BSON_INIT_DEBUG_STATE(s)                    \
+	do {                                                   \
+		memset(&(s), 0, sizeof(php_phongo_bson_state));    \
+		s.map.root_type     = PHONGO_TYPEMAP_NATIVE_ARRAY; \
+		s.map.document_type = PHONGO_TYPEMAP_NATIVE_ARRAY; \
+	} while (0)
 
 void php_phongo_zval_to_bson(zval* data, php_phongo_bson_flags_t flags, bson_t* bson, bson_t** bson_out TSRMLS_DC);
 bool php_phongo_bson_to_zval_ex(const unsigned char* data, int data_len, php_phongo_bson_state* state);

--- a/php_phongo.c
+++ b/php_phongo.c
@@ -1182,12 +1182,9 @@ void php_phongo_server_to_zval(zval* retval, mongoc_server_description_t* sd) /*
 	if (bson_iter_init_find(&iter, is_master, "tags") && BSON_ITER_HOLDS_DOCUMENT(&iter)) {
 		const uint8_t*        bytes;
 		uint32_t              len;
-		php_phongo_bson_state state = PHONGO_BSON_STATE_INITIALIZER;
+		php_phongo_bson_state state;
 
-		/* Use native arrays for debugging output */
-		state.map.root_type     = PHONGO_TYPEMAP_NATIVE_ARRAY;
-		state.map.document_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
-
+		PHONGO_BSON_INIT_DEBUG_STATE(state);
 		bson_iter_document(&iter, &len, &bytes);
 		php_phongo_bson_to_zval_ex(bytes, len, &state);
 
@@ -1199,11 +1196,9 @@ void php_phongo_server_to_zval(zval* retval, mongoc_server_description_t* sd) /*
 	}
 
 	{
-		php_phongo_bson_state state = PHONGO_BSON_STATE_INITIALIZER;
-		/* Use native arrays for debugging output */
-		state.map.root_type     = PHONGO_TYPEMAP_NATIVE_ARRAY;
-		state.map.document_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
+		php_phongo_bson_state state;
 
+		PHONGO_BSON_INIT_DEBUG_STATE(state);
 		php_phongo_bson_to_zval_ex(bson_get_data(is_master), is_master->len, &state);
 
 #if PHP_VERSION_ID >= 70000

--- a/php_phongo.c
+++ b/php_phongo.c
@@ -2149,6 +2149,8 @@ static mongoc_ssl_opt_t* php_phongo_make_ssl_opt(mongoc_uri_t* uri, zval* zoptio
 	} else if (php_array_existsc(zoptions, "capath")) {
 		PHONGO_SSL_OPTION_SWAP_STRING(ssl_opt->ca_dir, "capath");
 		any_ssl_option_set = true;
+
+		php_error_docref(NULL TSRMLS_CC, E_DEPRECATED, "The \"capath\" context driver option is deprecated. Please use the \"ca_dir\" driver option instead.");
 	}
 
 	if (php_array_existsc(zoptions, "crl_file")) {
@@ -2216,6 +2218,8 @@ static bool php_phongo_apply_driver_options_to_uri(mongoc_uri_t* uri, zval* zopt
 
 			return false;
 		}
+
+		php_error_docref(NULL TSRMLS_CC, E_DEPRECATED, "The \"allow_invalid_hostname\" driver option is deprecated. Please use the \"tlsAllowInvalidHostnames\" URI option instead.");
 	}
 
 	if (php_array_existsc(zoptions, "weak_cert_validation")) {
@@ -2224,12 +2228,16 @@ static bool php_phongo_apply_driver_options_to_uri(mongoc_uri_t* uri, zval* zopt
 
 			return false;
 		}
+
+		php_error_docref(NULL TSRMLS_CC, E_DEPRECATED, "The \"weak_cert_validation\" driver option is deprecated. Please use the \"tlsAllowInvalidCertificates\" URI option instead.");
 	} else if (php_array_existsc(zoptions, "allow_self_signed")) {
 		if (!mongoc_uri_set_option_as_bool(uri, MONGOC_URI_TLSALLOWINVALIDCERTIFICATES, php_array_fetchc_bool(zoptions, "allow_self_signed"))) {
 			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Failed to parse \"%s\" driver option", "allow_self_signed");
 
 			return false;
 		}
+
+		php_error_docref(NULL TSRMLS_CC, E_DEPRECATED, "The \"allow_self_signed\" context driver option is deprecated. Please use the \"tlsAllowInvalidCertificates\" URI option instead.");
 	}
 
 	if (php_array_existsc(zoptions, "pem_file")) {
@@ -2238,12 +2246,16 @@ static bool php_phongo_apply_driver_options_to_uri(mongoc_uri_t* uri, zval* zopt
 
 			return false;
 		}
+
+		php_error_docref(NULL TSRMLS_CC, E_DEPRECATED, "The \"pem_file\" driver option is deprecated. Please use the \"tlsCertificateKeyFile\" URI option instead.");
 	} else if (php_array_existsc(zoptions, "local_cert")) {
 		if (!php_phongo_apply_driver_option_to_uri(uri, zoptions, "local_cert", MONGOC_URI_TLSCERTIFICATEKEYFILE)) {
 			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Failed to parse \"%s\" driver option", "local_cert");
 
 			return false;
 		}
+
+		php_error_docref(NULL TSRMLS_CC, E_DEPRECATED, "The \"local_cert\" context driver option is deprecated. Please use the \"tlsCertificateKeyFile\" URI option instead.");
 	}
 
 	if (php_array_existsc(zoptions, "pem_pwd")) {
@@ -2252,12 +2264,16 @@ static bool php_phongo_apply_driver_options_to_uri(mongoc_uri_t* uri, zval* zopt
 
 			return false;
 		}
+
+		php_error_docref(NULL TSRMLS_CC, E_DEPRECATED, "The \"pem_pwd\" driver option is deprecated. Please use the \"tlsCertificateKeyFilePassword\" URI option instead.");
 	} else if (php_array_existsc(zoptions, "passphrase")) {
 		if (!php_phongo_apply_driver_option_to_uri(uri, zoptions, "passphrase", MONGOC_URI_TLSCERTIFICATEKEYFILEPASSWORD)) {
 			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Failed to parse \"%s\" driver option", "passphrase");
 
 			return false;
 		}
+
+		php_error_docref(NULL TSRMLS_CC, E_DEPRECATED, "The \"passphrase\" context driver option is deprecated. Please use the \"tlsCertificateKeyFilePassword\" URI option instead.");
 	}
 
 	if (php_array_existsc(zoptions, "ca_file")) {
@@ -2266,12 +2282,16 @@ static bool php_phongo_apply_driver_options_to_uri(mongoc_uri_t* uri, zval* zopt
 
 			return false;
 		}
+
+		php_error_docref(NULL TSRMLS_CC, E_DEPRECATED, "The \"ca_file\" driver option is deprecated. Please use the \"tlsCAFile\" URI option instead.");
 	} else if (php_array_existsc(zoptions, "cafile")) {
 		if (!php_phongo_apply_driver_option_to_uri(uri, zoptions, "cafile", MONGOC_URI_TLSCAFILE)) {
 			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Failed to parse \"%s\" driver option", "cafile");
 
 			return false;
 		}
+
+		php_error_docref(NULL TSRMLS_CC, E_DEPRECATED, "The \"cafile\" context driver option is deprecated. Please use the \"tlsCAFile\" URI option instead.");
 	}
 
 	return true;

--- a/src/BSON/Javascript.c
+++ b/src/BSON/Javascript.c
@@ -177,8 +177,9 @@ static PHP_METHOD(Javascript, getScope)
 	}
 
 	if (intern->scope->len) {
-		php_phongo_bson_state state = PHONGO_BSON_STATE_INITIALIZER;
+		php_phongo_bson_state state;
 
+		PHONGO_BSON_INIT_STATE(state);
 		php_phongo_bson_to_zval_ex(bson_get_data(intern->scope), intern->scope->len, &state);
 #if PHP_VERSION_ID >= 70000
 		RETURN_ZVAL(&state.zchild, 0, 1);
@@ -206,8 +207,9 @@ static PHP_METHOD(Javascript, jsonSerialize)
 	ADD_ASSOC_STRINGL(return_value, "$code", intern->code, intern->code_len);
 
 	if (intern->scope && intern->scope->len) {
-		php_phongo_bson_state state = PHONGO_BSON_STATE_INITIALIZER;
+		php_phongo_bson_state state;
 
+		PHONGO_BSON_INIT_STATE(state);
 		if (php_phongo_bson_to_zval_ex(bson_get_data(intern->scope), intern->scope->len, &state)) {
 #if PHP_VERSION_ID >= 70000
 			Z_ADDREF(state.zchild);
@@ -228,9 +230,11 @@ static PHP_METHOD(Javascript, serialize)
 {
 	php_phongo_javascript_t* intern;
 	ZVAL_RETVAL_TYPE         retval;
-	php_phongo_bson_state    state = PHONGO_BSON_STATE_INITIALIZER;
+	php_phongo_bson_state    state;
 	php_serialize_data_t     var_hash;
 	smart_str                buf = { 0 };
+
+	PHONGO_BSON_INIT_STATE(state);
 
 	intern = Z_JAVASCRIPT_OBJ_P(getThis());
 
@@ -451,8 +455,9 @@ HashTable* php_phongo_javascript_get_properties_hash(zval* object, bool is_debug
 		zend_hash_str_update(props, "code", sizeof("code") - 1, &code);
 
 		if (intern->scope) {
-			php_phongo_bson_state state = PHONGO_BSON_STATE_INITIALIZER;
+			php_phongo_bson_state state;
 
+			PHONGO_BSON_INIT_STATE(state);
 			if (php_phongo_bson_to_zval_ex(bson_get_data(intern->scope), intern->scope->len, &state)) {
 				Z_ADDREF(state.zchild);
 				zend_hash_str_update(props, "scope", sizeof("scope") - 1, &state.zchild);
@@ -480,8 +485,9 @@ HashTable* php_phongo_javascript_get_properties_hash(zval* object, bool is_debug
 		zend_hash_update(props, "code", sizeof("code"), &code, sizeof(code), NULL);
 
 		if (intern->scope) {
-			php_phongo_bson_state state = PHONGO_BSON_STATE_INITIALIZER;
+			php_phongo_bson_state state;
 
+			PHONGO_BSON_INIT_STATE(state);
 			if (php_phongo_bson_to_zval_ex(bson_get_data(intern->scope), intern->scope->len, &state)) {
 				Z_ADDREF_P(state.zchild);
 				zend_hash_update(props, "scope", sizeof("scope"), &state.zchild, sizeof(state.zchild), NULL);

--- a/src/BSON/functions.c
+++ b/src/BSON/functions.c
@@ -55,7 +55,9 @@ PHP_FUNCTION(MongoDB_BSON_toPHP)
 	char*                 data;
 	phongo_zpp_char_len   data_len;
 	zval*                 typemap = NULL;
-	php_phongo_bson_state state   = PHONGO_BSON_STATE_INITIALIZER;
+	php_phongo_bson_state state;
+
+	PHONGO_BSON_INIT_STATE(state);
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|a!", &data, &data_len, &typemap) == FAILURE) {
 		return;

--- a/src/MongoDB/BulkWrite.c
+++ b/src/MongoDB/BulkWrite.c
@@ -34,9 +34,10 @@ zend_class_entry* php_phongo_bulkwrite_ce;
 /* Extracts the "_id" field of a BSON document into a return value. */
 static void php_phongo_bulkwrite_extract_id(bson_t* doc, zval** return_value) /* {{{ */
 {
-	php_phongo_bson_state state = PHONGO_BSON_STATE_INITIALIZER;
-	zval*                 id    = NULL;
+	zval*                 id = NULL;
+	php_phongo_bson_state state;
 
+	PHONGO_BSON_INIT_STATE(state);
 	state.map.root_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
 
 	if (!php_phongo_bson_to_zval_ex(bson_get_data(doc), doc->len, &state)) {

--- a/src/MongoDB/Cursor.c
+++ b/src/MongoDB/Cursor.c
@@ -222,9 +222,11 @@ static zend_object_iterator* php_phongo_cursor_get_iterator(zend_class_entry* ce
 static PHP_METHOD(Cursor, setTypeMap)
 {
 	php_phongo_cursor_t*  intern;
-	php_phongo_bson_state state                   = PHONGO_BSON_STATE_INITIALIZER;
+	php_phongo_bson_state state;
 	zval*                 typemap                 = NULL;
 	bool                  restore_current_element = false;
+
+	PHONGO_BSON_INIT_STATE(state);
 
 	intern = Z_CURSOR_OBJ_P(getThis());
 

--- a/src/MongoDB/Manager.c
+++ b/src/MongoDB/Manager.c
@@ -79,6 +79,16 @@ static bool php_phongo_manager_merge_context_options(zval* zdriverOptions TSRMLS
 		return false;
 	}
 
+	/* When running PHP in debug mode, php_error_docref duplicates the current
+	 * scope, leading to a COW violation in zend_hash_merge and
+	 * zend_symtable_str_del (called by php_array_unsetc). This macro allows
+	 * that violation in debug mode and is a NOOP when in non-debug. */
+#if PHP_VERSION_ID >= 70200
+	HT_ALLOW_COW_VIOLATION(Z_ARRVAL_P(zdriverOptions));
+#endif
+
+	php_error_docref(NULL TSRMLS_CC, E_DEPRECATED, "The \"context\" driver option is deprecated.");
+
 	/* Perform array union (see: add_function() in zend_operators.c) */
 #if PHP_VERSION_ID >= 70000
 	zend_hash_merge(Z_ARRVAL_P(zdriverOptions), Z_ARRVAL_P(zcontextOptions), zval_add_ref, 0);
@@ -90,6 +100,7 @@ static bool php_phongo_manager_merge_context_options(zval* zdriverOptions TSRMLS
 #endif
 
 	php_array_unsetc(zdriverOptions, "context");
+
 	return true;
 } /* }}} */
 

--- a/src/MongoDB/Monitoring/CommandFailedEvent.c
+++ b/src/MongoDB/Monitoring/CommandFailedEvent.c
@@ -97,7 +97,9 @@ PHP_METHOD(CommandFailedEvent, getOperationId)
 PHP_METHOD(CommandFailedEvent, getReply)
 {
 	php_phongo_commandfailedevent_t* intern;
-	php_phongo_bson_state            state = PHONGO_BSON_STATE_INITIALIZER;
+	php_phongo_bson_state            state;
+
+	PHONGO_BSON_INIT_STATE(state);
 
 	intern = Z_COMMANDFAILEDEVENT_OBJ_P(getThis());
 
@@ -226,7 +228,9 @@ static HashTable* php_phongo_commandfailedevent_get_debug_info(zval* object, int
 	php_phongo_commandfailedevent_t* intern;
 	zval                             retval = ZVAL_STATIC_INIT;
 	char                             operation_id[20], request_id[20];
-	php_phongo_bson_state            reply_state = PHONGO_BSON_STATE_INITIALIZER;
+	php_phongo_bson_state            reply_state;
+
+	PHONGO_BSON_INIT_STATE(reply_state);
 
 	intern   = Z_COMMANDFAILEDEVENT_OBJ_P(object);
 	*is_temp = 1;

--- a/src/MongoDB/Monitoring/CommandStartedEvent.c
+++ b/src/MongoDB/Monitoring/CommandStartedEvent.c
@@ -31,7 +31,9 @@ zend_class_entry* php_phongo_commandstartedevent_ce;
 PHP_METHOD(CommandStartedEvent, getCommand)
 {
 	php_phongo_commandstartedevent_t* intern;
-	php_phongo_bson_state             state = PHONGO_BSON_STATE_INITIALIZER;
+	php_phongo_bson_state             state;
+
+	PHONGO_BSON_INIT_STATE(state);
 
 	intern = Z_COMMANDSTARTEDEVENT_OBJ_P(getThis());
 
@@ -204,7 +206,9 @@ static HashTable* php_phongo_commandstartedevent_get_debug_info(zval* object, in
 	php_phongo_commandstartedevent_t* intern;
 	zval                              retval = ZVAL_STATIC_INIT;
 	char                              operation_id[20], request_id[20];
-	php_phongo_bson_state             command_state = PHONGO_BSON_STATE_INITIALIZER;
+	php_phongo_bson_state             command_state;
+
+	PHONGO_BSON_INIT_STATE(command_state);
 
 	intern   = Z_COMMANDSTARTEDEVENT_OBJ_P(object);
 	*is_temp = 1;

--- a/src/MongoDB/Monitoring/CommandSucceededEvent.c
+++ b/src/MongoDB/Monitoring/CommandSucceededEvent.c
@@ -78,7 +78,9 @@ PHP_METHOD(CommandSucceededEvent, getOperationId)
 PHP_METHOD(CommandSucceededEvent, getReply)
 {
 	php_phongo_commandsucceededevent_t* intern;
-	php_phongo_bson_state               state = PHONGO_BSON_STATE_INITIALIZER;
+	php_phongo_bson_state               state;
+
+	PHONGO_BSON_INIT_STATE(state);
 
 	intern = Z_COMMANDSUCCEEDEDEVENT_OBJ_P(getThis());
 
@@ -201,7 +203,9 @@ static HashTable* php_phongo_commandsucceededevent_get_debug_info(zval* object, 
 	php_phongo_commandsucceededevent_t* intern;
 	zval                                retval = ZVAL_STATIC_INIT;
 	char                                operation_id[20], request_id[20];
-	php_phongo_bson_state               reply_state = PHONGO_BSON_STATE_INITIALIZER;
+	php_phongo_bson_state               reply_state;
+
+	PHONGO_BSON_INIT_STATE(reply_state);
 
 	intern   = Z_COMMANDSUCCEEDEDEVENT_OBJ_P(object);
 	*is_temp = 1;

--- a/src/MongoDB/ReadPreference.c
+++ b/src/MongoDB/ReadPreference.c
@@ -359,11 +359,9 @@ static PHP_METHOD(ReadPreference, getTagSets)
 	tags = mongoc_read_prefs_get_tags(intern->read_preference);
 
 	if (tags->len) {
-		php_phongo_bson_state state = PHONGO_BSON_STATE_INITIALIZER;
-		/* Use native arrays for debugging output */
-		state.map.root_type     = PHONGO_TYPEMAP_NATIVE_ARRAY;
-		state.map.document_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
+		php_phongo_bson_state state;
 
+		PHONGO_BSON_INIT_DEBUG_STATE(state);
 		php_phongo_bson_to_zval_ex(bson_get_data(tags), tags->len, &state);
 #if PHP_VERSION_ID >= 70000
 		RETURN_ZVAL(&state.zchild, 0, 1);
@@ -431,10 +429,12 @@ static HashTable* php_phongo_readpreference_get_properties_hash(zval* object, bo
 	}
 
 	if (!bson_empty0(tags)) {
+		php_phongo_bson_state state;
+
 		/* Use PHONGO_TYPEMAP_NATIVE_ARRAY for the root type since tags is an
 		 * array; however, inner documents and arrays can use the default. */
-		php_phongo_bson_state state = PHONGO_BSON_STATE_INITIALIZER;
-		state.map.root_type         = PHONGO_TYPEMAP_NATIVE_ARRAY;
+		PHONGO_BSON_INIT_STATE(state);
+		state.map.root_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
 
 		php_phongo_bson_to_zval_ex(bson_get_data(tags), tags->len, &state);
 #if PHP_VERSION_ID >= 70000
@@ -522,11 +522,9 @@ static PHP_METHOD(ReadPreference, serialize)
 	}
 
 	if (!bson_empty0(tags)) {
-		php_phongo_bson_state state = PHONGO_BSON_STATE_INITIALIZER;
-		/* Use native arrays for debugging output */
-		state.map.root_type     = PHONGO_TYPEMAP_NATIVE_ARRAY;
-		state.map.document_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
+		php_phongo_bson_state state;
 
+		PHONGO_BSON_INIT_DEBUG_STATE(state);
 		php_phongo_bson_to_zval_ex(bson_get_data(tags), tags->len, &state);
 #if PHP_VERSION_ID >= 70000
 		ADD_ASSOC_ZVAL_EX(&retval, "tags", &state.zchild);

--- a/src/MongoDB/Server.c
+++ b/src/MongoDB/Server.c
@@ -214,12 +214,11 @@ static PHP_METHOD(Server, getTags)
 		if (bson_iter_init_find(&iter, is_master, "tags") && BSON_ITER_HOLDS_DOCUMENT(&iter)) {
 			const uint8_t*        bytes;
 			uint32_t              len;
-			php_phongo_bson_state state = PHONGO_BSON_STATE_INITIALIZER;
+			php_phongo_bson_state state;
 
-			state.map.root_type     = PHONGO_TYPEMAP_NATIVE_ARRAY;
-			state.map.document_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
-
+			PHONGO_BSON_INIT_DEBUG_STATE(state);
 			bson_iter_document(&iter, &len, &bytes);
+
 			if (!php_phongo_bson_to_zval_ex(bytes, len, &state)) {
 				/* Exception should already have been thrown */
 				zval_ptr_dtor(&state.zchild);
@@ -259,10 +258,9 @@ static PHP_METHOD(Server, getInfo)
 
 	if ((sd = mongoc_client_get_server_description(intern->client, intern->server_id))) {
 		const bson_t*         is_master = mongoc_server_description_ismaster(sd);
-		php_phongo_bson_state state     = PHONGO_BSON_STATE_INITIALIZER;
+		php_phongo_bson_state state;
 
-		state.map.root_type     = PHONGO_TYPEMAP_NATIVE_ARRAY;
-		state.map.document_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
+		PHONGO_BSON_INIT_DEBUG_STATE(state);
 
 		if (!php_phongo_bson_to_zval_ex(bson_get_data(is_master), is_master->len, &state)) {
 			/* Exception should already have been thrown */

--- a/src/MongoDB/Session.c
+++ b/src/MongoDB/Session.c
@@ -150,7 +150,9 @@ static PHP_METHOD(Session, getClusterTime)
 {
 	php_phongo_session_t* intern;
 	const bson_t*         cluster_time;
-	php_phongo_bson_state state = PHONGO_BSON_STATE_INITIALIZER;
+	php_phongo_bson_state state;
+
+	PHONGO_BSON_INIT_STATE(state);
 
 	intern = Z_SESSION_OBJ_P(getThis());
 	SESSION_CHECK_LIVELINESS(intern, "getClusterTime")
@@ -184,7 +186,9 @@ static PHP_METHOD(Session, getLogicalSessionId)
 {
 	php_phongo_session_t* intern;
 	const bson_t*         lsid;
-	php_phongo_bson_state state = PHONGO_BSON_STATE_INITIALIZER;
+	php_phongo_bson_state state;
+
+	PHONGO_BSON_INIT_STATE(state);
 
 	intern = Z_SESSION_OBJ_P(getThis());
 	SESSION_CHECK_LIVELINESS(intern, "getLogicalSessionId")
@@ -550,11 +554,9 @@ static HashTable* php_phongo_session_get_debug_info(zval* object, int* is_temp T
 
 	if (intern->client_session) {
 		const bson_t* lsid;
+		php_phongo_bson_state state;
 
-		php_phongo_bson_state state = PHONGO_BSON_STATE_INITIALIZER;
-		/* Use native arrays for debugging output */
-		state.map.root_type     = PHONGO_TYPEMAP_NATIVE_ARRAY;
-		state.map.document_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
+		PHONGO_BSON_INIT_DEBUG_STATE(state);
 
 		lsid = mongoc_client_session_get_lsid(intern->client_session);
 
@@ -572,14 +574,12 @@ static HashTable* php_phongo_session_get_debug_info(zval* object, int* is_temp T
 	if (intern->client_session) {
 		const bson_t* cluster_time;
 
-		php_phongo_bson_state state = PHONGO_BSON_STATE_INITIALIZER;
-		/* Use native arrays for debugging output */
-		state.map.root_type     = PHONGO_TYPEMAP_NATIVE_ARRAY;
-		state.map.document_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
-
 		cluster_time = mongoc_client_session_get_cluster_time(intern->client_session);
 
 		if (cluster_time) {
+			php_phongo_bson_state state;
+
+			PHONGO_BSON_INIT_DEBUG_STATE(state);
 			php_phongo_bson_to_zval_ex(bson_get_data(cluster_time), cluster_time->len, &state);
 
 #if PHP_VERSION_ID >= 70000

--- a/src/MongoDB/WriteResult.c
+++ b/src/MongoDB/WriteResult.c
@@ -248,11 +248,12 @@ static PHP_METHOD(WriteResult, getUpsertedIds)
 	if (bson_iter_init_find(&iter, intern->reply, "upserted") && BSON_ITER_HOLDS_ARRAY(&iter) && bson_iter_recurse(&iter, &child)) {
 		while (bson_iter_next(&child)) {
 			uint32_t              data_len;
-			const uint8_t*        data  = NULL;
-			php_phongo_bson_state state = PHONGO_BSON_STATE_INITIALIZER;
+			const uint8_t*        data = NULL;
+			php_phongo_bson_state state;
 
 			/* Use PHONGO_TYPEMAP_NATIVE_ARRAY for the root type so we can
 			 * easily access the "index" and "_id" fields. */
+			PHONGO_BSON_INIT_STATE(state);
 			state.map.root_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
 
 			if (!BSON_ITER_HOLDS_DOCUMENT(&child)) {
@@ -420,12 +421,9 @@ static HashTable* php_phongo_writeresult_get_debug_info(zval* object, int* is_te
 	if (bson_iter_init_find(&iter, intern->reply, "upserted") && BSON_ITER_HOLDS_ARRAY(&iter)) {
 		uint32_t              len;
 		const uint8_t*        data;
-		php_phongo_bson_state state = PHONGO_BSON_STATE_INITIALIZER;
+		php_phongo_bson_state state;
 
-		/* Use native arrays for debugging output */
-		state.map.root_type     = PHONGO_TYPEMAP_NATIVE_ARRAY;
-		state.map.document_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
-
+		PHONGO_BSON_INIT_DEBUG_STATE(state);
 		bson_iter_array(&iter, &len, &data);
 		php_phongo_bson_to_zval_ex(data, len, &state);
 #if PHP_VERSION_ID >= 70000

--- a/src/bson.c
+++ b/src/bson.c
@@ -958,8 +958,9 @@ static bool php_phongo_bson_visit_document(const bson_iter_t* iter ARG_UNUSED, c
 	php_phongo_field_path_push(parent_state->field_path, key, PHONGO_FIELD_PATH_ITEM_DOCUMENT);
 
 	if (bson_iter_init(&child, v_document)) {
-		php_phongo_bson_state state = PHONGO_BSON_STATE_INITIALIZER;
+		php_phongo_bson_state state;
 
+		PHONGO_BSON_INIT_STATE(state);
 		php_phongo_bson_state_copy_ctor(&state, parent_state);
 
 #if PHP_VERSION_ID >= 70000
@@ -1069,8 +1070,9 @@ static bool php_phongo_bson_visit_array(const bson_iter_t* iter ARG_UNUSED, cons
 	php_phongo_field_path_push(parent_state->field_path, key, PHONGO_FIELD_PATH_ITEM_ARRAY);
 
 	if (bson_iter_init(&child, v_array)) {
-		php_phongo_bson_state state = PHONGO_BSON_STATE_INITIALIZER;
+		php_phongo_bson_state state;
 
+		PHONGO_BSON_INIT_STATE(state);
 		php_phongo_bson_state_copy_ctor(&state, parent_state);
 
 		/* Note that we are visiting an array, so element visitors know to use
@@ -1179,7 +1181,9 @@ bool php_phongo_bson_to_zval(const unsigned char* data, int data_len, zval** zv)
 #endif
 {
 	bool                  retval;
-	php_phongo_bson_state state = PHONGO_BSON_STATE_INITIALIZER;
+	php_phongo_bson_state state;
+
+	PHONGO_BSON_INIT_STATE(state);
 
 	retval = php_phongo_bson_to_zval_ex(data, data_len, &state);
 #if PHP_VERSION_ID >= 70000

--- a/tests/connect/bug0720.phpt
+++ b/tests/connect/bug0720.phpt
@@ -30,6 +30,9 @@ var_dump($cursor->toArray()[0]);
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+Deprecated: MongoDB\Driver\Manager::__construct(): The "allow_invalid_hostname" driver option is deprecated. Please use the "tlsAllowInvalidHostnames" URI option instead.%s
+
+Deprecated: MongoDB\Driver\Manager::__construct(): The "ca_file" driver option is deprecated. Please use the "tlsCAFile" URI option instead.%s
 object(stdClass)#%d (%d) {
   ["ok"]=>
   float(1)

--- a/tests/connect/standalone-ssl-no_verify-001.phpt
+++ b/tests/connect/standalone-ssl-no_verify-001.phpt
@@ -21,6 +21,9 @@ var_dump($cursor->toArray()[0]);
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+Deprecated: MongoDB\Driver\Manager::__construct(): The "allow_invalid_hostname" driver option is deprecated. Please use the "tlsAllowInvalidHostnames" URI option instead.%s
+
+Deprecated: MongoDB\Driver\Manager::__construct(): The "weak_cert_validation" driver option is deprecated. Please use the "tlsAllowInvalidCertificates" URI option instead.%s
 object(stdClass)#%d (%d) {
   ["ok"]=>
   float(1)

--- a/tests/connect/standalone-ssl-no_verify-002.phpt
+++ b/tests/connect/standalone-ssl-no_verify-002.phpt
@@ -25,6 +25,11 @@ var_dump($cursor->toArray()[0]);
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+Deprecated: MongoDB\Driver\Manager::__construct(): The "context" driver option is deprecated.%s
+
+Deprecated: MongoDB\Driver\Manager::__construct(): The "allow_invalid_hostname" driver option is deprecated. Please use the "tlsAllowInvalidHostnames" URI option instead.%s
+
+Deprecated: MongoDB\Driver\Manager::__construct(): The "allow_self_signed" context driver option is deprecated. Please use the "tlsAllowInvalidCertificates" URI option instead.%s
 object(stdClass)#%d (%d) {
   ["ok"]=>
   float(1)

--- a/tests/connect/standalone-ssl-verify_cert-001.phpt
+++ b/tests/connect/standalone-ssl-verify_cert-001.phpt
@@ -25,6 +25,11 @@ var_dump($cursor->toArray()[0]);
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+Deprecated: MongoDB\Driver\Manager::__construct(): The "allow_invalid_hostname" driver option is deprecated. Please use the "tlsAllowInvalidHostnames" URI option instead.%s
+
+Deprecated: MongoDB\Driver\Manager::__construct(): The "weak_cert_validation" driver option is deprecated. Please use the "tlsAllowInvalidCertificates" URI option instead.%s
+
+Deprecated: MongoDB\Driver\Manager::__construct(): The "ca_file" driver option is deprecated. Please use the "tlsCAFile" URI option instead.%s
 object(stdClass)#%d (%d) {
   ["ok"]=>
   float(1)

--- a/tests/connect/standalone-ssl-verify_cert-002.phpt
+++ b/tests/connect/standalone-ssl-verify_cert-002.phpt
@@ -29,6 +29,13 @@ var_dump($cursor->toArray()[0]);
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+Deprecated: MongoDB\Driver\Manager::__construct(): The "context" driver option is deprecated.%s
+
+Deprecated: MongoDB\Driver\Manager::__construct(): The "allow_invalid_hostname" driver option is deprecated. Please use the "tlsAllowInvalidHostnames" URI option instead.%s
+
+Deprecated: MongoDB\Driver\Manager::__construct(): The "allow_self_signed" context driver option is deprecated. Please use the "tlsAllowInvalidCertificates" URI option instead.%s
+
+Deprecated: MongoDB\Driver\Manager::__construct(): The "cafile" context driver option is deprecated. Please use the "tlsCAFile" URI option instead.%s
 object(stdClass)#%d (%d) {
   ["ok"]=>
   float(1)

--- a/tests/connect/standalone-ssl-verify_cert-error-001.phpt
+++ b/tests/connect/standalone-ssl-verify_cert-error-001.phpt
@@ -24,6 +24,9 @@ echo throws(function() use ($driverOptions) {
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+Deprecated: MongoDB\Driver\Manager::__construct(): The "allow_invalid_hostname" driver option is deprecated. Please use the "tlsAllowInvalidHostnames" URI option instead.%s
+
+Deprecated: MongoDB\Driver\Manager::__construct(): The "weak_cert_validation" driver option is deprecated. Please use the "tlsAllowInvalidCertificates" URI option instead.%s
 OK: Got MongoDB\Driver\Exception\ConnectionTimeoutException thrown from executeCommand
 No suitable servers found (`serverSelectionTryOnce` set): [%s calling ismaster on '%s:%d']
 ===DONE===

--- a/tests/connect/standalone-ssl-verify_cert-error-002.phpt
+++ b/tests/connect/standalone-ssl-verify_cert-error-002.phpt
@@ -28,6 +28,11 @@ echo throws(function() use ($driverOptions) {
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+Deprecated: MongoDB\Driver\Manager::__construct(): The "context" driver option is deprecated.%s
+
+Deprecated: MongoDB\Driver\Manager::__construct(): The "allow_invalid_hostname" driver option is deprecated. Please use the "tlsAllowInvalidHostnames" URI option instead.%s
+
+Deprecated: MongoDB\Driver\Manager::__construct(): The "allow_self_signed" context driver option is deprecated. Please use the "tlsAllowInvalidCertificates" URI option instead.%s
 OK: Got MongoDB\Driver\Exception\ConnectionTimeoutException thrown from executeCommand
 No suitable servers found (`serverSelectionTryOnce` set): [%s calling ismaster on '%s:%d']
 ===DONE===

--- a/tests/manager/bug0572.phpt
+++ b/tests/manager/bug0572.phpt
@@ -27,6 +27,9 @@ var_dump($cursor->toArray()[0]);
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+Deprecated: MongoDB\Driver\Manager::__construct(): The "context" driver option is deprecated.%s
+
+Deprecated: MongoDB\Driver\Manager::__construct(): The "allow_self_signed" context driver option is deprecated. Please use the "tlsAllowInvalidCertificates" URI option instead.%s
 object(stdClass)#%d (%d) {
   ["ok"]=>
   float(1)

--- a/tests/manager/bug0851-002.phpt
+++ b/tests/manager/bug0851-002.phpt
@@ -18,7 +18,10 @@ var_dump($driverOptions);
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECT--
+--EXPECTF--
+Deprecated: MongoDB\Driver\Manager::__construct(): The "context" driver option is deprecated.%s
+
+Deprecated: MongoDB\Driver\Manager::__construct(): The "weak_cert_validation" driver option is deprecated. Please use the "tlsAllowInvalidCertificates" URI option instead.%s
 array(2) {
   ["weak_cert_validation"]=>
   bool(true)

--- a/tests/manager/bug0940-001.phpt
+++ b/tests/manager/bug0940-001.phpt
@@ -12,6 +12,7 @@ var_dump(new MongoDB\Driver\Manager(null, [], ['ca_file' => false]));
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+Deprecated: MongoDB\Driver\Manager::__construct(): The "ca_file" driver option is deprecated. Please use the "tlsCAFile" URI option instead.%s
 object(MongoDB\Driver\Manager)#%d (%d) {
   ["uri"]=>
   string(20) "mongodb://127.0.0.1/"

--- a/tests/manager/bug0940-002.phpt
+++ b/tests/manager/bug0940-002.phpt
@@ -14,6 +14,9 @@ var_dump(new MongoDB\Driver\Manager(null, [], ['context' => $context]));
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+Deprecated: MongoDB\Driver\Manager::__construct(): The "context" driver option is deprecated.%s
+
+Deprecated: MongoDB\Driver\Manager::__construct(): The "cafile" context driver option is deprecated. Please use the "tlsCAFile" URI option instead.%s
 object(MongoDB\Driver\Manager)#%d (%d) {
   ["uri"]=>
   string(20) "mongodb://127.0.0.1/"

--- a/tests/manager/manager-ctor-ssl-deprecated-001.phpt
+++ b/tests/manager/manager-ctor-ssl-deprecated-001.phpt
@@ -1,0 +1,67 @@
+--TEST--
+MongoDB\Driver\Manager::__construct(): Test deprecated options
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_not_libmongoc_ssl(); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$deprecatedDriverOptions = [
+    ['allow_invalid_hostname' => true],
+    ['weak_cert_validation' => true],
+    ['allow_self_signed' => true],
+    ['pem_file' => 'foo'],
+    ['local_cert' => 'foo'],
+    ['pem_pwd' => 'foo'],
+    ['passphrase' => 'foo'],
+    ['ca_file' => 'foo'],
+    ['cafile' => 'foo'],
+    ['context' => stream_context_create(['ssl' => ['cafile' => 'foo']])],
+    ['context' => stream_context_create(['ssl' => ['capath' => 'foo']])],
+    ['context' => stream_context_create(['ssl' => ['local_cert' => 'foo']])],
+    ['context' => stream_context_create(['ssl' => ['passphrase' => 'foo']])],
+    ['context' => stream_context_create(['ssl' => ['allow_self_signed' => true]])],
+];
+
+foreach ($deprecatedDriverOptions as $driverOptions) {
+    echo raises(
+        function () use ($driverOptions) {
+            new MongoDB\Driver\Manager('mongodb://127.0.0.1/', [], $driverOptions);
+        },
+        E_DEPRECATED
+    ), "\n";
+}
+
+?>
+===DONE===
+--EXPECT--
+OK: Got E_DEPRECATED
+MongoDB\Driver\Manager::__construct(): The "allow_invalid_hostname" driver option is deprecated. Please use the "tlsAllowInvalidHostnames" URI option instead.
+OK: Got E_DEPRECATED
+MongoDB\Driver\Manager::__construct(): The "weak_cert_validation" driver option is deprecated. Please use the "tlsAllowInvalidCertificates" URI option instead.
+OK: Got E_DEPRECATED
+MongoDB\Driver\Manager::__construct(): The "allow_self_signed" context driver option is deprecated. Please use the "tlsAllowInvalidCertificates" URI option instead.
+OK: Got E_DEPRECATED
+MongoDB\Driver\Manager::__construct(): The "pem_file" driver option is deprecated. Please use the "tlsCertificateKeyFile" URI option instead.
+OK: Got E_DEPRECATED
+MongoDB\Driver\Manager::__construct(): The "local_cert" context driver option is deprecated. Please use the "tlsCertificateKeyFile" URI option instead.
+OK: Got E_DEPRECATED
+MongoDB\Driver\Manager::__construct(): The "pem_pwd" driver option is deprecated. Please use the "tlsCertificateKeyFilePassword" URI option instead.
+OK: Got E_DEPRECATED
+MongoDB\Driver\Manager::__construct(): The "passphrase" context driver option is deprecated. Please use the "tlsCertificateKeyFilePassword" URI option instead.
+OK: Got E_DEPRECATED
+MongoDB\Driver\Manager::__construct(): The "ca_file" driver option is deprecated. Please use the "tlsCAFile" URI option instead.
+OK: Got E_DEPRECATED
+MongoDB\Driver\Manager::__construct(): The "cafile" context driver option is deprecated. Please use the "tlsCAFile" URI option instead.
+OK: Got E_DEPRECATED
+MongoDB\Driver\Manager::__construct(): The "context" driver option is deprecated.
+OK: Got E_DEPRECATED
+MongoDB\Driver\Manager::__construct(): The "context" driver option is deprecated.
+OK: Got E_DEPRECATED
+MongoDB\Driver\Manager::__construct(): The "context" driver option is deprecated.
+OK: Got E_DEPRECATED
+MongoDB\Driver\Manager::__construct(): The "context" driver option is deprecated.
+OK: Got E_DEPRECATED
+MongoDB\Driver\Manager::__construct(): The "context" driver option is deprecated.
+===DONE===

--- a/tests/manager/manager-ctor-ssl-deprecated-002.phpt
+++ b/tests/manager/manager-ctor-ssl-deprecated-002.phpt
@@ -1,0 +1,31 @@
+--TEST--
+MongoDB\Driver\Manager::__construct(): Test deprecated options (capath)
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_not_libmongoc_ssl(['OpenSSL', 'LibreSSL']); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+echo raises(
+    function () {
+        new MongoDB\Driver\Manager('mongodb://127.0.0.1/', [], ['capath' => 'foo']);
+    },
+    E_DEPRECATED
+), "\n";
+
+echo raises(
+    function () {
+        new MongoDB\Driver\Manager('mongodb://127.0.0.1/', [], ['context' => stream_context_create(['ssl' => ['capath' => 'foo']])]);
+    },
+    E_DEPRECATED
+), "\n";
+
+?>
+===DONE===
+--EXPECT--
+OK: Got E_DEPRECATED
+MongoDB\Driver\Manager::__construct(): The "capath" context driver option is deprecated. Please use the "ca_dir" driver option instead.
+OK: Got E_DEPRECATED
+MongoDB\Driver\Manager::__construct(): The "context" driver option is deprecated.
+===DONE===

--- a/tests/manager/manager-set-uri-options-002.phpt
+++ b/tests/manager/manager-set-uri-options-002.phpt
@@ -46,7 +46,14 @@ printf("Inserted: %d\n", $inserted);
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+Deprecated: MongoDB\Driver\Manager::__construct(): The "context" driver option is deprecated.%s
+
+Deprecated: MongoDB\Driver\Manager::__construct(): The "allow_self_signed" context driver option is deprecated. Please use the "tlsAllowInvalidCertificates" URI option instead.%s
 OK: Got MongoDB\Driver\Exception\ConnectionTimeoutException
 No suitable servers found (`serverSelectionTryOnce` set): [%scalling ismaster on '%s']
+
+Deprecated: MongoDB\Driver\Manager::__construct(): The "context" driver option is deprecated.%s
+
+Deprecated: MongoDB\Driver\Manager::__construct(): The "allow_self_signed" context driver option is deprecated. Please use the "tlsAllowInvalidCertificates" URI option instead.%s
 Inserted: 1
 ===DONE===

--- a/tests/manager/manager-set-uri-options-003.phpt
+++ b/tests/manager/manager-set-uri-options-003.phpt
@@ -17,4 +17,5 @@ $manager = new MongoDB\Driver\Manager(URI . '&sslclientcertificatekeypassword=do
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+Deprecated: MongoDB\Driver\Manager::__construct(): The "pem_pwd" driver option is deprecated. Please use the "tlsCertificateKeyFilePassword" URI option instead.%s
 ===DONE===

--- a/tests/utils/tools.php
+++ b/tests/utils/tools.php
@@ -545,6 +545,8 @@ function destroyTemporaryMongoInstance($id = NULL)
 
 function severityToString($type) {
     switch($type) {
+    case E_DEPRECATED:
+        return "E_DEPRECATED";
     case E_RECOVERABLE_ERROR:
         return "E_RECOVERABLE_ERROR";
     case E_WARNING:


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1074

I opted for the separate macro approach to convey that this is purely for debug purposes. For other purposes (there are a couple of instances where we change the `root_type` in the type map), it is still preferred to initialise the default state and update the type map manually.