### PR TITLE
Set PHP_BINARY from runtime constant

### DIFF
--- a/.travis.scripts/debug-core.sh
+++ b/.travis.scripts/debug-core.sh
@@ -6,5 +6,5 @@ if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
     exit 1
 fi
 
-PHP_BINARY=`which php`
+PHP_BINARY=`php -r 'echo PHP_BINARY;'`
 gdb -batch -ex "bt full" -ex "quit" "${PHP_BINARY}" "${1}"


### PR DESCRIPTION
This avoids an issue when "php" in the path is just a forwarding shim.

Related to #1076 