### PR TITLE
PHPC-1167: Avoid dangling session pointer in bulk writes

### DIFF
--- a/php_phongo.c
+++ b/php_phongo.c
@@ -734,6 +734,7 @@ bool phongo_execute_bulk_write(mongoc_client_t* client, const char* namespace, p
 	mongoc_bulk_operation_set_hint(bulk, server_id);
 
 	if (zsession) {
+		ZVAL_ZVAL(&bulk_write->session, zsession, 1, 0);
 		mongoc_bulk_operation_set_client_session(bulk, Z_SESSION_OBJ_P(zsession)->client_session);
 	}
 

--- a/php_phongo_structs.h
+++ b/php_phongo_structs.h
@@ -29,6 +29,7 @@ typedef struct {
 	char*                    database;
 	char*                    collection;
 	bool                     executed;
+	zval                     session;
 	zend_object              std;
 } php_phongo_bulkwrite_t;
 

--- a/src/MongoDB/BulkWrite.c
+++ b/src/MongoDB/BulkWrite.c
@@ -566,6 +566,10 @@ static void php_phongo_bulkwrite_free_object(zend_object* object) /* {{{ */
 	if (intern->collection) {
 		efree(intern->collection);
 	}
+
+	if (!Z_ISUNDEF(intern->session)) {
+		zval_ptr_dtor(&intern->session);
+	}
 } /* }}} */
 
 static zend_object* php_phongo_bulkwrite_create_object(zend_class_entry* class_type) /* {{{ */
@@ -613,6 +617,13 @@ static HashTable* php_phongo_bulkwrite_get_debug_info(zval* object, int* is_temp
 
 	ADD_ASSOC_BOOL_EX(&retval, "executed", intern->executed);
 	ADD_ASSOC_LONG_EX(&retval, "server_id", mongoc_bulk_operation_get_hint(intern->bulk));
+
+	if (!Z_ISUNDEF(intern->session)) {
+		ADD_ASSOC_ZVAL_EX(&retval, "session", &intern->session);
+		Z_ADDREF(intern->session);
+	} else {
+		ADD_ASSOC_NULL_EX(&retval, "session");
+	}
 
 	if (mongoc_bulk_operation_get_write_concern(intern->bulk)) {
 		zval write_concern;

--- a/tests/bulk/bulkwrite-debug-001.phpt
+++ b/tests/bulk/bulkwrite-debug-001.phpt
@@ -32,6 +32,8 @@ object(MongoDB\Driver\BulkWrite)#%d (%d) {
   bool(false)
   ["server_id"]=>
   int(0)
+  ["session"]=>
+  NULL
   ["write_concern"]=>
   NULL
 }
@@ -48,6 +50,8 @@ object(MongoDB\Driver\BulkWrite)#%d (%d) {
   bool(false)
   ["server_id"]=>
   int(0)
+  ["session"]=>
+  NULL
   ["write_concern"]=>
   NULL
 }
@@ -64,6 +68,8 @@ object(MongoDB\Driver\BulkWrite)#%d (%d) {
   bool(false)
   ["server_id"]=>
   int(0)
+  ["session"]=>
+  NULL
   ["write_concern"]=>
   NULL
 }
@@ -80,6 +86,8 @@ object(MongoDB\Driver\BulkWrite)#%d (%d) {
   bool(false)
   ["server_id"]=>
   int(0)
+  ["session"]=>
+  NULL
   ["write_concern"]=>
   NULL
 }
@@ -96,6 +104,8 @@ object(MongoDB\Driver\BulkWrite)#%d (%d) {
   bool(false)
   ["server_id"]=>
   int(0)
+  ["session"]=>
+  NULL
   ["write_concern"]=>
   NULL
 }

