### PR TITLE
PHPC-1687: Always free reply from commit_transaction

### DIFF
--- a/src/MongoDB/Session.c
+++ b/src/MongoDB/Session.c
@@ -485,8 +485,9 @@ static PHP_METHOD(Session, commitTransaction)
 
 	if (!mongoc_client_session_commit_transaction(intern->client_session, &reply, &error)) {
 		phongo_throw_exception_from_bson_error_t_and_reply(&error, &reply);
-		bson_destroy(&reply);
 	}
+
+	bson_destroy(&reply);
 } /* }}} */
 
 /* {{{ proto void MongoDB\Driver\Session::abortTransaction(void)


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1687

No test changes, as the fix can be verified with:

```
TEST_PHP_ARGS=-m make test TESTS=tests/session/session-commitTransaction-001.phpt
```

Also confirmed that this fixes the original bug report in #1163.