### PR TITLE
PHPC-1418: Test PHP 7.3 in Evergreen

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -595,6 +595,10 @@ axes:
   - id: php-versions
     display_name: PHP Version
     values:
+      - id: "7.3"
+        display_name: "PHP 7.3"
+        variables:
+          PHP_VERSION: "7.3.8"
       - id: "7.2"
         display_name: "PHP 7.2"
         variables:
@@ -675,7 +679,7 @@ buildvariants:
      - name: "test-replicaset-auth"
 
 - matrix_name: "tests-php7"
-  matrix_spec: {"os-php7": "*", "versions": "4.2", "php-versions": ["7.0","7.1","7.2"] }
+  matrix_spec: {"os-php7": "*", "versions": "4.2", "php-versions": ["7.0","7.1","7.2","7.3"] }
   display_name: "All: ${versions}/${php-versions} — ${os-php7}"
   tasks:
      - name: "test-standalone-ssl"
@@ -691,9 +695,9 @@ buildvariants:
      - name: "test-replicaset-old"
 
 - matrix_name: "mongo-30-php7"
-  matrix_spec: {"os-php7": "*", "versions": ["3.0", "3.2", "3.4"], "php-versions": "7.2" }
-  # Pending PHPC-1372, restore exclude_spec: {"os-php7": "ubuntu1604-arm64", "versions": ["3.0", "3.2"], "php-versions": "7.2"}
-  exclude_spec: [ {"os-php7": "rhel71-power8", "versions": "3.0", "php-versions": "7.2"}, {"os-php7": "rhel74-zseries", "versions": ["3.0", "3.2"], "php-versions": "7.2"} ]
+  matrix_spec: {"os-php7": "*", "versions": ["3.0", "3.2", "3.4"], "php-versions": "7.3" }
+  # Pending PHPC-1372, restore exclude_spec: {"os-php7": "ubuntu1604-arm64", "versions": ["3.0", "3.2"], "php-versions": "7.3"}
+  exclude_spec: [ {"os-php7": "rhel71-power8", "versions": "3.0", "php-versions": "7.3"}, {"os-php7": "rhel74-zseries", "versions": ["3.0", "3.2"], "php-versions": "7.3"} ]
   display_name: "${versions}/${php-versions} — ${os-php7}"
   tasks:
      - name: "test-standalone-old"
@@ -709,7 +713,7 @@ buildvariants:
      - name: "test-replicaset-auth"
 
 - matrix_name: "mongo-36-php7"
-  matrix_spec: {"os-php7": "*", "versions": ["3.6"], "php-versions": "7.2" }
+  matrix_spec: {"os-php7": "*", "versions": ["3.6"], "php-versions": "7.3" }
   display_name: "${versions}/${php-versions} — ${os-php7}"
   tasks:
      - name: "test-standalone"
@@ -731,9 +735,9 @@ buildvariants:
      - name: "test-sharded-rs"
 
 - matrix_name: "mongo-40-php7"
-  matrix_spec: {"os-php7": "*", "versions": ["4.0", "4.2", "latest"], "php-versions": "7.2" }
+  matrix_spec: {"os-php7": "*", "versions": ["4.0", "4.2", "latest"], "php-versions": "7.3" }
   exclude_spec:
-     - {"os-php7": "rhel74-zseries", "versions": ["4.0", "4.2", "latest"], "php-versions": "7.2"}
+     - {"os-php7": "rhel74-zseries", "versions": ["4.0", "4.2", "latest"], "php-versions": "7.3"}
   display_name: "${versions}/${php-versions} — ${os-php7}"
   tasks:
      - name: "test-standalone"
@@ -746,7 +750,7 @@ buildvariants:
      - name: "test-sharded-rs"
 
 - matrix_name: "mongo-40-php7-nossl"
-  matrix_spec: {"os-php7": "rhel74-zseries", "versions": ["4.0", "4.2", "latest"], "php-versions": "7.2"}
+  matrix_spec: {"os-php7": "rhel74-zseries", "versions": ["4.0", "4.2", "latest"], "php-versions": "7.3"}
   display_name: "${versions}/${php-versions} — ${os-php7}"
   tasks:
      - name: "test-standalone"
@@ -758,13 +762,13 @@ buildvariants:
      - name: "test-sharded-rs"
 
 - matrix_name: "mongo-42-storage-engines"
-  matrix_spec: {"os-php7": "debian92-test", "versions": "4.2", "php-versions": "7.2", "storage-engine": ["wiredtiger", "inmemory"]}
+  matrix_spec: {"os-php7": "debian92-test", "versions": "4.2", "php-versions": "7.3", "storage-engine": ["wiredtiger", "inmemory"]}
   display_name: "${versions}/${php-versions}/${os-php7} — ${storage-engine}"
   tasks:
      - name: "test-standalone"
 
 - matrix_name: "mongo-40-storage-engines"
-  matrix_spec: {"os-php7": "debian92-test", "versions": "4.0", "php-versions": "7.2", "storage-engine": "mmapv1"}
+  matrix_spec: {"os-php7": "debian92-test", "versions": "4.0", "php-versions": "7.3", "storage-engine": "mmapv1"}
   display_name: "${versions}/${php-versions}/${os-php7} — ${storage-engine}"
   tasks:
      - name: "test-standalone"


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1418

@jmikola: looking at the [diff that introduced PHP 7.3](https://github.com/10gen/mongo-php-toolchain/pull/1/files#diff-a0e5b2ada9d7aee94a81a64d53055dde), I see that PHP 7.0 was removed. However, Evergreen build stages covering PHP 7.0 still complete successfully, so I'm not quite sure what's going on here. Do you know what's going on here, or where I could check to find out?