### PR TITLE
PHPC-1554: Tests for directConnection URI option

### DIFF
--- a/tests/manager/manager-ctor-directconnection-001.phpt
+++ b/tests/manager/manager-ctor-directconnection-001.phpt
@@ -1,0 +1,31 @@
+--TEST--
+MongoDB\Driver\Manager::__construct(): directConnection option
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_not_replica_set(); ?>
+<?php skip_if_not_enough_data_nodes(2); ?>
+--FILE--
+<?php
+
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new \MongoDB\Driver\Manager(URI, ['directConnection' => false]);
+$server = $manager->selectServer(new \MongoDB\Driver\ReadPreference('primaryPreferred'));
+
+printf("Topology has multiple nodes when directConnection=false: %s\n", count($manager->getServers()) > 1 ? 'true' : 'false');
+
+$uri = sprintf('mongodb://%s:%d', $server->getHost(), $server->getPort());
+$manager2 = new \MongoDB\Driver\Manager($uri, ['directConnection' => true]);
+$server2 = $manager2->selectServer(new \MongoDB\Driver\ReadPreference('primaryPreferred'));
+
+printf("Topology has single node when directConnection=true: %s\n", count($manager2->getServers()) == 1 ? 'true' : 'false');
+printf("Single node in topology matches seed in URI: %s\n", ($server2 == $server) ? 'true' : 'false');
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+Topology has multiple nodes when directConnection=false: true
+Topology has single node when directConnection=true: true
+Single node in topology matches seed in URI: true
+===DONE===

--- a/tests/manager/manager-ctor-directconnection-error-001.phpt
+++ b/tests/manager/manager-ctor-directconnection-error-001.phpt
@@ -1,0 +1,18 @@
+--TEST--
+MongoDB\Driver\Manager::__construct(): directConnection=true conflicts with multiple seeds
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/tools.php';
+
+echo throws(function() {
+    $manager = new \MongoDB\Driver\Manager('mongodb://a.example.com,b.example.com/?directConnection=true');
+}, "MongoDB\Driver\Exception\InvalidArgumentException"), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Failed to parse MongoDB URI: 'mongodb://a.example.com,b.example.com/?directConnection=true'. Multiple seeds not allowed with directConnection option.
+===DONE===

--- a/tests/manager/manager-ctor-directconnection-error-002.phpt
+++ b/tests/manager/manager-ctor-directconnection-error-002.phpt
@@ -1,0 +1,18 @@
+--TEST--
+MongoDB\Driver\Manager::__construct(): directConnection=true conflicts with SRV
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/tools.php';
+
+echo throws(function() {
+    $manager = new \MongoDB\Driver\Manager('mongodb+srv://a.example.com/?directConnection=true');
+}, "MongoDB\Driver\Exception\InvalidArgumentException"), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Failed to parse MongoDB URI: 'mongodb+srv://a.example.com/?directConnection=true'. SRV URI not allowed with directConnection option.
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1554

No code changes were needed as [`php_phongo_apply_options_to_uri`](https://github.com/mongodb/mongo-php-driver/blob/89b29ede8e276468db244eb752cb60c50edd926e/php_phongo.c#L1484) already handles boolean options in the URI.