### PR TITLE
PHPC-1430: Deprecate obsolete driver options

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -37,6 +37,16 @@ functions:
         working_dir: "src"
         script: |
            git submodule update --init
+    # Switch to a different version of libmongoc
+    - command: shell.exec
+      params:
+        working_dir: "src/src/libmongoc"
+        script: |
+           if [ -n "$LIBMONGOC_VERSION" ]; then
+              git fetch
+              git checkout $LIBMONGOC_VERSION
+              ../../build/calc_release_version.py
+           fi
     # Applies the submitted patch, if any
     # Deprecated. Should be removed. But still needed for certain agents (ZAP)
     - command: git.apply_patch
@@ -668,6 +678,18 @@ axes:
         variables:
            STORAGE_ENGINE: "inmemory"
 
+  - id: libmongoc-version
+    display_name: libmongoc version
+    values:
+      - id: "1.15-latest"
+        display_name: "1.15 latest"
+        variables:
+          LIBMONGOC_VERSION: "r1.15"
+      - id: "master"
+        display_name: "Upcoming release (master)"
+        variables:
+          LIBMONGOC_VERSION: "master"
+
 
 buildvariants:
 
@@ -772,3 +794,11 @@ buildvariants:
   display_name: "${versions}/${php-versions}/${os-php7} — ${storage-engine}"
   tasks:
      - name: "test-standalone"
