### PR TITLE
Enabling Travis builds for s390x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,14 @@ env:
     - SERVER_VERSION=4.2.0
     - DEPLOYMENT=STANDALONE
 
+linux-s390x: &linux-s390x
+  os: linux
+  arch: s390x
+  dist: bionic
+  env: &env_s390x
+    - SERVER_DISTRO=ubuntu1804
+    - SERVER_VERSION=4.2.3
+
 jobs:
   include:
 
@@ -104,13 +112,85 @@ jobs:
     - stage: Test
       php: 7.3
       env:
+        - CONFIGURE_OPTS="--with-mongodb-client-side-encryption=no"    
+
+    # Test on s390x
+    - stage: Smoke Testing
+      php: 7.3
+      <<: *linux-s390x
+      
+    # Test remaining PHP versions on s390x
+    - stage: Test
+      php: 7.2
+      <<: *linux-s390x
+    - stage: Test
+      php: 7.4
+      <<: *linux-s390x
+
+    # Test against various server topologies on s390x
+    - stage: Test
+      php: 7.3
+      <<: *linux-s390x
+      env:
+        - *env_s390x
+        - TESTS=tests/atlas.phpt
+        - TEST_PHP_ARGS="-q -s output.txt -x --show-diff"
+    - stage: Test
+      php: 7.3
+      <<: *linux-s390x
+      env:
+        - *env_s390x
+        - DEPLOYMENT=STANDALONE_SSL
+    - stage: Test
+      php: 7.3
+      <<: *linux-s390x
+      env:
+        - *env_s390x
+        - DEPLOYMENT=SHARDED_CLUSTER
+    - stage: Test
+      php: 7.3
+      <<: *linux-s390x
+      env:
+        - *env_s390x
+        - DEPLOYMENT=SHARDED_CLUSTER_RS
+    - stage: Test
+      php: 7.3
+      <<: *linux-s390x
+      env:
+        - *env_s390x
+        - DEPLOYMENT=STANDALONE_AUTH
+    - stage: Test
+      php: 7.3
+      <<: *linux-s390x
+      env:
+        - *env_s390x
+        - DEPLOYMENT=REPLICASET
+    - stage: Test
+      php: 7.3
+      <<: *linux-s390x
+      env:
+        - *env_s390x
+        - DEPLOYMENT=REPLICASET_SINGLE
+    - stage: Test
+      php: 7.3
+      <<: *linux-s390x
+      env:
+        - *env_s390x
+        - DEPLOYMENT=REPLICASET_AUTH
+        
+    # Test with different configure options on s390x
+    - stage: Test
+      php: 7.3
+      <<: *linux-s390x
+      env:
+        - *env_s390x
         - CONFIGURE_OPTS="--with-mongodb-client-side-encryption=no"
 
 before_install:
   - openssl aes-256-cbc -K $encrypted_b354efda2943_key -iv $encrypted_b354efda2943_iv -in .travis.scripts/atlas-uris.txt.enc -out .travis.scripts/atlas-uris.txt -d || true
   - pip install --user "mongo-orchestration>=0.6.7,<1.0"
   - .travis.scripts/before_install.sh
-  - export SERVER_FILENAME=mongodb-linux-x86_64-${SERVER_DISTRO}-${SERVER_VERSION}
+  - export SERVER_FILENAME=mongodb-linux-${HOSTTYPE}-${SERVER_DISTRO}-${SERVER_VERSION}
   - wget -qO- http://fastdl.mongodb.org/linux/${SERVER_FILENAME}.tgz | tar xz
   - export PATH=${PWD}/${SERVER_FILENAME}/bin:${PATH}
   - mongod --version


### PR DESCRIPTION
As Travis CI [officially supports](https://blog.travis-ci.com/2019-11-12-multi-cpu-architecture-ibm-power-ibm-z) s390x builds, adding support for same.