### PR TITLE
PHPC-1446: Implicitly enable TLS when any TLS-related driver option is set

### DIFF
--- a/php_phongo.c
+++ b/php_phongo.c
@@ -2720,7 +2720,7 @@ void phongo_manager_init(php_phongo_manager_t* manager, const char* uri_string, 
 	}
 
 #ifdef MONGOC_ENABLE_SSL
-	if (ssl_opt && mongoc_uri_get_tls(uri)) {
+	if (ssl_opt) {
 		mongoc_client_set_ssl_opts(manager->client, ssl_opt);
 	}
 #endif

--- a/tests/manager/manager-ctor-ssl-003.phpt
+++ b/tests/manager/manager-ctor-ssl-003.phpt
@@ -1,0 +1,28 @@
+--TEST--
+MongoDB\Driver\Manager::__construct(): Specifying a driver option implicitly enables TLS
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_not_libmongoc_ssl(['OpenSSL', 'LibreSSL']); ?>
+<?php skip_if_ssl(); ?>
+--FILE--
+<?php
+
+require_once __DIR__ . "/../utils/basic.inc";
+
+// Ensure that the server is up to ensure we're not hitting a different failure below
+$manager = new MongoDB\Driver\Manager(URI);
+$manager->executeCommand(DATABASE_NAME, new MongoDB\Driver\Command(['ping' => 1]));
+
+$manager = new MongoDB\Driver\Manager(URI, [], ['ca_dir' => 'foo']);
+
+echo throws(function () use ($manager) {
+    // Note that this command will not fail if the server was configured with allowSSL or preferSSL for net.ssl.mode.
+    $manager->executeCommand(DATABASE_NAME, new MongoDB\Driver\Command(['ping' => true]));
+}, MongoDB\Driver\Exception\ConnectionTimeoutException::class), "\n";
+
+?>
+===DONE===
+--EXPECTF--
+OK: Got MongoDB\Driver\Exception\ConnectionTimeoutException
+No suitable servers found (`serverSelectionTryOnce` set): %s
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1446

The test assumes that the server isn't configured for SSL, which works in our test environment but may not always work. We also need to skip if the URI explicitly enables SSL as we can then no longer test that it's implicitly enabled.