### PR TITLE
Only enable kms-message support if an SSL library was found

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -390,7 +390,7 @@ if test "$PHP_MONGODB" != "no"; then
 
     dnl If compiling without libmongocrypt, use kms_message sources bundled with libmongoc.
     dnl If compiling with libmongocrypt, kms_message bundled with libmongocrypt is used as it is most likely newer.
-    if test "$PHP_MONGODB_CLIENT_SIDE_ENCRYPTION" != "yes"; then
+    if test "$PHP_MONGODB_CLIENT_SIDE_ENCRYPTION" != "yes" && "$PHP_MONGODB_SSL" != "no"; then
       PHP_MONGODB_ADD_SOURCES([src/libmongoc/src/kms-message/src/], $PHP_MONGODB_KMS_MESSAGE_SOURCES, $PHP_MONGODB_BUNDLED_CFLAGS)
       PHP_MONGODB_ADD_INCLUDE([src/libmongoc/src/kms-message/src/])
       PHP_MONGODB_ADD_BUILD_DIR([src/libmongoc/src/kms-message/src/])

--- a/config.w32
+++ b/config.w32
@@ -285,8 +285,11 @@ if (PHP_MONGODB != "no") {
       mongocrypt_opts
     );
   } else if (PHP_MONGODB_CLIENT_SIDE_ENCRYPTION != "no") {
+    // No SSL library found, we can't enable libmongocrypt
     WARNING("mongodb libmongocrypt support not enabled, crypto libs not found");
+  }
 
+  if (PHP_MONGODB_CLIENT_SIDE_ENCRYPTION == "no" && mongoc_ssl_found) {
     // Add kms_message sources bundled with libmongoc
     ADD_SOURCES(configure_module_dirname + "/src/libmongoc/src/kms_message/src", PHP_MONGODB_KMS_MESSAGE_SOURCES, "mongodb");
     ADD_FLAG("CFLAGS_MONGODB", "/I" + configure_module_dirname + "/src/libmongoc/src/kms-message/src");


### PR DESCRIPTION
This PR ensures we only enable kms-message compilation in libmongoc if any SSL library was found (see https://github.com/mongodb/mongo-php-driver/pull/1105#discussion_r386732019).