--- a/tests/bulk/bulkwrite-debug-002.phpt
+++ b/tests/bulk/bulkwrite-debug-002.phpt
@@ -1,0 +1,68 @@
+--TEST--
+MongoDB\Driver\BulkWrite debug output after execution
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_not_live(); ?>
+<?php skip_if_not_clean(); ?>
+<?php skip_if_server_version('<', '3.6'); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(URI);
+
+$tests = [
+    [],
+    ['session' => $manager->startSession()],
+];
+
+foreach ($tests as $options) {
+    $bulk = new MongoDB\Driver\BulkWrite();
+    $bulk->insert(['foo' => 'bar']);
+    $manager->executeBulkWrite(NS, $bulk, $options);
+    var_dump($bulk);
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+object(MongoDB\Driver\BulkWrite)#%d (%d) {
+  ["database"]=>
+  %s
+  ["collection"]=>
+  %s
+  ["ordered"]=>
+  bool(true)
+  ["bypassDocumentValidation"]=>
+  NULL
+  ["executed"]=>
+  bool(true)
+  ["server_id"]=>
+  int(%d)
+  ["session"]=>
+  NULL
+  ["write_concern"]=>
+  NULL
+}
+object(MongoDB\Driver\BulkWrite)#%d (%d) {
+  ["database"]=>
+  %s
+  ["collection"]=>
+  %s
+  ["ordered"]=>
+  bool(true)
+  ["bypassDocumentValidation"]=>
+  NULL
+  ["executed"]=>
+  bool(true)
+  ["server_id"]=>
+  int(%d)
+  ["session"]=>
+  object(MongoDB\Driver\Session)#%d (%d) {
+    %a
+  }
+  ["write_concern"]=>
+  NULL
+}
+===DONE===

--- a/tests/bulk/write-0001.phpt
+++ b/tests/bulk/write-0001.phpt
@@ -53,6 +53,8 @@ object(MongoDB\Driver\BulkWrite)#%d (%d) {
   bool(false)
   ["server_id"]=>
   int(0)
+  ["session"]=>
+  NULL
   ["write_concern"]=>
   NULL
 }
@@ -69,6 +71,8 @@ object(MongoDB\Driver\BulkWrite)#%d (%d) {
   bool(false)
   ["server_id"]=>
   int(0)
+  ["session"]=>
+  NULL
   ["write_concern"]=>
   NULL
 }
@@ -85,6 +89,8 @@ object(MongoDB\Driver\BulkWrite)#%d (%d) {
   bool(false)
   ["server_id"]=>
   int(0)
+  ["session"]=>
+  NULL
   ["write_concern"]=>
   NULL
 }
@@ -101,6 +107,8 @@ object(MongoDB\Driver\BulkWrite)#%d (%d) {
   bool(false)
   ["server_id"]=>
   int(0)
+  ["session"]=>
+  NULL
   ["write_concern"]=>
   NULL
 }
@@ -117,6 +125,8 @@ object(MongoDB\Driver\BulkWrite)#%d (%d) {
   bool(true)
   ["server_id"]=>
   int(%r[1-9]\d*%r)
+  ["session"]=>
+  NULL
   ["write_concern"]=>
   NULL
 }

--- a/tests/bulk/write-0002.phpt
+++ b/tests/bulk/write-0002.phpt
@@ -49,6 +49,8 @@ object(MongoDB\Driver\BulkWrite)#%d (%d) {
   bool(false)
   ["server_id"]=>
   int(0)
+  ["session"]=>
+  NULL
   ["write_concern"]=>
   NULL
 }
@@ -65,6 +67,8 @@ object(MongoDB\Driver\BulkWrite)#%d (%d) {
   bool(true)
   ["server_id"]=>
   int(%r[1-9]\d*%r)
+  ["session"]=>
+  NULL
   ["write_concern"]=>
   array(%d) {
     ["w"]=>


### PR DESCRIPTION
PHPC-1167

This solution is similar to the cursor solution implemented for PHPC-1151. The bulk write keeps a copy of the session object to ensure it won't go out of scope directly after executing the bulk write. Since we don't have a use-after-free (since the session is not accessed after the bulk write has been executed), there are no tests to guard against regressions.