### PR TITLE
[WAIT] PHPC-1645: Allow disabling libmongoc client persistence

### DIFF
--- a/php_phongo_structs.h
+++ b/php_phongo_structs.h
@@ -73,6 +73,7 @@ typedef struct {
 	int              created_by_pid;
 	char*            client_hash;
 	size_t           client_hash_len;
+	bool             use_persistent_client;
 	zend_object      std;
 } php_phongo_manager_t;
 

--- a/src/MongoDB/Manager.c
+++ b/src/MongoDB/Manager.c
@@ -798,7 +798,13 @@ static void php_phongo_manager_free_object(zend_object* object) /* {{{ */
 	zend_object_std_dtor(&intern->std);
 
 	if (intern->client) {
-		MONGOC_DEBUG("Not destroying persistent client for Manager");
+		if (intern->use_persistent_client) {
+			MONGOC_DEBUG("Not destroying persistent client for Manager");
+		} else {
+			MONGOC_DEBUG("Destroying private client for Manager");
+			mongoc_client_destroy(intern->client);
+		}
+
 		intern->client = NULL;
 	}
 

--- a/tests/manager/manager-ctor-007.phpt
+++ b/tests/manager/manager-ctor-007.phpt
@@ -1,0 +1,20 @@
+--TEST--
+MongoDB\Driver\Manager::__construct() reuses cached mongoc client
+--FILE--
+<?php
+
+ini_set('mongodb.debug', 'stderr');
+new MongoDB\Driver\Manager();
+new MongoDB\Driver\Manager();
+ini_set('mongodb.debug', '');
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+%A
+[%s]     PHONGO: DEBUG   > Created client with hash: %s
+%A
+[%s]     PHONGO: DEBUG   > Found client for hash: %s
+%A
+===DONE===

--- a/tests/manager/manager-ctor-008.phpt
+++ b/tests/manager/manager-ctor-008.phpt
@@ -1,0 +1,20 @@
+--TEST--
+MongoDB\Driver\Manager::__construct() does not canonicalise options
+--FILE--
+<?php
+
+ini_set('mongodb.debug', 'stderr');
+new MongoDB\Driver\Manager();
+new MongoDB\Driver\Manager('mongodb://localhost:27017/');
+ini_set('mongodb.debug', '');
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+%A
+[%s]     PHONGO: DEBUG   > Created client with hash: %s
+%A
+[%s]     PHONGO: DEBUG   > Created client with hash: %s
+%A
+===DONE===

--- a/tests/manager/manager-ctor-009.phpt
+++ b/tests/manager/manager-ctor-009.phpt
@@ -1,0 +1,38 @@
+--TEST--
+MongoDB\Driver\Manager::__construct() allows disabling client persistence
+--FILE--
+<?php
+
+ini_set('mongodb.debug', 'stderr');
+new MongoDB\Driver\Manager();
+
+// Won't reuse first client instance due to different options
+new MongoDB\Driver\Manager(null, [], ['disableClientPersistence' => false]);
+// Will reuse the previously created client
+new MongoDB\Driver\Manager(null, [], ['disableClientPersistence' => false]);
+
+// Will create a new private client
+new MongoDB\Driver\Manager(null, [], ['disableClientPersistence' => true]);
+
+// Will create another new private client
+new MongoDB\Driver\Manager(null, [], ['disableClientPersistence' => true]);
+ini_set('mongodb.debug', '');
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+%A
+[%s]     PHONGO: DEBUG   > Created client with hash: %s
+[%s]     PHONGO: DEBUG   > Persisted client with hash: %s
+[%s]     mongoc: DEBUG   > Not destroying persistent client for Manager%A
+[%s]     PHONGO: DEBUG   > Created client with hash: %s
+[%s]     PHONGO: DEBUG   > Persisted client with hash: %s
+[%s]     mongoc: DEBUG   > Not destroying persistent client for Manager%A
+[%s]     PHONGO: DEBUG   > Found client for hash: %s
+[%s]     mongoc: DEBUG   > Not destroying persistent client for Manager%A
+[%s]     PHONGO: DEBUG   > Created client with hash: %s
+[%s]     mongoc: DEBUG   > Destroying private client for Manager%A
+[%s]     PHONGO: DEBUG   > Created client with hash: %s
+[%s]     mongoc: DEBUG   > Destroying private client for Manager%A
+===DONE===


### PR DESCRIPTION
PHPC-1645

I've chosen `disableClientPersistence` as name as it implies that the option should be omitted entirely if persistence is to be enabled. Since we don't canonicalise options before creating the client hash, a manager with driverOptions `[]` will create a different client from a manager with driverOptions `['disableClientPersistence' => false]` due to the different driver options. This is intentional at this time.