### PR TITLE
PHPC-1372: Re-enable ARM64 builds in Evergreen matrix

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -653,10 +653,9 @@ axes:
       - id: rhel74-zseries
         display_name: "RHEL 7.4 zSeries"
         run_on: rhel72-zseries-test
-      # Pending re-installation of PHP toolchain on ARM64 (see: PHPC-1372)
-      # - id: ubuntu1604-arm64
-      #   display_name: "Ubuntu 16.04 ARM64"
-      #   run_on: ubuntu1604-arm64-large
+      - id: ubuntu1804-arm64-test
+        display_name: "Ubuntu 18.04 ARM64"
+        run_on: ubuntu1804-arm64-test
       # Pending installation of PHP toolchain on macOS hosts (see: PHPC-869)
       # - id: macos-1014
       #   display_name: "Mac OS 10.14"
@@ -702,6 +701,8 @@ buildvariants:
 
 - matrix_name: "tests-php7"
   matrix_spec: {"os-php7": "*", "versions": "4.2", "php-versions": ["7.0","7.1","7.2","7.3"] }
+  exclude_spec:
+    - {"os-php7": "ubuntu1804-arm64-test", "versions": "4.2", "php-versions": ["7.0","7.1","7.2"]}
   display_name: "All: ${versions}/${php-versions} — ${os-php7}"
   tasks:
      - name: "test-standalone-ssl"
@@ -718,8 +719,10 @@ buildvariants:
 
 - matrix_name: "mongo-30-php7"
   matrix_spec: {"os-php7": "*", "versions": ["3.0", "3.2", "3.4"], "php-versions": "7.3" }
-  # Pending PHPC-1372, restore exclude_spec: {"os-php7": "ubuntu1604-arm64", "versions": ["3.0", "3.2"], "php-versions": "7.3"}
-  exclude_spec: [ {"os-php7": "rhel71-power8", "versions": "3.0", "php-versions": "7.3"}, {"os-php7": "rhel74-zseries", "versions": ["3.0", "3.2"], "php-versions": "7.3"} ]
+  exclude_spec:
+    - {"os-php7": "ubuntu1804-arm64-test", "versions": ["3.0", "3.2", "3.4"], "php-versions": "7.3"}
+    - {"os-php7": "rhel71-power8", "versions": "3.0", "php-versions": "7.3"}
+    - {"os-php7": "rhel74-zseries", "versions": ["3.0", "3.2"], "php-versions": "7.3"}
   display_name: "${versions}/${php-versions} — ${os-php7}"
   tasks:
      - name: "test-standalone-old"
@@ -736,6 +739,8 @@ buildvariants:
 
 - matrix_name: "mongo-36-php7"
   matrix_spec: {"os-php7": "*", "versions": ["3.6"], "php-versions": "7.3" }
+  exclude_spec:
+    - {"os-php7": "ubuntu1804-arm64-test", "versions": "3.6", "php-versions": "7.3"}
   display_name: "${versions}/${php-versions} — ${os-php7}"
   tasks:
      - name: "test-standalone"
@@ -759,7 +764,8 @@ buildvariants:
 - matrix_name: "mongo-40-php7"
   matrix_spec: {"os-php7": "*", "versions": ["4.0", "4.2", "latest"], "php-versions": "7.3" }
   exclude_spec:
-     - {"os-php7": "rhel74-zseries", "versions": ["4.0", "4.2", "latest"], "php-versions": "7.3"}
+    - {"os-php7": "rhel74-zseries", "versions": ["4.0", "4.2", "latest"], "php-versions": "7.3"}
+    - {"os-php7": "ubuntu1804-arm64-test", "versions": "4.0", "php-versions": "7.3"}
   display_name: "${versions}/${php-versions} — ${os-php7}"
   tasks:
      - name: "test-standalone"


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1372
Evergreen build: https://evergreen.mongodb.com/version/5dc1633361837d7f5d6ecfd0

Currently only tests PHP 7.3 on MongoDB 4.2 and newer, as other versions aren't available.