### PR TITLE
PHPC-1503: Fix config.w32 for PHP 7.4.0

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -248,8 +248,10 @@ if (PHP_MONGODB != "no") {
 
   if (typeof COMPILER_NAME === 'string') {
     mongoc_opts.MONGOC_CC = COMPILER_NAME;
-  } else if (typeof VC_VERSIONS[VCVERS] === 'string') {
+  } else if (typeof VC_VERSIONS === 'array' && typeof VC_VERSIONS[VCVERS] === 'string') {
     mongoc_opts.MONGOC_CC = VC_VERSIONS[VCVERS];
+  } else if (typeof COMPILER_NAME_LONG === 'string') {
+    mongoc_opts.MONGOC_CC = COMPILER_NAME_LONG;
   }
 
   /* MONGOC_USER_SET_CFLAGS and MONGOC_USER_SET_LDFLAGS can be left blank, as we


### PR DESCRIPTION
The VS version evaluation has been reworked[1] for PHP 7.4.0, which
includes the removal of the VC_VERSIONS array.  To avoid the JScript
error, we check whether VC_VERSIONS is defined, and otherwise fall back
to COMPILER_NAME_LONG.

[1] <http://git.php.net/?p=php-src.git;a=commit;h=6a624c1dfda0dbfaaff3e453e6cb58de12748fb3>