### PR TITLE
PHPC-348: Check for errors after calling bson_to_zval()

### DIFF
--- a/src/BSON/Javascript.c
+++ b/src/BSON/Javascript.c
@@ -180,7 +180,12 @@ static PHP_METHOD(Javascript, getScope)
 		php_phongo_bson_state state;
 
 		PHONGO_BSON_INIT_STATE(state);
-		php_phongo_bson_to_zval_ex(bson_get_data(intern->scope), intern->scope->len, &state);
+
+		if (!php_phongo_bson_to_zval_ex(bson_get_data(intern->scope), intern->scope->len, &state)) {
+			zval_ptr_dtor(&state.zchild);
+			return;
+		}
+
 #if PHP_VERSION_ID >= 70000
 		RETURN_ZVAL(&state.zchild, 0, 1);
 #else

--- a/src/MongoDB/Command.c
+++ b/src/MongoDB/Command.c
@@ -194,7 +194,11 @@ static HashTable* php_phongo_command_get_debug_info(zval* object, int* is_temp T
 		zval* zv;
 #endif
 
-		php_phongo_bson_to_zval(bson_get_data(intern->bson), intern->bson->len, &zv);
+		if (!php_phongo_bson_to_zval(bson_get_data(intern->bson), intern->bson->len, &zv)) {
+			zval_ptr_dtor(&zv);
+			goto done;
+		}
+
 #if PHP_VERSION_ID >= 70000
 		ADD_ASSOC_ZVAL_EX(&retval, "command", &zv);
 #else
@@ -204,6 +208,7 @@ static HashTable* php_phongo_command_get_debug_info(zval* object, int* is_temp T
 		ADD_ASSOC_NULL_EX(&retval, "command");
 	}
 
+done:
 	return Z_ARRVAL(retval);
 
 } /* }}} */

--- a/src/MongoDB/Monitoring/CommandStartedEvent.c
+++ b/src/MongoDB/Monitoring/CommandStartedEvent.c
@@ -41,7 +41,11 @@ PHP_METHOD(CommandStartedEvent, getCommand)
 		return;
 	}
 
-	php_phongo_bson_to_zval_ex(bson_get_data(intern->command), intern->command->len, &state);
+	if (!php_phongo_bson_to_zval_ex(bson_get_data(intern->command), intern->command->len, &state)) {
+		zval_ptr_dtor(&state.zchild);
+		return;
+	}
+
 #if PHP_VERSION_ID >= 70000
 	RETURN_ZVAL(&state.zchild, 0, 1);
 #else
@@ -214,7 +218,11 @@ static HashTable* php_phongo_commandstartedevent_get_debug_info(zval* object, in
 	*is_temp = 1;
 	array_init_size(&retval, 6);
 
-	php_phongo_bson_to_zval_ex(bson_get_data(intern->command), intern->command->len, &command_state);
+	if (!php_phongo_bson_to_zval_ex(bson_get_data(intern->command), intern->command->len, &command_state)) {
+		zval_ptr_dtor(&command_state.zchild);
+		goto done;
+	}
+
 #if PHP_VERSION_ID >= 70000
 	ADD_ASSOC_ZVAL(&retval, "command", &command_state.zchild);
 #else
@@ -245,6 +253,7 @@ static HashTable* php_phongo_commandstartedevent_get_debug_info(zval* object, in
 #endif
 	}
 
+done:
 	return Z_ARRVAL(retval);
 } /* }}} */
 /* }}} */

