### PR TITLE
Run clang-format on existing sources

### DIFF
--- a/phongo_compat.h
+++ b/phongo_compat.h
@@ -253,7 +253,7 @@
 	} else {                                                  \
 		ZVAL_LONG((_zv), (_value));                           \
 	}
-#else  /* SIZEOF_PHONGO_LONG != 8 && SIZEOF_PHONGO_LONG != 4 */
+#else /* SIZEOF_PHONGO_LONG != 8 && SIZEOF_PHONGO_LONG != 4 */
 #error Unsupported architecture (integers are neither 32-bit nor 64-bit)
 #endif /* SIZEOF_PHONGO_LONG */
 

--- a/php_phongo.c
+++ b/php_phongo.c
@@ -427,7 +427,7 @@ zend_bool phongo_writeconcernerror_init(zval* return_value, bson_t* bson TSRMLS_
 
 	object_init_ex(return_value, php_phongo_writeconcernerror_ce);
 
-	intern = Z_WRITECONCERNERROR_OBJ_P(return_value);
+	intern       = Z_WRITECONCERNERROR_OBJ_P(return_value);
 	intern->code = 0;
 
 	if (bson_iter_init_find(&iter, bson, "code") && BSON_ITER_HOLDS_INT32(&iter)) {
@@ -465,7 +465,7 @@ zend_bool phongo_writeerror_init(zval* return_value, bson_t* bson TSRMLS_DC) /* 
 
 	object_init_ex(return_value, php_phongo_writeerror_ce);
 
-	intern = Z_WRITEERROR_OBJ_P(return_value);
+	intern        = Z_WRITEERROR_OBJ_P(return_value);
 	intern->code  = 0;
 	intern->index = 0;
 
@@ -786,7 +786,7 @@ bool phongo_execute_bulk_write(mongoc_client_t* client, const char* namespace, p
 		}
 
 		if (EG(exception)) {
-			char *message;
+			char* message;
 
 			(void) spprintf(&message, 0, "Bulk write failed due to previous %s: %s", PHONGO_ZVAL_EXCEPTION_NAME(EG(exception)), error.message);
 			zend_throw_exception(php_phongo_bulkwriteexception_ce, message, 0 TSRMLS_CC);
@@ -1464,7 +1464,7 @@ static bool php_phongo_uri_finalize_auth(mongoc_uri_t* uri TSRMLS_DC) /* {{{ */
 	if (mongoc_uri_get_auth_mechanism(uri)) {
 		if (!strcasecmp(mongoc_uri_get_auth_mechanism(uri), "GSSAPI") ||
 			!strcasecmp(mongoc_uri_get_auth_mechanism(uri), "MONGODB-X509")) {
-			const char *source = mongoc_uri_get_auth_source(uri);
+			const char* source = mongoc_uri_get_auth_source(uri);
 
 			if (source) {
 				if (strcasecmp(source, "$external")) {
@@ -1499,8 +1499,8 @@ static bool php_phongo_uri_finalize_auth(mongoc_uri_t* uri TSRMLS_DC) /* {{{ */
 
 static bool php_phongo_uri_finalize_tls(mongoc_uri_t* uri TSRMLS_DC) /* {{{ */
 {
-	const bson_t *options;
-	bson_iter_t iter;
+	const bson_t* options;
+	bson_iter_t   iter;
 
 	if (!(options = mongoc_uri_get_options(uri))) {
 		return true;
@@ -2075,7 +2075,7 @@ static bool php_phongo_apply_wc_options_to_uri(mongoc_uri_t* uri, bson_t* option
 
 static void php_phongo_mongoc_ssl_opts_from_uri(mongoc_ssl_opt_t* ssl_opt, mongoc_uri_t* uri, bool* any_ssl_option_set)
 {
-	bool insecure        = mongoc_uri_get_option_as_bool(uri, MONGOC_URI_TLSINSECURE, false);
+	bool        insecure = mongoc_uri_get_option_as_bool(uri, MONGOC_URI_TLSINSECURE, false);
 	const char* pem_file = mongoc_uri_get_option_as_utf8(uri, MONGOC_URI_TLSCERTIFICATEKEYFILE, NULL);
 	const char* pem_pwd  = mongoc_uri_get_option_as_utf8(uri, MONGOC_URI_TLSCERTIFICATEKEYFILEPASSWORD, NULL);
 	const char* ca_file  = mongoc_uri_get_option_as_utf8(uri, MONGOC_URI_TLSCAFILE, NULL);
@@ -2210,7 +2210,7 @@ static inline bool php_phongo_apply_driver_option_to_uri(mongoc_uri_t* uri, zval
 	char* value;
 
 	value = php_phongo_fetch_ssl_opt_string(zoptions, driverOptionKey);
-	ret = mongoc_uri_set_option_as_utf8(uri, optionKey, value);
+	ret   = mongoc_uri_set_option_as_utf8(uri, optionKey, value);
 	efree(value);
 
 	return ret;
@@ -3039,7 +3039,7 @@ PHP_MINIT_FUNCTION(mongodb)
 	php_phongo_timestamp_init_ce(INIT_FUNC_ARGS_PASSTHRU);
 	php_phongo_undefined_init_ce(INIT_FUNC_ARGS_PASSTHRU);
 	php_phongo_utcdatetime_init_ce(INIT_FUNC_ARGS_PASSTHRU);
-	
+
 	php_phongo_cursor_interface_init_ce(INIT_FUNC_ARGS_PASSTHRU);
 
 	php_phongo_bulkwrite_init_ce(INIT_FUNC_ARGS_PASSTHRU);

--- a/src/BSON/Binary.c
+++ b/src/BSON/Binary.c
@@ -369,11 +369,11 @@ static phongo_create_object_retval php_phongo_binary_create_object(zend_class_en
 
 static phongo_create_object_retval php_phongo_binary_clone_object(zval* object TSRMLS_DC) /* {{{ */
 {
-	php_phongo_binary_t* intern;
-	php_phongo_binary_t* new_intern;
+	php_phongo_binary_t*        intern;
+	php_phongo_binary_t*        new_intern;
 	phongo_create_object_retval new_object;
 
-	intern = Z_BINARY_OBJ_P(object);
+	intern     = Z_BINARY_OBJ_P(object);
 	new_object = php_phongo_binary_create_object(Z_OBJCE_P(object) TSRMLS_CC);
 
 #if PHP_VERSION_ID >= 70000

--- a/src/BSON/DBPointer.c
+++ b/src/BSON/DBPointer.c
@@ -289,11 +289,11 @@ phongo_create_object_retval php_phongo_dbpointer_create_object(zend_class_entry*
 
 static phongo_create_object_retval php_phongo_dbpointer_clone_object(zval* object TSRMLS_DC) /* {{{ */
 {
-	php_phongo_dbpointer_t* intern;
-	php_phongo_dbpointer_t* new_intern;
+	php_phongo_dbpointer_t*     intern;
+	php_phongo_dbpointer_t*     new_intern;
 	phongo_create_object_retval new_object;
 
-	intern = Z_DBPOINTER_OBJ_P(object);
+	intern     = Z_DBPOINTER_OBJ_P(object);
 	new_object = php_phongo_dbpointer_create_object(Z_OBJCE_P(object) TSRMLS_CC);
 
 #if PHP_VERSION_ID >= 70000

--- a/src/BSON/Decimal128.c
+++ b/src/BSON/Decimal128.c
@@ -302,11 +302,11 @@ static phongo_create_object_retval php_phongo_decimal128_create_object(zend_clas
 
 static phongo_create_object_retval php_phongo_decimal128_clone_object(zval* object TSRMLS_DC) /* {{{ */
 {
-	php_phongo_decimal128_t* intern;
-	php_phongo_decimal128_t* new_intern;
+	php_phongo_decimal128_t*    intern;
+	php_phongo_decimal128_t*    new_intern;
 	phongo_create_object_retval new_object;
 
-	intern = Z_DECIMAL128_OBJ_P(object);
+	intern     = Z_DECIMAL128_OBJ_P(object);
 	new_object = php_phongo_decimal128_create_object(Z_OBJCE_P(object) TSRMLS_CC);
 
 #if PHP_VERSION_ID >= 70000

--- a/src/BSON/Int64.c
+++ b/src/BSON/Int64.c
@@ -256,11 +256,11 @@ phongo_create_object_retval php_phongo_int64_create_object(zend_class_entry* cla
 
 static phongo_create_object_retval php_phongo_int64_clone_object(zval* object TSRMLS_DC) /* {{{ */
 {
-	php_phongo_int64_t* intern;
-	php_phongo_int64_t* new_intern;
+	php_phongo_int64_t*         intern;
+	php_phongo_int64_t*         new_intern;
 	phongo_create_object_retval new_object;
 
-	intern = Z_INT64_OBJ_P(object);
+	intern     = Z_INT64_OBJ_P(object);
 	new_object = php_phongo_int64_create_object(Z_OBJCE_P(object) TSRMLS_CC);
 
 #if PHP_VERSION_ID >= 70000

--- a/src/BSON/Javascript.c
+++ b/src/BSON/Javascript.c
@@ -419,11 +419,11 @@ phongo_create_object_retval php_phongo_javascript_create_object(zend_class_entry
 
 static phongo_create_object_retval php_phongo_javascript_clone_object(zval* object TSRMLS_DC) /* {{{ */
 {
-	php_phongo_javascript_t* intern;
-	php_phongo_javascript_t* new_intern;
+	php_phongo_javascript_t*    intern;
+	php_phongo_javascript_t*    new_intern;
 	phongo_create_object_retval new_object;
 
-	intern = Z_JAVASCRIPT_OBJ_P(object);
+	intern     = Z_JAVASCRIPT_OBJ_P(object);
 	new_object = php_phongo_javascript_create_object(Z_OBJCE_P(object) TSRMLS_CC);
 
 #if PHP_VERSION_ID >= 70000

--- a/src/BSON/ObjectId.c
+++ b/src/BSON/ObjectId.c
@@ -30,7 +30,7 @@
 #include "phongo_compat.h"
 #include "php_phongo.h"
 
-#define PHONGO_OID_SIZE sizeof(((php_phongo_objectid_t *)0)->oid)
+#define PHONGO_OID_SIZE sizeof(((php_phongo_objectid_t*) 0)->oid)
 #define PHONGO_OID_LEN (PHONGO_OID_SIZE - 1)
 
 zend_class_entry* php_phongo_objectid_ce;
@@ -341,11 +341,11 @@ static phongo_create_object_retval php_phongo_objectid_create_object(zend_class_
 
 static phongo_create_object_retval php_phongo_objectid_clone_object(zval* object TSRMLS_DC) /* {{{ */
 {
-	php_phongo_objectid_t* intern;
-	php_phongo_objectid_t* new_intern;
+	php_phongo_objectid_t*      intern;
+	php_phongo_objectid_t*      new_intern;
 	phongo_create_object_retval new_object;
 
-	intern = Z_OBJECTID_OBJ_P(object);
+	intern     = Z_OBJECTID_OBJ_P(object);
 	new_object = php_phongo_objectid_create_object(Z_OBJCE_P(object) TSRMLS_CC);
 
 #if PHP_VERSION_ID >= 70000

--- a/src/BSON/Regex.c
+++ b/src/BSON/Regex.c
@@ -373,11 +373,11 @@ static phongo_create_object_retval php_phongo_regex_create_object(zend_class_ent
 
 static phongo_create_object_retval php_phongo_regex_clone_object(zval* object TSRMLS_DC) /* {{{ */
 {
-	php_phongo_regex_t* intern;
-	php_phongo_regex_t* new_intern;
+	php_phongo_regex_t*         intern;
+	php_phongo_regex_t*         new_intern;
 	phongo_create_object_retval new_object;
 
-	intern = Z_REGEX_OBJ_P(object);
+	intern     = Z_REGEX_OBJ_P(object);
 	new_object = php_phongo_regex_create_object(Z_OBJCE_P(object) TSRMLS_CC);
 
 #if PHP_VERSION_ID >= 70000

--- a/src/BSON/Symbol.c
+++ b/src/BSON/Symbol.c
@@ -251,11 +251,11 @@ phongo_create_object_retval php_phongo_symbol_create_object(zend_class_entry* cl
 
 static phongo_create_object_retval php_phongo_symbol_clone_object(zval* object TSRMLS_DC) /* {{{ */
 {
-	php_phongo_symbol_t* intern;
-	php_phongo_symbol_t* new_intern;
+	php_phongo_symbol_t*        intern;
+	php_phongo_symbol_t*        new_intern;
 	phongo_create_object_retval new_object;
 
-	intern = Z_SYMBOL_OBJ_P(object);
+	intern     = Z_SYMBOL_OBJ_P(object);
 	new_object = php_phongo_symbol_create_object(Z_OBJCE_P(object) TSRMLS_CC);
 
 #if PHP_VERSION_ID >= 70000

--- a/src/BSON/Timestamp.c
+++ b/src/BSON/Timestamp.c
@@ -424,11 +424,11 @@ static phongo_create_object_retval php_phongo_timestamp_create_object(zend_class
 
 static phongo_create_object_retval php_phongo_timestamp_clone_object(zval* object TSRMLS_DC) /* {{{ */
 {
-	php_phongo_timestamp_t* intern;
-	php_phongo_timestamp_t* new_intern;
+	php_phongo_timestamp_t*     intern;
+	php_phongo_timestamp_t*     new_intern;
 	phongo_create_object_retval new_object;
 
-	intern = Z_TIMESTAMP_OBJ_P(object);
+	intern     = Z_TIMESTAMP_OBJ_P(object);
 	new_object = php_phongo_timestamp_create_object(Z_OBJCE_P(object) TSRMLS_CC);
 
 #if PHP_VERSION_ID >= 70000

--- a/src/BSON/UTCDateTime.c
+++ b/src/BSON/UTCDateTime.c
@@ -441,11 +441,11 @@ static phongo_create_object_retval php_phongo_utcdatetime_create_object(zend_cla
 
 static phongo_create_object_retval php_phongo_utcdatetime_clone_object(zval* object TSRMLS_DC) /* {{{ */
 {
-	php_phongo_utcdatetime_t* intern;
-	php_phongo_utcdatetime_t* new_intern;
+	php_phongo_utcdatetime_t*   intern;
+	php_phongo_utcdatetime_t*   new_intern;
 	phongo_create_object_retval new_object;
 
-	intern = Z_UTCDATETIME_OBJ_P(object);
+	intern     = Z_UTCDATETIME_OBJ_P(object);
 	new_object = php_phongo_utcdatetime_create_object(Z_OBJCE_P(object) TSRMLS_CC);
 
 #if PHP_VERSION_ID >= 70000

--- a/src/MongoDB/BulkWrite.c
+++ b/src/MongoDB/BulkWrite.c
@@ -243,7 +243,7 @@ static bool php_phongo_bulkwrite_update_apply_options(bson_t* boptions, zval* zo
 	bool multi = false, upsert = false;
 
 	if (zoptions) {
-		multi = php_array_fetchc_bool(zoptions, "multi");
+		multi  = php_array_fetchc_bool(zoptions, "multi");
 		upsert = php_array_fetchc_bool(zoptions, "upsert");
 	}
 

--- a/src/MongoDB/Cursor.c
+++ b/src/MongoDB/Cursor.c
@@ -129,8 +129,8 @@ static void php_phongo_cursor_iterator_move_forward(zend_object_iterator* iter T
 			php_phongo_cursor_free_current(cursor);
 		}
 	} else {
-		bson_error_t error = { 0 };
-		const bson_t* doc = NULL;
+		bson_error_t  error = { 0 };
+		const bson_t* doc   = NULL;
 
 		if (mongoc_cursor_error_document(cursor->cursor, &error, &doc)) {
 			/* Intentionally not destroying the cursor as it will happen

--- a/src/MongoDB/ReadPreference.c
+++ b/src/MongoDB/ReadPreference.c
@@ -444,8 +444,8 @@ static HashTable* php_phongo_readpreference_get_properties_hash(zval* object, bo
 		return props;
 	}
 
-	tags = mongoc_read_prefs_get_tags(intern->read_preference);
-	mode = mongoc_read_prefs_get_mode(intern->read_preference);
+	tags       = mongoc_read_prefs_get_tags(intern->read_preference);
+	mode       = mongoc_read_prefs_get_mode(intern->read_preference);
 	modeString = php_phongo_readpreference_get_mode_string(mode TSRMLS_CC);
 
 	if (modeString) {
@@ -522,7 +522,7 @@ static PHP_METHOD(ReadPreference, serialize)
 	php_phongo_readpreference_t* intern;
 	ZVAL_RETVAL_TYPE             retval;
 	php_serialize_data_t         var_hash;
-	smart_str                    buf = { 0 };
+	smart_str                    buf        = { 0 };
 	const char*                  modeString = NULL;
 	const bson_t*                tags;
 	int64_t                      maxStalenessSeconds;

--- a/src/MongoDB/Session.c
+++ b/src/MongoDB/Session.c
@@ -312,9 +312,9 @@ static PHP_METHOD(Session, getTransactionOptions)
 	}
 
 	max_commit_time_ms = mongoc_transaction_opts_get_max_commit_time_ms(opts);
-	read_concern = mongoc_transaction_opts_get_read_concern(opts);
-	read_preference = mongoc_transaction_opts_get_read_prefs(opts);
-	write_concern = mongoc_transaction_opts_get_write_concern(opts);
+	read_concern       = mongoc_transaction_opts_get_read_concern(opts);
+	read_preference    = mongoc_transaction_opts_get_read_prefs(opts);
+	write_concern      = mongoc_transaction_opts_get_write_concern(opts);
 
 	array_init_size(return_value, 4);
 
@@ -390,7 +390,6 @@ static PHP_METHOD(Session, getTransactionState)
 
 	PHONGO_RETURN_STRING(state);
 } /* }}} */
-
 
 /* Creates a opts structure from an array optionally containing an RP, RC,
  * WC object, and/or maxCommitTimeMS int. Returns NULL if no options were found,
@@ -685,7 +684,7 @@ static HashTable* php_phongo_session_get_debug_info(zval* object, int* is_temp T
 	array_init(&retval);
 
 	if (intern->client_session) {
-		const bson_t* lsid;
+		const bson_t*         lsid;
 		php_phongo_bson_state state;
 
 		PHONGO_BSON_INIT_DEBUG_STATE(state);

--- a/src/bson.c
+++ b/src/bson.c
@@ -611,7 +611,7 @@ static bool php_phongo_bson_new_javascript_from_javascript_and_scope(zval* objec
 
 	if (scope) {
 		php_phongo_bson_state state;
-		bool valid_scope;
+		bool                  valid_scope;
 
 		PHONGO_BSON_INIT_STATE(state);
 


### PR DESCRIPTION
As per the suggestion in https://github.com/mongodb/mongo-php-driver/pull/1071#discussion_r364075950, this PR fixes pre-existing code style errors that were missed in previous PRs.

Note: a few changes in PHP 5 compatible code had to be excluded manually. Since this code will be dropped after the next release anyways, I didn't investigate any further.