### PR TITLE
PHPC-1639: Manager::executeCommand should not inherit read preference

### DIFF
--- a/tests/manager/manager-executeCommand-006.phpt
+++ b/tests/manager/manager-executeCommand-006.phpt
@@ -1,0 +1,26 @@
+--TEST--
+MongoDB\Driver\Manager::executeCommand() does not inherit read preference
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_not_replica_set(); ?>
+<?php skip_if_no_secondary(); ?>
+<?php skip_if_not_clean(); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(URI, ['readPreference' => 'secondary']);
+
+$command = new MongoDB\Driver\Command(['ping' => 1]);
+$cursor = $manager->executeCommand(DATABASE_NAME, $command);
+
+echo "is_primary: ", $cursor->getServer()->isPrimary() ? 'true' : 'false', "\n";
+echo "is_secondary: ", $cursor->getServer()->isSecondary() ? 'true' : 'false', "\n\n";
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+is_primary: true
+is_secondary: false
+
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1639

~I've fixed this in 1.8 for the time being, but can re-target this PR on 1.7 for a July patch release. I've implemented this in 1.8 for the time being, since merging up from 1.7 to 1.8 would cause additional work due to the removal of `TSRMLS` macros in function signatures.~