--- a/src/MongoDB/Query.c
+++ b/src/MongoDB/Query.c
@@ -455,7 +455,11 @@ static HashTable* php_phongo_query_get_debug_info(zval* object, int* is_temp TSR
 		zval* zv;
 #endif
 
-		php_phongo_bson_to_zval(bson_get_data(intern->filter), intern->filter->len, &zv);
+		if (!php_phongo_bson_to_zval(bson_get_data(intern->filter), intern->filter->len, &zv)) {
+			zval_ptr_dtor(&zv);
+			goto done;
+		}
+
 #if PHP_VERSION_ID >= 70000
 		ADD_ASSOC_ZVAL_EX(&retval, "filter", &zv);
 #else
@@ -472,7 +476,11 @@ static HashTable* php_phongo_query_get_debug_info(zval* object, int* is_temp TSR
 		zval* zv;
 #endif
 
-		php_phongo_bson_to_zval(bson_get_data(intern->opts), intern->opts->len, &zv);
+		if (!php_phongo_bson_to_zval(bson_get_data(intern->opts), intern->opts->len, &zv)) {
+			zval_ptr_dtor(&zv);
+			goto done;
+		}
+
 #if PHP_VERSION_ID >= 70000
 		ADD_ASSOC_ZVAL_EX(&retval, "options", &zv);
 #else
@@ -499,6 +507,7 @@ static HashTable* php_phongo_query_get_debug_info(zval* object, int* is_temp TSR
 		ADD_ASSOC_NULL_EX(&retval, "readConcern");
 	}
 
+done:
 	return Z_ARRVAL(retval);
 
 } /* }}} */

--- a/src/MongoDB/Session.c
+++ b/src/MongoDB/Session.c
@@ -560,7 +560,10 @@ static HashTable* php_phongo_session_get_debug_info(zval* object, int* is_temp T
 
 		lsid = mongoc_client_session_get_lsid(intern->client_session);
 
-		php_phongo_bson_to_zval_ex(bson_get_data(lsid), lsid->len, &state);
+		if (!php_phongo_bson_to_zval_ex(bson_get_data(lsid), lsid->len, &state)) {
+			zval_ptr_dtor(&state.zchild);
+			goto done;
+		}
 
 #if PHP_VERSION_ID >= 70000
 		ADD_ASSOC_ZVAL_EX(&retval, "logicalSessionId", &state.zchild);
@@ -580,7 +583,11 @@ static HashTable* php_phongo_session_get_debug_info(zval* object, int* is_temp T
 			php_phongo_bson_state state;
 
 			PHONGO_BSON_INIT_DEBUG_STATE(state);
-			php_phongo_bson_to_zval_ex(bson_get_data(cluster_time), cluster_time->len, &state);
+
+			if (!php_phongo_bson_to_zval_ex(bson_get_data(cluster_time), cluster_time->len, &state)) {
+				zval_ptr_dtor(&state.zchild);
+				goto done;
+			}
 
 #if PHP_VERSION_ID >= 70000
 			ADD_ASSOC_ZVAL_EX(&retval, "clusterTime", &state.zchild);
@@ -650,6 +657,7 @@ static HashTable* php_phongo_session_get_debug_info(zval* object, int* is_temp T
 		ADD_ASSOC_NULL_EX(&retval, "server");
 	}
 
+done:
 	return Z_ARRVAL(retval);
 } /* }}} */
 /* }}} */

--- a/src/MongoDB/WriteResult.c
+++ b/src/MongoDB/WriteResult.c
@@ -425,7 +425,11 @@ static HashTable* php_phongo_writeresult_get_debug_info(zval* object, int* is_te
 
 		PHONGO_BSON_INIT_DEBUG_STATE(state);
 		bson_iter_array(&iter, &len, &data);
-		php_phongo_bson_to_zval_ex(data, len, &state);
+		if (!php_phongo_bson_to_zval_ex(data, len, &state)) {
+			zval_ptr_dtor(&state.zchild);
+			goto done;
+		}
+
 #if PHP_VERSION_ID >= 70000
 		ADD_ASSOC_ZVAL_EX(&retval, "upsertedIds", &state.zchild);
 #else
@@ -491,6 +495,7 @@ static HashTable* php_phongo_writeresult_get_debug_info(zval* object, int* is_te
 		ADD_ASSOC_NULL_EX(&retval, "writeConcern");
 	}
 
+done:
 	return Z_ARRVAL(retval);
 } /* }}} */
 /* }}} */


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-348

Note: there are three occurrences of `php_phongo_bson_to_zval_ex` in `Cursor.c` ([1](https://github.com/mongodb/mongo-php-driver/blob/987fa38d7f0631bae407f122664e706b6593712f/src/MongoDB/Cursor.c#L126), [2](https://github.com/mongodb/mongo-php-driver/blob/987fa38d7f0631bae407f122664e706b6593712f/src/MongoDB/Cursor.c#L167), [3](https://github.com/mongodb/mongo-php-driver/blob/987fa38d7f0631bae407f122664e706b6593712f/src/MongoDB/Cursor.c#L255)) where I wasn't sure if freeing the result was a good idea.

When used in the `debug_info` functions, I thought it was best to add `null` values and continue assembling the output, but we may want to return without processing any further properties. I'm not quite sure what the preferred course of action is.