### PR TITLE
PHPC-1546, PHPC-1520: Enable SASL/FLE for Windows builds and define KMS_MSG_STATIC for bundled libmongocrypt

### DIFF
--- a/.appveyor/build_task.cmd
+++ b/.appveyor/build_task.cmd
@@ -31,7 +31,7 @@ setlocal enableextensions enabledelayedexpansion
 
 	if %errorlevel% neq 0 exit /b 3
 
-	cmd /c configure.bat --disable-all --with-mp=auto --enable-cli --%ZTS_STATE%-zts --enable-json --with-openssl --enable-mongodb=shared --enable-object-out-dir=%PHP_BUILD_OBJ_DIR% --with-config-file-scan-dir=%APPVEYOR_BUILD_FOLDER%\build\modules.d --with-prefix=%APPVEYOR_BUILD_FOLDER%\build --with-php-build=%DEPS_DIR%
+	cmd /c configure.bat --disable-all --with-mp=auto --enable-cli --%ZTS_STATE%-zts --enable-json --with-openssl --enable-mongodb=shared --with-mongodb-sasl=yes --with-mongodb-client-side-encryption=yes --enable-object-out-dir=%PHP_BUILD_OBJ_DIR% --with-config-file-scan-dir=%APPVEYOR_BUILD_FOLDER%\build\modules.d --with-prefix=%APPVEYOR_BUILD_FOLDER%\build --with-php-build=%DEPS_DIR%
 
 	if %errorlevel% neq 0 exit /b 3
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -303,7 +303,7 @@ bin\phpsdk_setvars.bat
 cd C:\php-sdk\phpdev\vc11\x86\php-5.6.12-src
 nmake clean
 buildconf --force
-configure --disable-all --with-openssl --enable-cli --enable-json --enable-mongodb=shared
+configure --disable-all --with-openssl --enable-cli --enable-json --enable-mongodb=shared --with-mongodb-sasl=yes --with-mongodb-client-side-encryption=yes
 nmake
 ```
 

--- a/config.m4
+++ b/config.m4
@@ -285,7 +285,7 @@ if test "$PHP_MONGODB" != "no"; then
   if test "$PHP_MONGODB_SYSTEM_LIBS" = "no"; then
     PHP_MONGODB_BUNDLED_CFLAGS="$STD_CFLAGS -DBSON_COMPILATION -DMONGOC_COMPILATION"
     dnl TODO: MONGOCRYPT-219 makes the -std argument obsolete
-    PHP_MONGODB_LIBMONGOCRYPT_CFLAGS="$PHP_MONGODB_BUNDLED_CFLAGS -std=gnu99"
+    PHP_MONGODB_LIBMONGOCRYPT_CFLAGS="$PHP_MONGODB_BUNDLED_CFLAGS -DKMS_MSG_STATIC -std=gnu99"
 
     dnl M4 doesn't know if we're building statically or as a shared module, so
     dnl attempt to include both paths while ignoring errors. If neither path

--- a/config.w32
+++ b/config.w32
@@ -260,7 +260,7 @@ if (PHP_MONGODB != "no") {
     var PHP_MONGODB_MONGOCRYPT_KMS_MESSAGE_SOURCES="hexlify.c kms_b64.c kms_caller_identity_request.c kms_crypto_apple.c kms_crypto_libcrypto.c kms_crypto_none.c kms_crypto_windows.c kms_decrypt_request.c kms_encrypt_request.c kms_kv_list.c kms_message.c kms_request.c kms_request_opt.c kms_request_str.c kms_response.c kms_response_parser.c sort.c";
 
     ADD_SOURCES(configure_module_dirname + "/src/libmongocrypt/src", PHP_MONGODB_MONGOCRYPT_SOURCES, "mongodb");
-    ADD_SOURCES(configure_module_dirname + "/src/libmongocrypt/src/crypto", PHP_MONGODB_MONGOCRYPT_SOURCES, "mongodb");
+    ADD_SOURCES(configure_module_dirname + "/src/libmongocrypt/src/crypto", PHP_MONGODB_MONGOCRYPT_CRYPTO_SOURCES, "mongodb");
     ADD_SOURCES(configure_module_dirname + "/src/libmongocrypt/src/os_posix", PHP_MONGODB_MONGOCRYPT_OS_POSIX_SOURCES, "mongodb");
     ADD_SOURCES(configure_module_dirname + "/src/libmongocrypt/src/os_win", PHP_MONGODB_MONGOCRYPT_OS_WIN_SOURCES, "mongodb");
     ADD_SOURCES(configure_module_dirname + "/src/libmongocrypt/kms-message/src", PHP_MONGODB_MONGOCRYPT_KMS_MESSAGE_SOURCES, "mongodb");

--- a/config.w32
+++ b/config.w32
@@ -232,7 +232,7 @@ if (PHP_MONGODB != "no") {
     ADD_FLAG("CFLAGS_MONGODB", "/I" + configure_module_dirname + "/src/libmongocrypt/src");
     ADD_FLAG("CFLAGS_MONGODB", "/I" + configure_module_dirname + "/src/libmongocrypt/kms-message/src");
     ADD_FLAG("CFLAGS_MONGODB", "/I" + configure_module_dirname + "/src/libmongocrypt-compat");
-    ADD_FLAG("CFLAGS_MONGODB", "/D KMS_MESSAGE_ENABLE_CRYPTO=1 /D KMS_MESSAGE_ENABLE_CRYPTO_LIBCRYPTO=1");
+    ADD_FLAG("CFLAGS_MONGODB", "/D KMS_MSG_STATIC=1 /D KMS_MESSAGE_ENABLE_CRYPTO=1 /D KMS_MESSAGE_ENABLE_CRYPTO_LIBCRYPTO=1");
 
     var mongocrypt_opts = {
       MONGOCRYPT_ENABLE_TRACE: 1,


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1520
https://jira.mongodb.org/browse/PHPC-1546

Note: I wasn't able to test this locally, as I don't have a Windows build environment on my laptop. I'll see if I can validate the absence of warnings from AppVeyor logs; otherwise, I'll double-check Friday when I'm back in the office.