### PR TITLE
Fix undefined var if throws() fails to catch

### DIFF
--- a/tests/utils/tools.php
+++ b/tests/utils/tools.php
@@ -593,10 +593,10 @@ function throws($function, $exceptionname, $infunction = null) {
     try {
         $function();
     } catch (Throwable $e) {
-    } catch(Exception $e) {
+    } catch (Exception $e) {
     }
 
-    if ($e === null) {
+    if (!isset($e)) {
         echo "FAILED: Expected $exceptionname thrown, but no exception thrown!\n";
         return;
     }


### PR DESCRIPTION
Something I noticed while testing [PHPC-1274](https://jira.mongodb.org/browse/PHPC-1274).