+
+- matrix_name: "libmongoc-versions-php7"
+  matrix_spec: {"os-php7": "debian92-test", "versions": "4.2", "php-versions": "7.2", "libmongoc-version": "*"}
+  display_name: "${versions}/${php-versions}/${os-php7} — libmongoc ${libmongoc-version}"
+  tasks:
+     - name: "test-standalone"
+     - name: "test-replicaset"
+     - name: "test-sharded-rs"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -229,6 +229,16 @@ if $PKG_CONFIG libmongoc-1.0 --atleast-version 1.15.0; then
 AC_MSG_ERROR(system libmongoc must be upgraded to version >= 1.15.0)
 ```
 
+### Update tested versions in evergreen configuration
+
+Evergreen tests against multiple versions of libmongoc. When updating to a newer
+libmongoc version, make sure to update the `libmongoc-version` build axis in
+`.evergreen/config.yml`. In general, we test against two additional versions of
+libmongoc:
+- The upcoming patch release of the current libmongoc minor version (e.g. the
+  `r1.x` branch)
+- The upcoming minor release of libmongoc (e.g. the `master` branch)
+
 ### Update sources in PECL package generation script
 
 If either libmongoc or libbson introduce a new source directory, that may also

--- a/php_phongo.c
+++ b/php_phongo.c
@@ -2149,6 +2149,8 @@ static mongoc_ssl_opt_t* php_phongo_make_ssl_opt(mongoc_uri_t* uri, zval* zoptio
 	} else if (php_array_existsc(zoptions, "capath")) {
 		PHONGO_SSL_OPTION_SWAP_STRING(ssl_opt->ca_dir, "capath");
 		any_ssl_option_set = true;
+
+		php_error_docref(NULL TSRMLS_CC, E_DEPRECATED, "The \"capath\" context driver option is deprecated. Please use the \"ca_dir\" driver option instead.");
 	}
 
 	if (php_array_existsc(zoptions, "crl_file")) {
@@ -2216,6 +2218,8 @@ static bool php_phongo_apply_driver_options_to_uri(mongoc_uri_t* uri, zval* zopt
 
 			return false;
 		}
+
+		php_error_docref(NULL TSRMLS_CC, E_DEPRECATED, "The \"allow_invalid_hostname\" driver option is deprecated. Please use the \"tlsAllowInvalidHostnames\" URI option instead.");
 	}
 
 	if (php_array_existsc(zoptions, "weak_cert_validation")) {
@@ -2224,12 +2228,16 @@ static bool php_phongo_apply_driver_options_to_uri(mongoc_uri_t* uri, zval* zopt
 
 			return false;
 		}
+
+		php_error_docref(NULL TSRMLS_CC, E_DEPRECATED, "The \"weak_cert_validation\" driver option is deprecated. Please use the \"tlsAllowInvalidCertificates\" URI option instead.");
 	} else if (php_array_existsc(zoptions, "allow_self_signed")) {
 		if (!mongoc_uri_set_option_as_bool(uri, MONGOC_URI_TLSALLOWINVALIDCERTIFICATES, php_array_fetchc_bool(zoptions, "allow_self_signed"))) {
 			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Failed to parse \"%s\" driver option", "allow_self_signed");
 
 			return false;
 		}
+
+		php_error_docref(NULL TSRMLS_CC, E_DEPRECATED, "The \"allow_self_signed\" context driver option is deprecated. Please use the \"tlsAllowInvalidCertificates\" URI option instead.");
 	}
 
 	if (php_array_existsc(zoptions, "pem_file")) {
@@ -2238,12 +2246,16 @@ static bool php_phongo_apply_driver_options_to_uri(mongoc_uri_t* uri, zval* zopt
 
 			return false;
 		}
+
+		php_error_docref(NULL TSRMLS_CC, E_DEPRECATED, "The \"pem_file\" driver option is deprecated. Please use the \"tlsCertificateKeyFile\" URI option instead.");
 	} else if (php_array_existsc(zoptions, "local_cert")) {
 		if (!php_phongo_apply_driver_option_to_uri(uri, zoptions, "local_cert", MONGOC_URI_TLSCERTIFICATEKEYFILE)) {
 			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Failed to parse \"%s\" driver option", "local_cert");
 
 			return false;
 		}
+
+		php_error_docref(NULL TSRMLS_CC, E_DEPRECATED, "The \"local_cert\" context driver option is deprecated. Please use the \"tlsCertificateKeyFile\" URI option instead.");
 	}
 
 	if (php_array_existsc(zoptions, "pem_pwd")) {
@@ -2252,12 +2264,16 @@ static bool php_phongo_apply_driver_options_to_uri(mongoc_uri_t* uri, zval* zopt
 
 			return false;
 		}
+
+		php_error_docref(NULL TSRMLS_CC, E_DEPRECATED, "The \"pem_pwd\" driver option is deprecated. Please use the \"tlsCertificateKeyFilePassword\" URI option instead.");
 	} else if (php_array_existsc(zoptions, "passphrase")) {
 		if (!php_phongo_apply_driver_option_to_uri(uri, zoptions, "passphrase", MONGOC_URI_TLSCERTIFICATEKEYFILEPASSWORD)) {
 			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Failed to parse \"%s\" driver option", "passphrase");
 
 			return false;
 		}
+
+		php_error_docref(NULL TSRMLS_CC, E_DEPRECATED, "The \"passphrase\" context driver option is deprecated. Please use the \"tlsCertificateKeyFilePassword\" URI option instead.");
 	}
 
 	if (php_array_existsc(zoptions, "ca_file")) {
@@ -2266,12 +2282,16 @@ static bool php_phongo_apply_driver_options_to_uri(mongoc_uri_t* uri, zval* zopt
 
 			return false;
 		}
+
+		php_error_docref(NULL TSRMLS_CC, E_DEPRECATED, "The \"ca_file\" driver option is deprecated. Please use the \"tlsCAFile\" URI option instead.");
 	} else if (php_array_existsc(zoptions, "cafile")) {
 		if (!php_phongo_apply_driver_option_to_uri(uri, zoptions, "cafile", MONGOC_URI_TLSCAFILE)) {
 			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Failed to parse \"%s\" driver option", "cafile");
 
 			return false;
 		}
+
+		php_error_docref(NULL TSRMLS_CC, E_DEPRECATED, "The \"cafile\" context driver option is deprecated. Please use the \"tlsCAFile\" URI option instead.");
 	}
 
 	return true;

--- a/src/MongoDB/Manager.c
+++ b/src/MongoDB/Manager.c
@@ -79,6 +79,16 @@ static bool php_phongo_manager_merge_context_options(zval* zdriverOptions TSRMLS
 		return false;
 	}
 
+	/* When running PHP in debug mode, php_error_docref duplicates the current
+	 * scope, leading to a COW violation in zend_hash_merge and
+	 * zend_symtable_str_del (called by php_array_unsetc). This macro allows
+	 * that violation in debug mode and is a NOOP when in non-debug. */
+#if PHP_VERSION_ID >= 70200
+	HT_ALLOW_COW_VIOLATION(Z_ARRVAL_P(zdriverOptions));
+#endif
+
+	php_error_docref(NULL TSRMLS_CC, E_DEPRECATED, "The \"context\" driver option is deprecated.");
+
 	/* Perform array union (see: add_function() in zend_operators.c) */
 #if PHP_VERSION_ID >= 70000
 	zend_hash_merge(Z_ARRVAL_P(zdriverOptions), Z_ARRVAL_P(zcontextOptions), zval_add_ref, 0);
@@ -90,6 +100,7 @@ static bool php_phongo_manager_merge_context_options(zval* zdriverOptions TSRMLS
 #endif
 
 	php_array_unsetc(zdriverOptions, "context");
+
 	return true;
 } /* }}} */
 

--- a/tests/connect/bug0720.phpt
+++ b/tests/connect/bug0720.phpt
@@ -30,6 +30,9 @@ var_dump($cursor->toArray()[0]);
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+Deprecated: MongoDB\Driver\Manager::__construct(): The "allow_invalid_hostname" driver option is deprecated. Please use the "tlsAllowInvalidHostnames" URI option instead.%s
+
+Deprecated: MongoDB\Driver\Manager::__construct(): The "ca_file" driver option is deprecated. Please use the "tlsCAFile" URI option instead.%s
 object(stdClass)#%d (%d) {
   ["ok"]=>
   float(1)

--- a/tests/connect/standalone-ssl-no_verify-001.phpt
+++ b/tests/connect/standalone-ssl-no_verify-001.phpt
@@ -21,6 +21,9 @@ var_dump($cursor->toArray()[0]);
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+Deprecated: MongoDB\Driver\Manager::__construct(): The "allow_invalid_hostname" driver option is deprecated. Please use the "tlsAllowInvalidHostnames" URI option instead.%s
+
+Deprecated: MongoDB\Driver\Manager::__construct(): The "weak_cert_validation" driver option is deprecated. Please use the "tlsAllowInvalidCertificates" URI option instead.%s
 object(stdClass)#%d (%d) {
   ["ok"]=>
   float(1)

--- a/tests/connect/standalone-ssl-no_verify-002.phpt
+++ b/tests/connect/standalone-ssl-no_verify-002.phpt
@@ -25,6 +25,11 @@ var_dump($cursor->toArray()[0]);
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+Deprecated: MongoDB\Driver\Manager::__construct(): The "context" driver option is deprecated.%s
+
+Deprecated: MongoDB\Driver\Manager::__construct(): The "allow_invalid_hostname" driver option is deprecated. Please use the "tlsAllowInvalidHostnames" URI option instead.%s
+
+Deprecated: MongoDB\Driver\Manager::__construct(): The "allow_self_signed" context driver option is deprecated. Please use the "tlsAllowInvalidCertificates" URI option instead.%s
 object(stdClass)#%d (%d) {
   ["ok"]=>
   float(1)

--- a/tests/connect/standalone-ssl-verify_cert-001.phpt
+++ b/tests/connect/standalone-ssl-verify_cert-001.phpt
@@ -25,6 +25,11 @@ var_dump($cursor->toArray()[0]);
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+Deprecated: MongoDB\Driver\Manager::__construct(): The "allow_invalid_hostname" driver option is deprecated. Please use the "tlsAllowInvalidHostnames" URI option instead.%s
+
+Deprecated: MongoDB\Driver\Manager::__construct(): The "weak_cert_validation" driver option is deprecated. Please use the "tlsAllowInvalidCertificates" URI option instead.%s
+
+Deprecated: MongoDB\Driver\Manager::__construct(): The "ca_file" driver option is deprecated. Please use the "tlsCAFile" URI option instead.%s
 object(stdClass)#%d (%d) {
   ["ok"]=>
   float(1)

--- a/tests/connect/standalone-ssl-verify_cert-002.phpt
+++ b/tests/connect/standalone-ssl-verify_cert-002.phpt
@@ -29,6 +29,13 @@ var_dump($cursor->toArray()[0]);
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+Deprecated: MongoDB\Driver\Manager::__construct(): The "context" driver option is deprecated.%s
+
+Deprecated: MongoDB\Driver\Manager::__construct(): The "allow_invalid_hostname" driver option is deprecated. Please use the "tlsAllowInvalidHostnames" URI option instead.%s
+
+Deprecated: MongoDB\Driver\Manager::__construct(): The "allow_self_signed" context driver option is deprecated. Please use the "tlsAllowInvalidCertificates" URI option instead.%s
+
+Deprecated: MongoDB\Driver\Manager::__construct(): The "cafile" context driver option is deprecated. Please use the "tlsCAFile" URI option instead.%s
 object(stdClass)#%d (%d) {
   ["ok"]=>
   float(1)

--- a/tests/connect/standalone-ssl-verify_cert-error-001.phpt
+++ b/tests/connect/standalone-ssl-verify_cert-error-001.phpt
@@ -24,6 +24,9 @@ echo throws(function() use ($driverOptions) {
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+Deprecated: MongoDB\Driver\Manager::__construct(): The "allow_invalid_hostname" driver option is deprecated. Please use the "tlsAllowInvalidHostnames" URI option instead.%s
+
+Deprecated: MongoDB\Driver\Manager::__construct(): The "weak_cert_validation" driver option is deprecated. Please use the "tlsAllowInvalidCertificates" URI option instead.%s
 OK: Got MongoDB\Driver\Exception\ConnectionTimeoutException thrown from executeCommand
 No suitable servers found (`serverSelectionTryOnce` set): [%s calling ismaster on '%s:%d']
 ===DONE===

--- a/tests/connect/standalone-ssl-verify_cert-error-002.phpt
+++ b/tests/connect/standalone-ssl-verify_cert-error-002.phpt
@@ -28,6 +28,11 @@ echo throws(function() use ($driverOptions) {
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+Deprecated: MongoDB\Driver\Manager::__construct(): The "context" driver option is deprecated.%s
+
+Deprecated: MongoDB\Driver\Manager::__construct(): The "allow_invalid_hostname" driver option is deprecated. Please use the "tlsAllowInvalidHostnames" URI option instead.%s
+
+Deprecated: MongoDB\Driver\Manager::__construct(): The "allow_self_signed" context driver option is deprecated. Please use the "tlsAllowInvalidCertificates" URI option instead.%s
 OK: Got MongoDB\Driver\Exception\ConnectionTimeoutException thrown from executeCommand
 No suitable servers found (`serverSelectionTryOnce` set): [%s calling ismaster on '%s:%d']
 ===DONE===

--- a/tests/manager/bug0572.phpt
+++ b/tests/manager/bug0572.phpt
@@ -27,6 +27,9 @@ var_dump($cursor->toArray()[0]);
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+Deprecated: MongoDB\Driver\Manager::__construct(): The "context" driver option is deprecated.%s
+
+Deprecated: MongoDB\Driver\Manager::__construct(): The "allow_self_signed" context driver option is deprecated. Please use the "tlsAllowInvalidCertificates" URI option instead.%s
 object(stdClass)#%d (%d) {
   ["ok"]=>
   float(1)

--- a/tests/manager/bug0851-002.phpt
+++ b/tests/manager/bug0851-002.phpt
@@ -18,7 +18,10 @@ var_dump($driverOptions);
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECT--
+--EXPECTF--
+Deprecated: MongoDB\Driver\Manager::__construct(): The "context" driver option is deprecated.%s
+
+Deprecated: MongoDB\Driver\Manager::__construct(): The "weak_cert_validation" driver option is deprecated. Please use the "tlsAllowInvalidCertificates" URI option instead.%s
 array(2) {
   ["weak_cert_validation"]=>
   bool(true)

--- a/tests/manager/bug0940-001.phpt
+++ b/tests/manager/bug0940-001.phpt
@@ -12,6 +12,7 @@ var_dump(new MongoDB\Driver\Manager(null, [], ['ca_file' => false]));
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+Deprecated: MongoDB\Driver\Manager::__construct(): The "ca_file" driver option is deprecated. Please use the "tlsCAFile" URI option instead.%s
 object(MongoDB\Driver\Manager)#%d (%d) {
   ["uri"]=>
   string(20) "mongodb://127.0.0.1/"

--- a/tests/manager/bug0940-002.phpt
+++ b/tests/manager/bug0940-002.phpt
@@ -14,6 +14,9 @@ var_dump(new MongoDB\Driver\Manager(null, [], ['context' => $context]));
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+Deprecated: MongoDB\Driver\Manager::__construct(): The "context" driver option is deprecated.%s
+
+Deprecated: MongoDB\Driver\Manager::__construct(): The "cafile" context driver option is deprecated. Please use the "tlsCAFile" URI option instead.%s
 object(MongoDB\Driver\Manager)#%d (%d) {
   ["uri"]=>
   string(20) "mongodb://127.0.0.1/"

--- a/tests/manager/manager-ctor-ssl-deprecated-001.phpt
+++ b/tests/manager/manager-ctor-ssl-deprecated-001.phpt
@@ -1,0 +1,67 @@
+--TEST--
+MongoDB\Driver\Manager::__construct(): Test deprecated options
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_not_libmongoc_ssl(); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$deprecatedDriverOptions = [
+    ['allow_invalid_hostname' => true],
+    ['weak_cert_validation' => true],
+    ['allow_self_signed' => true],
+    ['pem_file' => 'foo'],
+    ['local_cert' => 'foo'],
+    ['pem_pwd' => 'foo'],
+    ['passphrase' => 'foo'],
+    ['ca_file' => 'foo'],
+    ['cafile' => 'foo'],
+    ['context' => stream_context_create(['ssl' => ['cafile' => 'foo']])],
+    ['context' => stream_context_create(['ssl' => ['capath' => 'foo']])],
+    ['context' => stream_context_create(['ssl' => ['local_cert' => 'foo']])],
+    ['context' => stream_context_create(['ssl' => ['passphrase' => 'foo']])],
+    ['context' => stream_context_create(['ssl' => ['allow_self_signed' => true]])],
+];
+
+foreach ($deprecatedDriverOptions as $driverOptions) {
+    echo raises(
+        function () use ($driverOptions) {
+            new MongoDB\Driver\Manager('mongodb://127.0.0.1/', [], $driverOptions);
+        },
+        E_DEPRECATED
+    ), "\n";
+}
+
+?>
+===DONE===
+--EXPECT--
+OK: Got E_DEPRECATED
+MongoDB\Driver\Manager::__construct(): The "allow_invalid_hostname" driver option is deprecated. Please use the "tlsAllowInvalidHostnames" URI option instead.
+OK: Got E_DEPRECATED
+MongoDB\Driver\Manager::__construct(): The "weak_cert_validation" driver option is deprecated. Please use the "tlsAllowInvalidCertificates" URI option instead.
+OK: Got E_DEPRECATED
+MongoDB\Driver\Manager::__construct(): The "allow_self_signed" context driver option is deprecated. Please use the "tlsAllowInvalidCertificates" URI option instead.
+OK: Got E_DEPRECATED
+MongoDB\Driver\Manager::__construct(): The "pem_file" driver option is deprecated. Please use the "tlsCertificateKeyFile" URI option instead.
+OK: Got E_DEPRECATED
+MongoDB\Driver\Manager::__construct(): The "local_cert" context driver option is deprecated. Please use the "tlsCertificateKeyFile" URI option instead.
+OK: Got E_DEPRECATED
+MongoDB\Driver\Manager::__construct(): The "pem_pwd" driver option is deprecated. Please use the "tlsCertificateKeyFilePassword" URI option instead.
+OK: Got E_DEPRECATED
+MongoDB\Driver\Manager::__construct(): The "passphrase" context driver option is deprecated. Please use the "tlsCertificateKeyFilePassword" URI option instead.
+OK: Got E_DEPRECATED
+MongoDB\Driver\Manager::__construct(): The "ca_file" driver option is deprecated. Please use the "tlsCAFile" URI option instead.
+OK: Got E_DEPRECATED
+MongoDB\Driver\Manager::__construct(): The "cafile" context driver option is deprecated. Please use the "tlsCAFile" URI option instead.
+OK: Got E_DEPRECATED
+MongoDB\Driver\Manager::__construct(): The "context" driver option is deprecated.
+OK: Got E_DEPRECATED
+MongoDB\Driver\Manager::__construct(): The "context" driver option is deprecated.
+OK: Got E_DEPRECATED
+MongoDB\Driver\Manager::__construct(): The "context" driver option is deprecated.
+OK: Got E_DEPRECATED
+MongoDB\Driver\Manager::__construct(): The "context" driver option is deprecated.
+OK: Got E_DEPRECATED
+MongoDB\Driver\Manager::__construct(): The "context" driver option is deprecated.
+===DONE===

--- a/tests/manager/manager-ctor-ssl-deprecated-002.phpt
+++ b/tests/manager/manager-ctor-ssl-deprecated-002.phpt
@@ -1,0 +1,31 @@
+--TEST--
+MongoDB\Driver\Manager::__construct(): Test deprecated options (capath)
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_not_libmongoc_ssl(['OpenSSL', 'LibreSSL']); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+echo raises(
+    function () {
+        new MongoDB\Driver\Manager('mongodb://127.0.0.1/', [], ['capath' => 'foo']);
+    },
+    E_DEPRECATED
+), "\n";
+
+echo raises(
+    function () {
+        new MongoDB\Driver\Manager('mongodb://127.0.0.1/', [], ['context' => stream_context_create(['ssl' => ['capath' => 'foo']])]);
+    },
+    E_DEPRECATED
+), "\n";
+
+?>
+===DONE===
+--EXPECT--
+OK: Got E_DEPRECATED
+MongoDB\Driver\Manager::__construct(): The "capath" context driver option is deprecated. Please use the "ca_dir" driver option instead.
+OK: Got E_DEPRECATED
+MongoDB\Driver\Manager::__construct(): The "context" driver option is deprecated.
+===DONE===

--- a/tests/manager/manager-set-uri-options-002.phpt
+++ b/tests/manager/manager-set-uri-options-002.phpt
@@ -46,7 +46,14 @@ printf("Inserted: %d\n", $inserted);
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+Deprecated: MongoDB\Driver\Manager::__construct(): The "context" driver option is deprecated.%s
+
+Deprecated: MongoDB\Driver\Manager::__construct(): The "allow_self_signed" context driver option is deprecated. Please use the "tlsAllowInvalidCertificates" URI option instead.%s
 OK: Got MongoDB\Driver\Exception\ConnectionTimeoutException
 No suitable servers found (`serverSelectionTryOnce` set): [%scalling ismaster on '%s']
+
+Deprecated: MongoDB\Driver\Manager::__construct(): The "context" driver option is deprecated.%s
+
+Deprecated: MongoDB\Driver\Manager::__construct(): The "allow_self_signed" context driver option is deprecated. Please use the "tlsAllowInvalidCertificates" URI option instead.%s
 Inserted: 1
 ===DONE===

--- a/tests/manager/manager-set-uri-options-003.phpt
+++ b/tests/manager/manager-set-uri-options-003.phpt
@@ -17,4 +17,5 @@ $manager = new MongoDB\Driver\Manager(URI . '&sslclientcertificatekeypassword=do
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+Deprecated: MongoDB\Driver\Manager::__construct(): The "pem_pwd" driver option is deprecated. Please use the "tlsCertificateKeyFilePassword" URI option instead.%s
 ===DONE===

--- a/tests/utils/tools.php
+++ b/tests/utils/tools.php
@@ -545,6 +545,8 @@ function destroyTemporaryMongoInstance($id = NULL)
 
 function severityToString($type) {
     switch($type) {
+    case E_DEPRECATED:
+        return "E_DEPRECATED";
     case E_RECOVERABLE_ERROR:
         return "E_RECOVERABLE_ERROR";
     case E_WARNING:


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1430

Contrary to what's in the ticket, this PR adds a deprecation notice for the `context` driver option as well, as per the documentation ([source](https://www.php.net/manual/en/mongodb-driver-manager.construct.php)):
> This option [context] is supported for backwards compatibility, but should be considered deprecated.

We can then formally deprecate this in 1.7.0.