### PR TITLE
PHPC-1492: Remove unnecessary EXPECTF patterns

### DIFF
--- a/tests/bson/bson-utcdatetime-int-size-001.phpt
+++ b/tests/bson/bson-utcdatetime-int-size-001.phpt
@@ -17,7 +17,7 @@ var_dump($utcdatetime->toDateTime());
 --EXPECTF--
 object(MongoDB\BSON\UTCDateTime)#%d (1) {
   ["milliseconds"]=>
-  %r(string\(13\) "|int\()%r1416445411987%r("|\))%r
+  string(13) "1416445411987"
 }
 object(DateTime)#%d (3) {
   ["date"]=>

--- a/tests/bson/bson-utcdatetime-int-size-002.phpt
+++ b/tests/bson/bson-utcdatetime-int-size-002.phpt
@@ -19,7 +19,7 @@ var_dump($utcdatetime->toDateTime());
 --EXPECTF--
 object(MongoDB\BSON\UTCDateTime)#%d (1) {
   ["milliseconds"]=>
-  %r(string\(13\) "|int\()%r1416445411987%r("|\))%r
+  string(13) "1416445411987"
 }
 object(DateTime)#%d (3) {
   ["date"]=>


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1492

UTCDateTime timestamps are always printed as strings.