### PR TITLE
PHPC-1591: Add tests for allowed cases when authSource is given but username is not

### DIFF
--- a/php_phongo.c
+++ b/php_phongo.c
@@ -1426,7 +1426,7 @@ static bool php_phongo_uri_finalize_auth(mongoc_uri_t* uri) /* {{{ */
 			}
 		}
 	} else if (require_auth) {
-		if (!username || strcmp(username, "") == 0) {
+		if (source && strcmp(source, "$external") != 0 && (!username || strcmp(username, "") == 0)) {
 			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Failed to parse URI options: Default authentication mechanism requires username.");
 			return false;
 		}

--- a/php_phongo.c
+++ b/php_phongo.c
@@ -1382,11 +1382,21 @@ static const char* php_phongo_bson_type_to_string(bson_type_t type) /* {{{ */
 
 static bool php_phongo_uri_finalize_auth(mongoc_uri_t* uri) /* {{{ */
 {
+	const bson_t* credentials = mongoc_uri_get_credentials(uri);
+	bson_iter_t   iter;
+	const char*   source       = NULL;
+	const char*   username     = mongoc_uri_get_username(uri);
+	bool          require_auth = username != NULL;
+
+	if (bson_iter_init_find_case(&iter, credentials, MONGOC_URI_AUTHSOURCE)) {
+		source       = bson_iter_utf8(&iter, NULL);
+		require_auth = true;
+	}
+
 	/* authSource with GSSAPI or X509 should always be external */
 	if (mongoc_uri_get_auth_mechanism(uri)) {
 		if (!strcasecmp(mongoc_uri_get_auth_mechanism(uri), "GSSAPI") ||
 			!strcasecmp(mongoc_uri_get_auth_mechanism(uri), "MONGODB-X509")) {
-			const char* source = mongoc_uri_get_auth_source(uri);
 
 			if (source) {
 				if (strcasecmp(source, "$external")) {
@@ -1414,6 +1424,11 @@ static bool php_phongo_uri_finalize_auth(mongoc_uri_t* uri) /* {{{ */
 				phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Failed to parse URI options: X509 authentication mechanism does not accept a password.");
 				return false;
 			}
+		}
+	} else if (require_auth) {
+		if (!username || strcmp(username, "") == 0) {
+			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Failed to parse URI options: Default authentication mechanism requires username.");
+			return false;
 		}
 	}
 

--- a/tests/manager/manager-ctor-auth_mechanism-error-001.phpt
+++ b/tests/manager/manager-ctor-auth_mechanism-error-001.phpt
@@ -33,6 +33,14 @@ echo throws(function() {
     new MongoDB\Driver\Manager('mongodb://localhost:27017/', ['password' => 'password', 'authMechanism' => 'MONGODB-X509']);
 }, "MongoDB\Driver\Exception\InvalidArgumentException"), "\n";
 
+echo throws(function() {
+    new MongoDB\Driver\Manager('mongodb://localhost:27017/?authSource=foo');
+}, "MongoDB\Driver\Exception\InvalidArgumentException"), "\n";
+
+echo throws(function() {
+    new MongoDB\Driver\Manager('mongodb://localhost:27017/', ['authSource' => 'foo']);
+}, "MongoDB\Driver\Exception\InvalidArgumentException"), "\n";
+
 ?>
 ===DONE===
 <?php exit(0); ?>
@@ -51,4 +59,8 @@ OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Failed to parse URI options: 'SCRAM-SHA-1' authentication mechanism requires username.
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Failed to parse URI options: X509 authentication mechanism does not accept a password.
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Failed to parse MongoDB URI: 'mongodb://localhost:27017/?authSource=foo'. Default authentication mechanism requires username.
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Failed to parse URI options: Default authentication mechanism requires username.
 ===DONE===

--- a/tests/manager/manager-ctor-auth_source-001.phpt
+++ b/tests/manager/manager-ctor-auth_source-001.phpt
@@ -1,0 +1,23 @@
+--TEST--
+MongoDB\Driver\Manager::__construct(): authSource option
+--FILE--
+<?php
+
+$tests = [
+    ['mongodb://username@127.0.0.1/?authSource=$external', []],
+    [null, ['authSource' => '$external']],
+];
+
+foreach ($tests as $test) {
+    list($uri, $options) = $test;
+
+    /* Note: the Manager's debug information does not include the auth mechanism
+     * so we are merely testing that no exception is thrown. */
+    $manager = new MongoDB\Driver\Manager($uri, $options);
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1591

Note that the suggested test in the ticket was not added as the C driver currently does not pass that test.