### PR TITLE
PHPC-1347: Do not allow empty string for replicaSet

### DIFF
--- a/php_phongo.c
+++ b/php_phongo.c
@@ -1583,6 +1583,11 @@ static bool php_phongo_apply_options_to_uri(mongoc_uri_t* uri, bson_t* options T
 				return false;
 			}
 
+			if (!strcasecmp(key, MONGOC_URI_REPLICASET) && !strcmp("", bson_iter_utf8(&iter, NULL))) {
+				phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Value for URI option \"%s\" cannot be empty string.", key);
+				return false;
+			}
+
 			if (!mongoc_uri_set_option_as_utf8(uri, key, bson_iter_utf8(&iter, NULL))) {
 				/* Assignment uses mongoc_uri_set_appname() for the "appname"
 				 * option, which validates length in addition to UTF-8 encoding.

--- a/tests/manager/manager-ctor_error-004.phpt
+++ b/tests/manager/manager-ctor_error-004.phpt
@@ -1,0 +1,25 @@
+--TEST--
+MongoDB\Driver\Manager::__construct(): empty replicaSet argument
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+echo throws(function () {
+    $manager = new MongoDB\Driver\Manager('mongodb://localhost:27017/?replicaSet=');
+    $manager->executeQuery(NS, new MongoDB\Driver\Query([]));
+}, MongoDB\Driver\Exception\InvalidArgumentException::class), "\n";
+
+echo throws(function () {
+    $manager = new MongoDB\Driver\Manager('mongodb://localhost:27017', ['replicaSet' => '']);
+    $manager->executeQuery(NS, new MongoDB\Driver\Query([]));
+}, MongoDB\Driver\Exception\InvalidArgumentException::class), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Failed to parse MongoDB URI: 'mongodb://localhost:27017/?replicaSet='. Value for URI option "replicaset" cannot be empty string.
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Value for URI option "replicaSet" cannot be empty string.
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1347

Since libmongoc rejects an URI with an empty `replicaSet` URI option, there is different behaviour depending on whether an empty replica set name is passed via the URI string or via the URI options array. The first causes an exception:
> Failed to parse MongoDB URI: 'mongodb://localhost:3000/?replicaSet='. Value for URI option "replicaset" cannot be empty string.

The latter lets users create the manager, but causes a connection exception on server selection:
> Fatal error: Uncaught MongoDB\Driver\Exception\ConnectionTimeoutException: No suitable servers found (`serverSelectionTryOnce` set)

This PR changes this and checks the `replicaSet` option when it is passed via URI options array, also throwing an exception when the option is explicitly given with an empty value. Not passing the option at all does not cause an error.