### PR TITLE
PHPC-1391: Prohibit starting a transaction for maxWireVersion < 7

### DIFF
--- a/tests/session/session-startTransaction_error-006.phpt
+++ b/tests/session/session-startTransaction_error-006.phpt
@@ -1,0 +1,26 @@
+--TEST--
+MongoDB\Driver\Session::startTransaction() throws an error on replicasets < 4.0
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_not_libmongoc_crypto() ?>
+<?php skip_if_not_replica_set(); ?>
+<?php skip_if_server_version('<', '3.6'); ?>
+<?php skip_if_server_version('>=', '4.0'); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(URI);
+$session = $manager->startSession();
+
+echo throws(function () use ($session) {
+    $session->startTransaction();
+}, MongoDB\Driver\Exception\RuntimeException::class), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\RuntimeException
+Multi-document transactions are not supported by this server version
+===DONE===

--- a/tests/session/session-startTransaction_error-007.phpt
+++ b/tests/session/session-startTransaction_error-007.phpt
@@ -1,0 +1,26 @@
+--TEST--
+MongoDB\Driver\Session::startTransaction() throws an error on sharded clusters < 4.2
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_not_libmongoc_crypto() ?>
+<?php skip_if_not_mongos_with_replica_set(); ?>
+<?php skip_if_server_version('<', '3.6'); ?>
+<?php skip_if_server_version('>=', '4.2'); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(URI);
+$session = $manager->startSession();
+
+echo throws(function () use ($session) {
+    $session->startTransaction();
+}, MongoDB\Driver\Exception\RuntimeException::class), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\RuntimeException
+Multi-document transactions are not supported by this server version
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1391

The exeption itself is caused by libmongoc not allowing transactions. This commit only adds tests to protect against regressions.