### PR TITLE
PHPC-1494: Add client metadata support for wrapping libraries

### DIFF
--- a/php_phongo.c
+++ b/php_phongo.c
@@ -2459,6 +2459,16 @@ static char* php_phongo_manager_make_client_hash(const char* uri_string, zval* o
 	return hash;
 }
 
+static void php_phongo_set_handshake_data()
+{
+	char* php_version_string = malloc(4 + sizeof(PHP_VERSION) + 1);
+
+	snprintf(php_version_string, 4 + sizeof(PHP_VERSION) + 1, "PHP %s", PHP_VERSION);
+	mongoc_handshake_data_append("ext-mongodb:PHP", PHP_MONGODB_VERSION, php_version_string);
+
+	free(php_version_string);
+}
+
 static mongoc_client_t* php_phongo_make_mongo_client(const mongoc_uri_t* uri) /* {{{ */
 {
 	const char *mongoc_version, *bson_version;
@@ -2484,6 +2494,8 @@ static mongoc_client_t* php_phongo_make_mongo_client(const mongoc_uri_t* uri) /*
 		BSON_VERSION_S,
 		bson_version,
 		PHP_VERSION);
+
+	php_phongo_set_handshake_data();
 
 	return mongoc_client_new_from_uri(uri);
 } /* }}} */
@@ -3326,20 +3338,12 @@ static zend_class_entry* php_phongo_fetch_internal_class(const char* class_name,
 /* {{{ PHP_MINIT_FUNCTION */
 PHP_MINIT_FUNCTION(mongodb)
 {
-	char* php_version_string;
-
 	(void) type; /* We don't care if we are loaded via dl() or extension= */
 
 	REGISTER_INI_ENTRIES();
 
 	/* Initialize libmongoc */
 	mongoc_init();
-
-	/* Set handshake options */
-	php_version_string = malloc(4 + sizeof(PHP_VERSION) + 1);
-	snprintf(php_version_string, 4 + sizeof(PHP_VERSION) + 1, "PHP %s", PHP_VERSION);
-	mongoc_handshake_data_append("ext-mongodb:PHP", PHP_MONGODB_VERSION, php_version_string);
-	free(php_version_string);
 
 	/* Initialize libbson */
 	bson_mem_set_vtable(&MONGODB_G(bsonMemVTable));

--- a/tests/manager/manager-ctor-driver-metadata-001.phpt
+++ b/tests/manager/manager-ctor-driver-metadata-001.phpt
@@ -1,0 +1,17 @@
+--TEST--
+MongoDB\Driver\Manager: Pass custom handshake data
+--INI--
+mongodb.debug=stderr
+--FILE--
+<?php
+
+$manager = new MongoDB\Driver\Manager(null, [], ['driver' => ['name' => 'test', 'version' => '0.1', 'platform' => 'mine']]);
+$manager = new MongoDB\Driver\Manager(null, [], ['driver' => ['name' => 'test']]);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+%A[%s]     PHONGO: DEBUG   > Setting driver handshake data: name ext-mongodb:PHP / test, version %s / 0.1, platform PHP %s / mine
+%A[%s]     PHONGO: DEBUG   > Setting driver handshake data: name ext-mongodb:PHP / test, version %s, platform PHP %s
+%A===DONE===%A

--- a/tests/manager/manager-ctor_error-005.phpt
+++ b/tests/manager/manager-ctor_error-005.phpt
@@ -1,0 +1,35 @@
+--TEST--
+MongoDB\Driver\Manager::__construct(): Invalid handshake data
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$tests = [
+    (object) [],
+    'string',
+    ['name' => []],
+    ['version' => []],
+    ['platform' => []],
+];
+
+foreach ($tests as $driver) {
+    echo throws(function () use ($driver) {
+        $manager = new MongoDB\Driver\Manager(null, [], ['driver' => $driver]);
+    }, MongoDB\Driver\Exception\InvalidArgumentException::class), "\n";
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "driver" driver option to be an array, stdClass given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "driver" driver option to be an array, string given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "name" handshake option to be a string, array given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "version" handshake option to be a string, array given
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Expected "platform" handshake option to be a string, array given
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1494

This adds a new "driver" driver option, which can be used to pass custom driver metadata to be used in the server handshake.