### PR TITLE
PHPC-1496: Use https URL for libmongocrypt submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
 [submodule "src/libmongoc"]
 	path = src/libmongoc
 	url = https://github.com/mongodb/mongo-c-driver.git
-	branch = 1.2.0-dev
 	ignore = untracked
 [submodule "src/libmongocrypt"]
 	path = src/libmongocrypt
-	url = git://github.com/mongodb/libmongocrypt.git
+	url = https://github.com/mongodb/libmongocrypt.git
+	ignore = untracked


### PR DESCRIPTION
See: https://github.com/mongodb/mongo-php-driver/commit/7cea21a25a3014bb34faf8509165ad79bd14ff95#r36836787

@alcaeus Separate question while we're modifying this file. The `branch` value for libmongoc looks quite outdated. Should we just remove that while we're at it?

I'm not familiar with the `ignore` option, but [this thread](https://stackoverflow.com/a/12332080/162228) suggests it's useful for suppressing some git output. I suppose that's worth keeping since developers on PHPC tend to modify libmongoc sources from time to time.