### PR TITLE
PHPC-1629: Call libmongoc is_valid functions before completing WriteConcern and ReadPreference initialization

### DIFF
--- a/src/MongoDB/ReadPreference.c
+++ b/src/MongoDB/ReadPreference.c
@@ -138,6 +138,11 @@ static bool php_phongo_readpreference_init_from_hash(php_phongo_readpreference_t
 		}
 	}
 
+	if (!mongoc_read_prefs_is_valid(intern->read_preference)) {
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Read preference is not valid");
+		goto failure;
+	}
+
 	return true;
 
 failure:

--- a/tests/writeConcern/writeconcern-ctor_error-005.phpt
+++ b/tests/writeConcern/writeconcern-ctor_error-005.phpt
@@ -1,0 +1,18 @@
+--TEST--
+MongoDB\Driver\WriteConcern construction (journaling with unacknowledged w)
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/tools.php';
+
+echo throws(function() {
+    new MongoDB\Driver\WriteConcern(0, 0, true);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Cannot enable journaling when using w = 0
+===DONE===

--- a/tests/writeConcern/writeconcern-serialization_error-001.phpt
+++ b/tests/writeConcern/writeconcern-serialization_error-001.phpt
@@ -1,0 +1,18 @@
+--TEST--
+MongoDB\Driver\WriteConcern serialization errors
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/tools.php';
+
+echo throws(function() {
+    unserialize('C:27:"MongoDB\Driver\WriteConcern":30:{a:2:{s:1:"w";i:0;s:1:"j";b:1;}}');
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Cannot enable journaling when using w = 0
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1629

This PR adds `is_valid` checks for read preference and write preference initialisation. While adding this, I noticed that the initialisation logic for write concern did not check for an invalid combination of unacknowledged writes and journaling, leading to a rather unhelpful "Write concern is not valid" message. This has been rectified, with the `mongoc_write_concern_is_valid` check there as a last resort should we miss any checks added in libmongoc.