### PR TITLE
PHPC-1472: Prevent multiple exceptions from being thrown while dumping manager

### DIFF
--- a/php_phongo.c
+++ b/php_phongo.c
@@ -1163,7 +1163,7 @@ php_phongo_server_description_type_t php_phongo_server_description_type(mongoc_s
 	return PHONGO_SERVER_UNKNOWN;
 }
 
-void php_phongo_server_to_zval(zval* retval, mongoc_server_description_t* sd) /* {{{ */
+bool php_phongo_server_to_zval(zval* retval, mongoc_server_description_t* sd) /* {{{ */
 {
 	mongoc_host_list_t* host      = mongoc_server_description_host(sd);
 	const bson_t*       is_master = mongoc_server_description_ismaster(sd);
@@ -1189,7 +1189,7 @@ void php_phongo_server_to_zval(zval* retval, mongoc_server_description_t* sd) /*
 		bson_iter_document(&iter, &len, &bytes);
 		if (!php_phongo_bson_to_zval_ex(bytes, len, &state)) {
 			zval_ptr_dtor(&state.zchild);
-			return;
+			return false;
 		}
 
 #if PHP_VERSION_ID >= 70000
@@ -1206,7 +1206,7 @@ void php_phongo_server_to_zval(zval* retval, mongoc_server_description_t* sd) /*
 
 		if (!php_phongo_bson_to_zval_ex(bson_get_data(is_master), is_master->len, &state)) {
 			zval_ptr_dtor(&state.zchild);
-			return;
+			return false;
 		}
 
 #if PHP_VERSION_ID >= 70000
@@ -1217,6 +1217,7 @@ void php_phongo_server_to_zval(zval* retval, mongoc_server_description_t* sd) /*
 	}
 	ADD_ASSOC_LONG_EX(retval, "round_trip_time", (phongo_long) mongoc_server_description_round_trip_time(sd));
 
+	return true;
 } /* }}} */
 
 void php_phongo_read_concern_to_zval(zval* retval, const mongoc_read_concern_t* read_concern) /* {{{ */

--- a/php_phongo.h
+++ b/php_phongo.h
@@ -155,7 +155,7 @@ void  php_phongo_prep_legacy_option_free(zval* options TSRMLS_DC);
 void php_phongo_read_preference_prep_tagsets(zval* tagSets TSRMLS_DC);
 bool php_phongo_read_preference_tags_are_valid(const bson_t* tags);
 
-void php_phongo_server_to_zval(zval* retval, mongoc_server_description_t* sd);
+bool php_phongo_server_to_zval(zval* retval, mongoc_server_description_t* sd);
 void php_phongo_read_concern_to_zval(zval* retval, const mongoc_read_concern_t* read_concern);
 void php_phongo_write_concern_to_zval(zval* retval, const mongoc_write_concern_t* write_concern);
 void php_phongo_cursor_to_zval(zval* retval, const mongoc_cursor_t* cursor);

--- a/src/MongoDB/Manager.c
+++ b/src/MongoDB/Manager.c
@@ -893,7 +893,13 @@ static HashTable* php_phongo_manager_get_debug_info(zval* object, int* is_temp T
 	for (i = 0; i < n; i++) {
 		zval obj;
 
-		php_phongo_server_to_zval(&obj, sds[i]);
+		if (!php_phongo_server_to_zval(&obj, sds[i])) {
+			/* Exception already thrown */
+			zval_ptr_dtor(&obj);
+			zval_ptr_dtor(&cluster);
+			goto done;
+		}
+
 		add_next_index_zval(&cluster, &obj);
 	}
 
@@ -906,13 +912,20 @@ static HashTable* php_phongo_manager_get_debug_info(zval* object, int* is_temp T
 		zval* obj = NULL;
 
 		MAKE_STD_ZVAL(obj);
-		php_phongo_server_to_zval(obj, sds[i]);
+		if (!php_phongo_server_to_zval(obj, sds[i])) {
+			/* Exception already thrown */
+			zval_ptr_dtor(&obj);
+			zval_ptr_dtor(&cluster);
+			goto done;
+		}
+
 		add_next_index_zval(cluster, obj);
 	}
 
 	ADD_ASSOC_ZVAL_EX(&retval, "cluster", cluster);
 #endif
 
+done:
 	mongoc_server_descriptions_destroy_all(sds, n);
 
 	return Z_ARRVAL(retval);


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1472

@jmikola: I'm not sure what a good way to test this is, as it can only come up when receiving invalid data from the server. Do you have an idea how to verify this indeed works as expected?