### PR TITLE
PHPC-1631: Support PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,6 +101,10 @@ jobs:
       env:
         - CONFIGURE_OPTS="--with-mongodb-client-side-encryption=no"
 
+    # Test with upcoming PHP version
+    - stage: Test
+      php: nightly
+
 before_install:
   - pip install --user "mongo-orchestration>=0.6.7,<1.0"
   - .travis.scripts/before_install.sh

--- a/bin/package.xml.in
+++ b/bin/package.xml.in
@@ -59,7 +59,7 @@ necessary to build a fully-functional MongoDB driver.
   <required>
    <php>
     <min>7.0.0</min>
-    <max>7.99.99</max>
+    <max>8.99.99</max>
    </php>
    <pearinstaller>
     <min>1.4.8</min>

--- a/config.m4
+++ b/config.m4
@@ -33,47 +33,47 @@ if test "$PHP_MONGODB" != "no"; then
 
   if test "$PHP_MONGODB_DEVELOPER_FLAGS" = "yes"; then
     dnl Warn about functions which might be candidates for format attributes
-    PHP_CHECK_GCC_ARG(-Wmissing-format-attribute,       _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wmissing-format-attribute")
+    AX_CHECK_COMPILE_FLAG(-Wmissing-format-attribute,       _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wmissing-format-attribute"     ,, -Werror)
     dnl Avoid duplicating values for an enum
-    PHP_CHECK_GCC_ARG(-Wduplicate-enum,                 _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wduplicate-enum")
+    AX_CHECK_COMPILE_FLAG(-Wduplicate-enum,                 _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wduplicate-enum"               ,, -Werror)
     dnl Warns on mismatches between #ifndef and #define header guards
-    PHP_CHECK_GCC_ARG(-Wheader-guard,                   _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wheader-guard")
+    AX_CHECK_COMPILE_FLAG(-Wheader-guard,                   _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wheader-guard"                 ,, -Werror)
     dnl logical not of a non-boolean expression
-    PHP_CHECK_GCC_ARG(-Wlogical-not-parentheses,        _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wlogical-not-parentheses")
+    AX_CHECK_COMPILE_FLAG(-Wlogical-not-parentheses,        _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wlogical-not-parentheses"      ,, -Werror)
     dnl Warn about suspicious uses of logical operators in expressions
-    PHP_CHECK_GCC_ARG(-Wlogical-op,                     _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wlogical-op")
+    AX_CHECK_COMPILE_FLAG(-Wlogical-op,                     _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wlogical-op",, -Werror         ,, -Werror)
     dnl memory error detector.
-    dnl FIXME: -fsanitize=address,undefined for clang. The PHP_CHECK_GCC_ARG macro isn't happy about that string :(
-    PHP_CHECK_GCC_ARG(-fsanitize-address,               _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -fsanitize-address")
+    dnl FIXME: -fsanitize=address,undefined for clang. The AX_CHECK_COMPILE_FLAG macro isn't happy about that string :(
+    AX_CHECK_COMPILE_FLAG(-fsanitize-address,               _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -fsanitize-address"             ,, -Werror)
     dnl Enable frame debugging
-    PHP_CHECK_GCC_ARG(-fno-omit-frame-pointer,          _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -fno-omit-frame-pointer")
+    AX_CHECK_COMPILE_FLAG(-fno-omit-frame-pointer,          _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -fno-omit-frame-pointer"        ,, -Werror)
     dnl Make sure we don't optimize calls
-    PHP_CHECK_GCC_ARG(-fno-optimize-sibling-calls,      _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -fno-optimize-sibling-calls")
-    PHP_CHECK_GCC_ARG(-Wlogical-op-parentheses,         _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wlogical-op-parentheses")
-    PHP_CHECK_GCC_ARG(-Wpointer-bool-conversion,        _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wpointer-bool-conversion")
-    PHP_CHECK_GCC_ARG(-Wbool-conversion,                _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wbool-conversion")
-    PHP_CHECK_GCC_ARG(-Wloop-analysis,                  _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wloop-analysis")
-    PHP_CHECK_GCC_ARG(-Wsizeof-array-argument,          _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wsizeof-array-argument")
-    PHP_CHECK_GCC_ARG(-Wstring-conversion,              _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wstring-conversion")
-    PHP_CHECK_GCC_ARG(-Wno-variadic-macros,             _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wno-variadic-macros")
-    PHP_CHECK_GCC_ARG(-Wno-sign-compare,                _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wno-sign-compare")
-    PHP_CHECK_GCC_ARG(-fstack-protector,                _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -fstack-protector")
-    PHP_CHECK_GCC_ARG(-fno-exceptions,                  _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -fno-exceptions")
-    PHP_CHECK_GCC_ARG(-Wformat-security,                _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wformat-security")
-    PHP_CHECK_GCC_ARG(-Wformat-nonliteral,              _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wformat-nonliteral")
-    PHP_CHECK_GCC_ARG(-Winit-self,                      _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Winit-self")
-    PHP_CHECK_GCC_ARG(-Wwrite-strings,                  _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wwrite-strings")
-    PHP_CHECK_GCC_ARG(-Wenum-compare,                   _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wenum-compare")
-    PHP_CHECK_GCC_ARG(-Wempty-body,                     _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wempty-body")
-    PHP_CHECK_GCC_ARG(-Wparentheses,                    _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wparentheses")
-    PHP_CHECK_GCC_ARG(-Wdeclaration-after-statement,    _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wdeclaration-after-statement")
-    PHP_CHECK_GCC_ARG(-Wmaybe-uninitialized,            _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wmaybe-uninitialized")
-    PHP_CHECK_GCC_ARG(-Wimplicit-fallthrough,           _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wimplicit-fallthrough")
-    PHP_CHECK_GCC_ARG(-Werror,                          _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Werror")
-    PHP_CHECK_GCC_ARG(-Wextra,                          _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wextra")
-    PHP_CHECK_GCC_ARG(-Wno-unused-parameter,            _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wno-unused-parameter")
-    PHP_CHECK_GCC_ARG(-Wno-unused-but-set-variable,     _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wno-unused-but-set-variable")
-    PHP_CHECK_GCC_ARG(-Wno-missing-field-initializers,  _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wno-missing-field-initializers")
+    AX_CHECK_COMPILE_FLAG(-fno-optimize-sibling-calls,      _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -fno-optimize-sibling-calls"    ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wlogical-op-parentheses,         _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wlogical-op-parentheses"       ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wpointer-bool-conversion,        _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wpointer-bool-conversion"      ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wbool-conversion,                _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wbool-conversion"              ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wloop-analysis,                  _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wloop-analysis"                ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wsizeof-array-argument,          _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wsizeof-array-argument"        ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wstring-conversion,              _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wstring-conversion"            ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wno-variadic-macros,             _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wno-variadic-macros"           ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wno-sign-compare,                _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wno-sign-compare"              ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-fstack-protector,                _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -fstack-protector"              ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-fno-exceptions,                  _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -fno-exceptions"                ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wformat-security,                _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wformat-security"              ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wformat-nonliteral,              _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wformat-nonliteral"            ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Winit-self,                      _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Winit-self"                    ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wwrite-strings,                  _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wwrite-strings"                ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wenum-compare,                   _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wenum-compare"                 ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wempty-body,                     _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wempty-body"                   ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wparentheses,                    _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wparentheses"                  ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wdeclaration-after-statement,    _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wdeclaration-after-statement"  ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wmaybe-uninitialized,            _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wmaybe-uninitialized"          ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wimplicit-fallthrough,           _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wimplicit-fallthrough"         ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Werror,                          _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Werror"                        ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wextra,                          _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wextra"                        ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wno-unused-parameter,            _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wno-unused-parameter"          ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wno-unused-but-set-variable,     _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wno-unused-but-set-variable"   ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wno-missing-field-initializers,  _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wno-missing-field-initializers",, -Werror)
 
     MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS"
     STD_CFLAGS="-g -O0 -Wall"

--- a/phongo_compat.c
+++ b/phongo_compat.c
@@ -22,7 +22,7 @@ void phongo_add_exception_prop(const char* prop, int prop_len, zval* value)
 	if (EG(exception)) {
 		zval ex;
 		ZVAL_OBJ(&ex, EG(exception));
-		zend_update_property(Z_OBJCE(ex), &ex, prop, prop_len, value);
+		zend_update_property(Z_OBJCE(ex), PHONGO_COMPAT_OBJ_P(&ex), prop, prop_len, value);
 	}
 }
 

--- a/phongo_compat.h
+++ b/phongo_compat.h
@@ -58,6 +58,19 @@
 #define PHONGO_BREAK_INTENTIONALLY_MISSING
 #endif
 
+#if PHP_VERSION_ID >= 80000
+#define PHONGO_COMPAT_OBJ_P(val) Z_OBJ_P(val)
+#define phongo_compat_object_handler_type zend_object
+#define PHONGO_COMPAT_GET_OBJ(val) val
+#define PHONGO_COMPAT_SET_COMPARE_OBJECTS_HANDLER(type) php_phongo_handler_##type.compare = php_phongo_##type##_compare_objects;
+#else /* PHP_VERSION_ID < 80000 */
+#define PHONGO_COMPAT_OBJ_P(val) val
+#define phongo_compat_object_handler_type zval
+#define PHONGO_COMPAT_GET_OBJ(val) Z_OBJ_P(val)
+#define PHONGO_COMPAT_SET_COMPARE_OBJECTS_HANDLER(type) php_phongo_handler_##type.compare_objects = php_phongo_##type##_compare_objects;
+#define ZEND_COMPARE_OBJECTS_FALLBACK(o1, o2)
+#endif /* PHP_VERSION_ID >= 80000 */
+
 #if SIZEOF_ZEND_LONG == 8
 #define PHONGO_LONG_FORMAT PRId64
 #elif SIZEOF_ZEND_LONG == 4

--- a/src/BSON/Binary.c
+++ b/src/BSON/Binary.c
@@ -312,14 +312,14 @@ static zend_object* php_phongo_binary_create_object(zend_class_entry* class_type
 	return &intern->std;
 } /* }}} */
 
-static zend_object* php_phongo_binary_clone_object(zval* object) /* {{{ */
+static zend_object* php_phongo_binary_clone_object(phongo_compat_object_handler_type* object) /* {{{ */
 {
 	php_phongo_binary_t* intern;
 	php_phongo_binary_t* new_intern;
 	zend_object*         new_object;
 
-	intern     = Z_BINARY_OBJ_P(object);
-	new_object = php_phongo_binary_create_object(Z_OBJCE_P(object));
+	intern     = Z_OBJ_BINARY(PHONGO_COMPAT_GET_OBJ(object));
+	new_object = php_phongo_binary_create_object(PHONGO_COMPAT_GET_OBJ(object)->ce);
 
 	new_intern = Z_OBJ_BINARY(new_object);
 	zend_objects_clone_members(&new_intern->std, &intern->std);
@@ -332,6 +332,8 @@ static zend_object* php_phongo_binary_clone_object(zval* object) /* {{{ */
 static int php_phongo_binary_compare_objects(zval* o1, zval* o2) /* {{{ */
 {
 	php_phongo_binary_t *intern1, *intern2;
+
+	ZEND_COMPARE_OBJECTS_FALLBACK(o1, o2);
 
 	intern1 = Z_BINARY_OBJ_P(o1);
 	intern2 = Z_BINARY_OBJ_P(o2);
@@ -349,12 +351,12 @@ static int php_phongo_binary_compare_objects(zval* o1, zval* o2) /* {{{ */
 	return zend_binary_strcmp(intern1->data, intern1->data_len, intern2->data, intern2->data_len);
 } /* }}} */
 
-static HashTable* php_phongo_binary_get_properties_hash(zval* object, bool is_debug) /* {{{ */
+static HashTable* php_phongo_binary_get_properties_hash(phongo_compat_object_handler_type* object, bool is_debug) /* {{{ */
 {
 	php_phongo_binary_t* intern;
 	HashTable*           props;
 
-	intern = Z_BINARY_OBJ_P(object);
+	intern = Z_OBJ_BINARY(PHONGO_COMPAT_GET_OBJ(object));
 
 	PHONGO_GET_PROPERTY_HASH_INIT_PROPS(is_debug, intern, props, 2);
 
@@ -375,13 +377,13 @@ static HashTable* php_phongo_binary_get_properties_hash(zval* object, bool is_de
 	return props;
 } /* }}} */
 
-static HashTable* php_phongo_binary_get_debug_info(zval* object, int* is_temp) /* {{{ */
+static HashTable* php_phongo_binary_get_debug_info(phongo_compat_object_handler_type* object, int* is_temp) /* {{{ */
 {
 	*is_temp = 1;
 	return php_phongo_binary_get_properties_hash(object, true);
 } /* }}} */
 
-static HashTable* php_phongo_binary_get_properties(zval* object) /* {{{ */
+static HashTable* php_phongo_binary_get_properties(phongo_compat_object_handler_type* object) /* {{{ */
 {
 	return php_phongo_binary_get_properties_hash(object, false);
 } /* }}} */
@@ -402,12 +404,12 @@ void php_phongo_binary_init_ce(INIT_FUNC_ARGS) /* {{{ */
 	zend_class_implements(php_phongo_binary_ce, 1, zend_ce_serializable);
 
 	memcpy(&php_phongo_handler_binary, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	php_phongo_handler_binary.clone_obj       = php_phongo_binary_clone_object;
-	php_phongo_handler_binary.compare_objects = php_phongo_binary_compare_objects;
-	php_phongo_handler_binary.get_debug_info  = php_phongo_binary_get_debug_info;
-	php_phongo_handler_binary.get_properties  = php_phongo_binary_get_properties;
-	php_phongo_handler_binary.free_obj        = php_phongo_binary_free_object;
-	php_phongo_handler_binary.offset          = XtOffsetOf(php_phongo_binary_t, std);
+	PHONGO_COMPAT_SET_COMPARE_OBJECTS_HANDLER(binary);
+	php_phongo_handler_binary.clone_obj      = php_phongo_binary_clone_object;
+	php_phongo_handler_binary.get_debug_info = php_phongo_binary_get_debug_info;
+	php_phongo_handler_binary.get_properties = php_phongo_binary_get_properties;
+	php_phongo_handler_binary.free_obj       = php_phongo_binary_free_object;
+	php_phongo_handler_binary.offset         = XtOffsetOf(php_phongo_binary_t, std);
 
 	zend_declare_class_constant_long(php_phongo_binary_ce, ZEND_STRL("TYPE_GENERIC"), BSON_SUBTYPE_BINARY);
 	zend_declare_class_constant_long(php_phongo_binary_ce, ZEND_STRL("TYPE_FUNCTION"), BSON_SUBTYPE_FUNCTION);

--- a/src/BSON/DBPointer.c
+++ b/src/BSON/DBPointer.c
@@ -228,14 +228,14 @@ zend_object* php_phongo_dbpointer_create_object(zend_class_entry* class_type) /*
 	return &intern->std;
 } /* }}} */
 
-static zend_object* php_phongo_dbpointer_clone_object(zval* object) /* {{{ */
+static zend_object* php_phongo_dbpointer_clone_object(phongo_compat_object_handler_type* object) /* {{{ */
 {
 	php_phongo_dbpointer_t* intern;
 	php_phongo_dbpointer_t* new_intern;
 	zend_object*            new_object;
 
-	intern     = Z_DBPOINTER_OBJ_P(object);
-	new_object = php_phongo_dbpointer_create_object(Z_OBJCE_P(object));
+	intern     = Z_OBJ_DBPOINTER(PHONGO_COMPAT_GET_OBJ(object));
+	new_object = php_phongo_dbpointer_create_object(PHONGO_COMPAT_GET_OBJ(object)->ce);
 
 	new_intern = Z_OBJ_DBPOINTER(new_object);
 	zend_objects_clone_members(&new_intern->std, &intern->std);
@@ -250,6 +250,8 @@ static int php_phongo_dbpointer_compare_objects(zval* o1, zval* o2) /* {{{ */
 	php_phongo_dbpointer_t *intern1, *intern2;
 	int                     retval;
 
+	ZEND_COMPARE_OBJECTS_FALLBACK(o1, o2);
+
 	intern1 = Z_DBPOINTER_OBJ_P(o1);
 	intern2 = Z_DBPOINTER_OBJ_P(o2);
 
@@ -262,12 +264,12 @@ static int php_phongo_dbpointer_compare_objects(zval* o1, zval* o2) /* {{{ */
 	return strcmp(intern1->id, intern2->id);
 } /* }}} */
 
-HashTable* php_phongo_dbpointer_get_properties_hash(zval* object, bool is_debug) /* {{{ */
+HashTable* php_phongo_dbpointer_get_properties_hash(phongo_compat_object_handler_type* object, bool is_debug) /* {{{ */
 {
 	php_phongo_dbpointer_t* intern;
 	HashTable*              props;
 
-	intern = Z_DBPOINTER_OBJ_P(object);
+	intern = Z_OBJ_DBPOINTER(PHONGO_COMPAT_GET_OBJ(object));
 
 	PHONGO_GET_PROPERTY_HASH_INIT_PROPS(is_debug, intern, props, 2);
 
@@ -287,13 +289,13 @@ HashTable* php_phongo_dbpointer_get_properties_hash(zval* object, bool is_debug)
 	return props;
 } /* }}} */
 
-static HashTable* php_phongo_dbpointer_get_debug_info(zval* object, int* is_temp) /* {{{ */
+static HashTable* php_phongo_dbpointer_get_debug_info(phongo_compat_object_handler_type* object, int* is_temp) /* {{{ */
 {
 	*is_temp = 1;
 	return php_phongo_dbpointer_get_properties_hash(object, true);
 } /* }}} */
 
-static HashTable* php_phongo_dbpointer_get_properties(zval* object) /* {{{ */
+static HashTable* php_phongo_dbpointer_get_properties(phongo_compat_object_handler_type* object) /* {{{ */
 {
 	return php_phongo_dbpointer_get_properties_hash(object, false);
 } /* }}} */
@@ -313,12 +315,12 @@ void php_phongo_dbpointer_init_ce(INIT_FUNC_ARGS) /* {{{ */
 	zend_class_implements(php_phongo_dbpointer_ce, 1, zend_ce_serializable);
 
 	memcpy(&php_phongo_handler_dbpointer, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	php_phongo_handler_dbpointer.clone_obj       = php_phongo_dbpointer_clone_object;
-	php_phongo_handler_dbpointer.compare_objects = php_phongo_dbpointer_compare_objects;
-	php_phongo_handler_dbpointer.get_debug_info  = php_phongo_dbpointer_get_debug_info;
-	php_phongo_handler_dbpointer.get_properties  = php_phongo_dbpointer_get_properties;
-	php_phongo_handler_dbpointer.free_obj        = php_phongo_dbpointer_free_object;
-	php_phongo_handler_dbpointer.offset          = XtOffsetOf(php_phongo_dbpointer_t, std);
+	PHONGO_COMPAT_SET_COMPARE_OBJECTS_HANDLER(dbpointer);
+	php_phongo_handler_dbpointer.clone_obj      = php_phongo_dbpointer_clone_object;
+	php_phongo_handler_dbpointer.get_debug_info = php_phongo_dbpointer_get_debug_info;
+	php_phongo_handler_dbpointer.get_properties = php_phongo_dbpointer_get_properties;
+	php_phongo_handler_dbpointer.free_obj       = php_phongo_dbpointer_free_object;
+	php_phongo_handler_dbpointer.offset         = XtOffsetOf(php_phongo_dbpointer_t, std);
 } /* }}} */
 
 /*

--- a/src/BSON/Decimal128.c
+++ b/src/BSON/Decimal128.c
@@ -257,14 +257,14 @@ static zend_object* php_phongo_decimal128_create_object(zend_class_entry* class_
 	return &intern->std;
 } /* }}} */
 
-static zend_object* php_phongo_decimal128_clone_object(zval* object) /* {{{ */
+static zend_object* php_phongo_decimal128_clone_object(phongo_compat_object_handler_type* object) /* {{{ */
 {
 	php_phongo_decimal128_t* intern;
 	php_phongo_decimal128_t* new_intern;
 	zend_object*             new_object;
 
-	intern     = Z_DECIMAL128_OBJ_P(object);
-	new_object = php_phongo_decimal128_create_object(Z_OBJCE_P(object));
+	intern     = Z_OBJ_DECIMAL128(PHONGO_COMPAT_GET_OBJ(object));
+	new_object = php_phongo_decimal128_create_object(PHONGO_COMPAT_GET_OBJ(object)->ce);
 
 	new_intern = Z_OBJ_DECIMAL128(new_object);
 	zend_objects_clone_members(&new_intern->std, &intern->std);
@@ -276,13 +276,13 @@ static zend_object* php_phongo_decimal128_clone_object(zval* object) /* {{{ */
 	return new_object;
 } /* }}} */
 
-static HashTable* php_phongo_decimal128_get_properties_hash(zval* object, bool is_debug) /* {{{ */
+static HashTable* php_phongo_decimal128_get_properties_hash(phongo_compat_object_handler_type* object, bool is_debug) /* {{{ */
 {
 	php_phongo_decimal128_t* intern;
 	HashTable*               props;
 	char                     outbuf[BSON_DECIMAL128_STRING] = "";
 
-	intern = Z_DECIMAL128_OBJ_P(object);
+	intern = Z_OBJ_DECIMAL128(PHONGO_COMPAT_GET_OBJ(object));
 
 	PHONGO_GET_PROPERTY_HASH_INIT_PROPS(is_debug, intern, props, 1);
 
@@ -302,13 +302,13 @@ static HashTable* php_phongo_decimal128_get_properties_hash(zval* object, bool i
 	return props;
 } /* }}} */
 
-static HashTable* php_phongo_decimal128_get_debug_info(zval* object, int* is_temp) /* {{{ */
+static HashTable* php_phongo_decimal128_get_debug_info(phongo_compat_object_handler_type* object, int* is_temp) /* {{{ */
 {
 	*is_temp = 1;
 	return php_phongo_decimal128_get_properties_hash(object, true);
 } /* }}} */
 
-static HashTable* php_phongo_decimal128_get_properties(zval* object) /* {{{ */
+static HashTable* php_phongo_decimal128_get_properties(phongo_compat_object_handler_type* object) /* {{{ */
 {
 	return php_phongo_decimal128_get_properties_hash(object, false);
 } /* }}} */

--- a/src/BSON/Int64.c
+++ b/src/BSON/Int64.c
@@ -211,14 +211,14 @@ zend_object* php_phongo_int64_create_object(zend_class_entry* class_type) /* {{{
 	return &intern->std;
 } /* }}} */
 
-static zend_object* php_phongo_int64_clone_object(zval* object) /* {{{ */
+static zend_object* php_phongo_int64_clone_object(phongo_compat_object_handler_type* object) /* {{{ */
 {
 	php_phongo_int64_t* intern;
 	php_phongo_int64_t* new_intern;
 	zend_object*        new_object;
 
-	intern     = Z_INT64_OBJ_P(object);
-	new_object = php_phongo_int64_create_object(Z_OBJCE_P(object));
+	intern     = Z_OBJ_INT64(PHONGO_COMPAT_GET_OBJ(object));
+	new_object = php_phongo_int64_create_object(PHONGO_COMPAT_GET_OBJ(object)->ce);
 
 	new_intern = Z_OBJ_INT64(new_object);
 	zend_objects_clone_members(&new_intern->std, &intern->std);
@@ -232,6 +232,8 @@ static int php_phongo_int64_compare_objects(zval* o1, zval* o2) /* {{{ */
 {
 	php_phongo_int64_t *intern1, *intern2;
 
+	ZEND_COMPARE_OBJECTS_FALLBACK(o1, o2);
+
 	intern1 = Z_INT64_OBJ_P(o1);
 	intern2 = Z_INT64_OBJ_P(o2);
 
@@ -242,12 +244,12 @@ static int php_phongo_int64_compare_objects(zval* o1, zval* o2) /* {{{ */
 	return 0;
 } /* }}} */
 
-HashTable* php_phongo_int64_get_properties_hash(zval* object, bool is_debug) /* {{{ */
+HashTable* php_phongo_int64_get_properties_hash(phongo_compat_object_handler_type* object, bool is_debug) /* {{{ */
 {
 	php_phongo_int64_t* intern;
 	HashTable*          props;
 
-	intern = Z_INT64_OBJ_P(object);
+	intern = Z_OBJ_INT64(PHONGO_COMPAT_GET_OBJ(object));
 
 	PHONGO_GET_PROPERTY_HASH_INIT_PROPS(is_debug, intern, props, 2);
 
@@ -265,13 +267,13 @@ HashTable* php_phongo_int64_get_properties_hash(zval* object, bool is_debug) /* 
 	return props;
 } /* }}} */
 
-static HashTable* php_phongo_int64_get_debug_info(zval* object, int* is_temp) /* {{{ */
+static HashTable* php_phongo_int64_get_debug_info(phongo_compat_object_handler_type* object, int* is_temp) /* {{{ */
 {
 	*is_temp = 1;
 	return php_phongo_int64_get_properties_hash(object, true);
 } /* }}} */
 
-static HashTable* php_phongo_int64_get_properties(zval* object) /* {{{ */
+static HashTable* php_phongo_int64_get_properties(phongo_compat_object_handler_type* object) /* {{{ */
 {
 	return php_phongo_int64_get_properties_hash(object, false);
 } /* }}} */
@@ -291,12 +293,12 @@ void php_phongo_int64_init_ce(INIT_FUNC_ARGS) /* {{{ */
 	zend_class_implements(php_phongo_int64_ce, 1, zend_ce_serializable);
 
 	memcpy(&php_phongo_handler_int64, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	php_phongo_handler_int64.clone_obj       = php_phongo_int64_clone_object;
-	php_phongo_handler_int64.compare_objects = php_phongo_int64_compare_objects;
-	php_phongo_handler_int64.get_debug_info  = php_phongo_int64_get_debug_info;
-	php_phongo_handler_int64.get_properties  = php_phongo_int64_get_properties;
-	php_phongo_handler_int64.free_obj        = php_phongo_int64_free_object;
-	php_phongo_handler_int64.offset          = XtOffsetOf(php_phongo_int64_t, std);
+	PHONGO_COMPAT_SET_COMPARE_OBJECTS_HANDLER(int64);
+	php_phongo_handler_int64.clone_obj      = php_phongo_int64_clone_object;
+	php_phongo_handler_int64.get_debug_info = php_phongo_int64_get_debug_info;
+	php_phongo_handler_int64.get_properties = php_phongo_int64_get_properties;
+	php_phongo_handler_int64.free_obj       = php_phongo_int64_free_object;
+	php_phongo_handler_int64.offset         = XtOffsetOf(php_phongo_int64_t, std);
 } /* }}} */
 
 /*

--- a/src/BSON/Javascript.c
+++ b/src/BSON/Javascript.c
@@ -351,14 +351,14 @@ zend_object* php_phongo_javascript_create_object(zend_class_entry* class_type) /
 	return &intern->std;
 } /* }}} */
 
-static zend_object* php_phongo_javascript_clone_object(zval* object) /* {{{ */
+static zend_object* php_phongo_javascript_clone_object(phongo_compat_object_handler_type* object) /* {{{ */
 {
 	php_phongo_javascript_t* intern;
 	php_phongo_javascript_t* new_intern;
 	zend_object*             new_object;
 
-	intern     = Z_JAVASCRIPT_OBJ_P(object);
-	new_object = php_phongo_javascript_create_object(Z_OBJCE_P(object));
+	intern     = Z_OBJ_JAVASCRIPT(PHONGO_COMPAT_GET_OBJ(object));
+	new_object = php_phongo_javascript_create_object(PHONGO_COMPAT_GET_OBJ(object)->ce);
 
 	new_intern = Z_OBJ_JAVASCRIPT(new_object);
 	zend_objects_clone_members(&new_intern->std, &intern->std);
@@ -373,6 +373,8 @@ static int php_phongo_javascript_compare_objects(zval* o1, zval* o2) /* {{{ */
 {
 	php_phongo_javascript_t *intern1, *intern2;
 
+	ZEND_COMPARE_OBJECTS_FALLBACK(o1, o2);
+
 	intern1 = Z_JAVASCRIPT_OBJ_P(o1);
 	intern2 = Z_JAVASCRIPT_OBJ_P(o2);
 
@@ -380,12 +382,12 @@ static int php_phongo_javascript_compare_objects(zval* o1, zval* o2) /* {{{ */
 	return strcmp(intern1->code, intern2->code);
 } /* }}} */
 
-HashTable* php_phongo_javascript_get_properties_hash(zval* object, bool is_debug) /* {{{ */
+HashTable* php_phongo_javascript_get_properties_hash(phongo_compat_object_handler_type* object, bool is_debug) /* {{{ */
 {
 	php_phongo_javascript_t* intern;
 	HashTable*               props;
 
-	intern = Z_JAVASCRIPT_OBJ_P(object);
+	intern = Z_OBJ_JAVASCRIPT(PHONGO_COMPAT_GET_OBJ(object));
 
 	PHONGO_GET_PROPERTY_HASH_INIT_PROPS(is_debug, intern, props, 2);
 
@@ -424,13 +426,13 @@ failure:
 	return NULL;
 } /* }}} */
 
-static HashTable* php_phongo_javascript_get_debug_info(zval* object, int* is_temp) /* {{{ */
+static HashTable* php_phongo_javascript_get_debug_info(phongo_compat_object_handler_type* object, int* is_temp) /* {{{ */
 {
 	*is_temp = 1;
 	return php_phongo_javascript_get_properties_hash(object, true);
 } /* }}} */
 
-static HashTable* php_phongo_javascript_get_properties(zval* object) /* {{{ */
+static HashTable* php_phongo_javascript_get_properties(phongo_compat_object_handler_type* object) /* {{{ */
 {
 	return php_phongo_javascript_get_properties_hash(object, false);
 } /* }}} */
@@ -451,12 +453,12 @@ void php_phongo_javascript_init_ce(INIT_FUNC_ARGS) /* {{{ */
 	zend_class_implements(php_phongo_javascript_ce, 1, zend_ce_serializable);
 
 	memcpy(&php_phongo_handler_javascript, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	php_phongo_handler_javascript.clone_obj       = php_phongo_javascript_clone_object;
-	php_phongo_handler_javascript.compare_objects = php_phongo_javascript_compare_objects;
-	php_phongo_handler_javascript.get_debug_info  = php_phongo_javascript_get_debug_info;
-	php_phongo_handler_javascript.get_properties  = php_phongo_javascript_get_properties;
-	php_phongo_handler_javascript.free_obj        = php_phongo_javascript_free_object;
-	php_phongo_handler_javascript.offset          = XtOffsetOf(php_phongo_javascript_t, std);
+	PHONGO_COMPAT_SET_COMPARE_OBJECTS_HANDLER(javascript);
+	php_phongo_handler_javascript.clone_obj      = php_phongo_javascript_clone_object;
+	php_phongo_handler_javascript.get_debug_info = php_phongo_javascript_get_debug_info;
+	php_phongo_handler_javascript.get_properties = php_phongo_javascript_get_properties;
+	php_phongo_handler_javascript.free_obj       = php_phongo_javascript_free_object;
+	php_phongo_handler_javascript.offset         = XtOffsetOf(php_phongo_javascript_t, std);
 } /* }}} */
 
 /*

--- a/src/BSON/ObjectId.c
+++ b/src/BSON/ObjectId.c
@@ -296,14 +296,14 @@ static zend_object* php_phongo_objectid_create_object(zend_class_entry* class_ty
 	return &intern->std;
 } /* }}} */
 
-static zend_object* php_phongo_objectid_clone_object(zval* object) /* {{{ */
+static zend_object* php_phongo_objectid_clone_object(phongo_compat_object_handler_type* object) /* {{{ */
 {
 	php_phongo_objectid_t* intern;
 	php_phongo_objectid_t* new_intern;
 	zend_object*           new_object;
 
-	intern     = Z_OBJECTID_OBJ_P(object);
-	new_object = php_phongo_objectid_create_object(Z_OBJCE_P(object));
+	intern     = Z_OBJ_OBJECTID(PHONGO_COMPAT_GET_OBJ(object));
+	new_object = php_phongo_objectid_create_object(PHONGO_COMPAT_GET_OBJ(object)->ce);
 
 	new_intern = Z_OBJ_OBJECTID(new_object);
 	zend_objects_clone_members(&new_intern->std, &intern->std);
@@ -320,18 +320,20 @@ static int php_phongo_objectid_compare_objects(zval* o1, zval* o2) /* {{{ */
 	php_phongo_objectid_t* intern1;
 	php_phongo_objectid_t* intern2;
 
+	ZEND_COMPARE_OBJECTS_FALLBACK(o1, o2);
+
 	intern1 = Z_OBJECTID_OBJ_P(o1);
 	intern2 = Z_OBJECTID_OBJ_P(o2);
 
 	return strcmp(intern1->oid, intern2->oid);
 } /* }}} */
 
-static HashTable* php_phongo_objectid_get_properties_hash(zval* object, bool is_debug) /* {{{ */
+static HashTable* php_phongo_objectid_get_properties_hash(phongo_compat_object_handler_type* object, bool is_debug) /* {{{ */
 {
 	php_phongo_objectid_t* intern;
 	HashTable*             props;
 
-	intern = Z_OBJECTID_OBJ_P(object);
+	intern = Z_OBJ_OBJECTID(PHONGO_COMPAT_GET_OBJ(object));
 
 	PHONGO_GET_PROPERTY_HASH_INIT_PROPS(is_debug, intern, props, 1);
 
@@ -349,13 +351,13 @@ static HashTable* php_phongo_objectid_get_properties_hash(zval* object, bool is_
 	return props;
 } /* }}} */
 
-static HashTable* php_phongo_objectid_get_debug_info(zval* object, int* is_temp) /* {{{ */
+static HashTable* php_phongo_objectid_get_debug_info(phongo_compat_object_handler_type* object, int* is_temp) /* {{{ */
 {
 	*is_temp = 1;
 	return php_phongo_objectid_get_properties_hash(object, true);
 } /* }}} */
 
-static HashTable* php_phongo_objectid_get_properties(zval* object) /* {{{ */
+static HashTable* php_phongo_objectid_get_properties(phongo_compat_object_handler_type* object) /* {{{ */
 {
 	return php_phongo_objectid_get_properties_hash(object, false);
 } /* }}} */
@@ -376,12 +378,12 @@ void php_phongo_objectid_init_ce(INIT_FUNC_ARGS) /* {{{ */
 	zend_class_implements(php_phongo_objectid_ce, 1, zend_ce_serializable);
 
 	memcpy(&php_phongo_handler_objectid, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	php_phongo_handler_objectid.clone_obj       = php_phongo_objectid_clone_object;
-	php_phongo_handler_objectid.compare_objects = php_phongo_objectid_compare_objects;
-	php_phongo_handler_objectid.get_debug_info  = php_phongo_objectid_get_debug_info;
-	php_phongo_handler_objectid.get_properties  = php_phongo_objectid_get_properties;
-	php_phongo_handler_objectid.free_obj        = php_phongo_objectid_free_object;
-	php_phongo_handler_objectid.offset          = XtOffsetOf(php_phongo_objectid_t, std);
+	PHONGO_COMPAT_SET_COMPARE_OBJECTS_HANDLER(objectid);
+	php_phongo_handler_objectid.clone_obj      = php_phongo_objectid_clone_object;
+	php_phongo_handler_objectid.get_debug_info = php_phongo_objectid_get_debug_info;
+	php_phongo_handler_objectid.get_properties = php_phongo_objectid_get_properties;
+	php_phongo_handler_objectid.free_obj       = php_phongo_objectid_free_object;
+	php_phongo_handler_objectid.offset         = XtOffsetOf(php_phongo_objectid_t, std);
 } /* }}} */
 
 /*

--- a/src/BSON/Regex.c
+++ b/src/BSON/Regex.c
@@ -325,14 +325,14 @@ static zend_object* php_phongo_regex_create_object(zend_class_entry* class_type)
 	return &intern->std;
 } /* }}} */
 
-static zend_object* php_phongo_regex_clone_object(zval* object) /* {{{ */
+static zend_object* php_phongo_regex_clone_object(phongo_compat_object_handler_type* object) /* {{{ */
 {
 	php_phongo_regex_t* intern;
 	php_phongo_regex_t* new_intern;
 	zend_object*        new_object;
 
-	intern     = Z_REGEX_OBJ_P(object);
-	new_object = php_phongo_regex_create_object(Z_OBJCE_P(object));
+	intern     = Z_OBJ_REGEX(PHONGO_COMPAT_GET_OBJ(object));
+	new_object = php_phongo_regex_create_object(PHONGO_COMPAT_GET_OBJ(object)->ce);
 
 	new_intern = Z_OBJ_REGEX(new_object);
 	zend_objects_clone_members(&new_intern->std, &intern->std);
@@ -347,6 +347,8 @@ static int php_phongo_regex_compare_objects(zval* o1, zval* o2) /* {{{ */
 	php_phongo_regex_t *intern1, *intern2;
 	int                 retval;
 
+	ZEND_COMPARE_OBJECTS_FALLBACK(o1, o2);
+
 	intern1 = Z_REGEX_OBJ_P(o1);
 	intern2 = Z_REGEX_OBJ_P(o2);
 
@@ -360,12 +362,12 @@ static int php_phongo_regex_compare_objects(zval* o1, zval* o2) /* {{{ */
 	return strcmp(intern1->flags, intern2->flags);
 } /* }}} */
 
-static HashTable* php_phongo_regex_get_properties_hash(zval* object, bool is_debug) /* {{{ */
+static HashTable* php_phongo_regex_get_properties_hash(phongo_compat_object_handler_type* object, bool is_debug) /* {{{ */
 {
 	php_phongo_regex_t* intern;
 	HashTable*          props;
 
-	intern = Z_REGEX_OBJ_P(object);
+	intern = Z_OBJ_REGEX(PHONGO_COMPAT_GET_OBJ(object));
 
 	PHONGO_GET_PROPERTY_HASH_INIT_PROPS(is_debug, intern, props, 2);
 
@@ -386,13 +388,13 @@ static HashTable* php_phongo_regex_get_properties_hash(zval* object, bool is_deb
 	return props;
 } /* }}} */
 
-static HashTable* php_phongo_regex_get_debug_info(zval* object, int* is_temp) /* {{{ */
+static HashTable* php_phongo_regex_get_debug_info(phongo_compat_object_handler_type* object, int* is_temp) /* {{{ */
 {
 	*is_temp = 1;
 	return php_phongo_regex_get_properties_hash(object, true);
 } /* }}} */
 
-static HashTable* php_phongo_regex_get_properties(zval* object) /* {{{ */
+static HashTable* php_phongo_regex_get_properties(phongo_compat_object_handler_type* object) /* {{{ */
 {
 	return php_phongo_regex_get_properties_hash(object, false);
 } /* }}} */
@@ -413,12 +415,12 @@ void php_phongo_regex_init_ce(INIT_FUNC_ARGS) /* {{{ */
 	zend_class_implements(php_phongo_regex_ce, 1, php_phongo_json_serializable_ce);
 
 	memcpy(&php_phongo_handler_regex, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	php_phongo_handler_regex.clone_obj       = php_phongo_regex_clone_object;
-	php_phongo_handler_regex.compare_objects = php_phongo_regex_compare_objects;
-	php_phongo_handler_regex.get_debug_info  = php_phongo_regex_get_debug_info;
-	php_phongo_handler_regex.get_properties  = php_phongo_regex_get_properties;
-	php_phongo_handler_regex.free_obj        = php_phongo_regex_free_object;
-	php_phongo_handler_regex.offset          = XtOffsetOf(php_phongo_regex_t, std);
+	PHONGO_COMPAT_SET_COMPARE_OBJECTS_HANDLER(regex);
+	php_phongo_handler_regex.clone_obj      = php_phongo_regex_clone_object;
+	php_phongo_handler_regex.get_debug_info = php_phongo_regex_get_debug_info;
+	php_phongo_handler_regex.get_properties = php_phongo_regex_get_properties;
+	php_phongo_handler_regex.free_obj       = php_phongo_regex_free_object;
+	php_phongo_handler_regex.offset         = XtOffsetOf(php_phongo_regex_t, std);
 } /* }}} */
 
 /*

--- a/src/BSON/Regex.c
+++ b/src/BSON/Regex.c
@@ -257,7 +257,7 @@ static PHP_METHOD(Regex, unserialize)
 } /* }}} */
 
 /* {{{ MongoDB\BSON\Regex function entries */
-ZEND_BEGIN_ARG_INFO_EX(ai_Regex___construct, 0, 0, 2)
+ZEND_BEGIN_ARG_INFO_EX(ai_Regex___construct, 0, 0, 1)
 	ZEND_ARG_INFO(0, pattern)
 	ZEND_ARG_INFO(0, flags)
 ZEND_END_ARG_INFO()

--- a/src/BSON/Symbol.c
+++ b/src/BSON/Symbol.c
@@ -206,14 +206,14 @@ zend_object* php_phongo_symbol_create_object(zend_class_entry* class_type) /* {{
 	return &intern->std;
 } /* }}} */
 
-static zend_object* php_phongo_symbol_clone_object(zval* object) /* {{{ */
+static zend_object* php_phongo_symbol_clone_object(phongo_compat_object_handler_type* object) /* {{{ */
 {
 	php_phongo_symbol_t* intern;
 	php_phongo_symbol_t* new_intern;
 	zend_object*         new_object;
 
-	intern     = Z_SYMBOL_OBJ_P(object);
-	new_object = php_phongo_symbol_create_object(Z_OBJCE_P(object));
+	intern     = Z_OBJ_SYMBOL(PHONGO_COMPAT_GET_OBJ(object));
+	new_object = php_phongo_symbol_create_object(PHONGO_COMPAT_GET_OBJ(object)->ce);
 
 	new_intern = Z_OBJ_SYMBOL(new_object);
 	zend_objects_clone_members(&new_intern->std, &intern->std);
@@ -227,18 +227,20 @@ static int php_phongo_symbol_compare_objects(zval* o1, zval* o2) /* {{{ */
 {
 	php_phongo_symbol_t *intern1, *intern2;
 
+	ZEND_COMPARE_OBJECTS_FALLBACK(o1, o2);
+
 	intern1 = Z_SYMBOL_OBJ_P(o1);
 	intern2 = Z_SYMBOL_OBJ_P(o2);
 
 	return strcmp(intern1->symbol, intern2->symbol);
 } /* }}} */
 
-HashTable* php_phongo_symbol_get_properties_hash(zval* object, bool is_debug) /* {{{ */
+HashTable* php_phongo_symbol_get_properties_hash(phongo_compat_object_handler_type* object, bool is_debug) /* {{{ */
 {
 	php_phongo_symbol_t* intern;
 	HashTable*           props;
 
-	intern = Z_SYMBOL_OBJ_P(object);
+	intern = Z_OBJ_SYMBOL(PHONGO_COMPAT_GET_OBJ(object));
 
 	PHONGO_GET_PROPERTY_HASH_INIT_PROPS(is_debug, intern, props, 2);
 
@@ -256,13 +258,13 @@ HashTable* php_phongo_symbol_get_properties_hash(zval* object, bool is_debug) /*
 	return props;
 } /* }}} */
 
-static HashTable* php_phongo_symbol_get_debug_info(zval* object, int* is_temp) /* {{{ */
+static HashTable* php_phongo_symbol_get_debug_info(phongo_compat_object_handler_type* object, int* is_temp) /* {{{ */
 {
 	*is_temp = 1;
 	return php_phongo_symbol_get_properties_hash(object, true);
 } /* }}} */
 
-static HashTable* php_phongo_symbol_get_properties(zval* object) /* {{{ */
+static HashTable* php_phongo_symbol_get_properties(phongo_compat_object_handler_type* object) /* {{{ */
 {
 	return php_phongo_symbol_get_properties_hash(object, false);
 } /* }}} */
@@ -282,12 +284,12 @@ void php_phongo_symbol_init_ce(INIT_FUNC_ARGS) /* {{{ */
 	zend_class_implements(php_phongo_symbol_ce, 1, zend_ce_serializable);
 
 	memcpy(&php_phongo_handler_symbol, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	php_phongo_handler_symbol.clone_obj       = php_phongo_symbol_clone_object;
-	php_phongo_handler_symbol.compare_objects = php_phongo_symbol_compare_objects;
-	php_phongo_handler_symbol.get_debug_info  = php_phongo_symbol_get_debug_info;
-	php_phongo_handler_symbol.get_properties  = php_phongo_symbol_get_properties;
-	php_phongo_handler_symbol.free_obj        = php_phongo_symbol_free_object;
-	php_phongo_handler_symbol.offset          = XtOffsetOf(php_phongo_symbol_t, std);
+	PHONGO_COMPAT_SET_COMPARE_OBJECTS_HANDLER(symbol);
+	php_phongo_handler_symbol.clone_obj      = php_phongo_symbol_clone_object;
+	php_phongo_handler_symbol.get_debug_info = php_phongo_symbol_get_debug_info;
+	php_phongo_handler_symbol.get_properties = php_phongo_symbol_get_properties;
+	php_phongo_handler_symbol.free_obj       = php_phongo_symbol_free_object;
+	php_phongo_handler_symbol.offset         = XtOffsetOf(php_phongo_symbol_t, std);
 } /* }}} */
 
 /*

--- a/src/BSON/Timestamp.c
+++ b/src/BSON/Timestamp.c
@@ -359,14 +359,14 @@ static zend_object* php_phongo_timestamp_create_object(zend_class_entry* class_t
 	return &intern->std;
 } /* }}} */
 
-static zend_object* php_phongo_timestamp_clone_object(zval* object) /* {{{ */
+static zend_object* php_phongo_timestamp_clone_object(phongo_compat_object_handler_type* object) /* {{{ */
 {
 	php_phongo_timestamp_t* intern;
 	php_phongo_timestamp_t* new_intern;
 	zend_object*            new_object;
 
-	intern     = Z_TIMESTAMP_OBJ_P(object);
-	new_object = php_phongo_timestamp_create_object(Z_OBJCE_P(object));
+	intern     = Z_OBJ_TIMESTAMP(PHONGO_COMPAT_GET_OBJ(object));
+	new_object = php_phongo_timestamp_create_object(PHONGO_COMPAT_GET_OBJ(object)->ce);
 
 	new_intern = Z_OBJ_TIMESTAMP(new_object);
 	zend_objects_clone_members(&new_intern->std, &intern->std);
@@ -379,6 +379,8 @@ static zend_object* php_phongo_timestamp_clone_object(zval* object) /* {{{ */
 static int php_phongo_timestamp_compare_objects(zval* o1, zval* o2) /* {{{ */
 {
 	php_phongo_timestamp_t *intern1, *intern2;
+
+	ZEND_COMPARE_OBJECTS_FALLBACK(o1, o2);
 
 	intern1 = Z_TIMESTAMP_OBJ_P(o1);
 	intern2 = Z_TIMESTAMP_OBJ_P(o2);
@@ -395,7 +397,7 @@ static int php_phongo_timestamp_compare_objects(zval* o1, zval* o2) /* {{{ */
 	return 0;
 } /* }}} */
 
-static HashTable* php_phongo_timestamp_get_properties_hash(zval* object, bool is_debug) /* {{{ */
+static HashTable* php_phongo_timestamp_get_properties_hash(phongo_compat_object_handler_type* object, bool is_debug) /* {{{ */
 {
 	php_phongo_timestamp_t* intern;
 	HashTable*              props;
@@ -404,7 +406,7 @@ static HashTable* php_phongo_timestamp_get_properties_hash(zval* object, bool is
 	int                     s_increment_len;
 	int                     s_timestamp_len;
 
-	intern = Z_TIMESTAMP_OBJ_P(object);
+	intern = Z_OBJ_TIMESTAMP(PHONGO_COMPAT_GET_OBJ(object));
 
 	PHONGO_GET_PROPERTY_HASH_INIT_PROPS(is_debug, intern, props, 2);
 
@@ -428,13 +430,13 @@ static HashTable* php_phongo_timestamp_get_properties_hash(zval* object, bool is
 	return props;
 } /* }}} */
 
-static HashTable* php_phongo_timestamp_get_debug_info(zval* object, int* is_temp) /* {{{ */
+static HashTable* php_phongo_timestamp_get_debug_info(phongo_compat_object_handler_type* object, int* is_temp) /* {{{ */
 {
 	*is_temp = 1;
 	return php_phongo_timestamp_get_properties_hash(object, true);
 } /* }}} */
 
-static HashTable* php_phongo_timestamp_get_properties(zval* object) /* {{{ */
+static HashTable* php_phongo_timestamp_get_properties(phongo_compat_object_handler_type* object) /* {{{ */
 {
 	return php_phongo_timestamp_get_properties_hash(object, false);
 } /* }}} */
@@ -455,12 +457,12 @@ void php_phongo_timestamp_init_ce(INIT_FUNC_ARGS) /* {{{ */
 	zend_class_implements(php_phongo_timestamp_ce, 1, zend_ce_serializable);
 
 	memcpy(&php_phongo_handler_timestamp, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	php_phongo_handler_timestamp.clone_obj       = php_phongo_timestamp_clone_object;
-	php_phongo_handler_timestamp.compare_objects = php_phongo_timestamp_compare_objects;
-	php_phongo_handler_timestamp.get_debug_info  = php_phongo_timestamp_get_debug_info;
-	php_phongo_handler_timestamp.get_properties  = php_phongo_timestamp_get_properties;
-	php_phongo_handler_timestamp.free_obj        = php_phongo_timestamp_free_object;
-	php_phongo_handler_timestamp.offset          = XtOffsetOf(php_phongo_timestamp_t, std);
+	PHONGO_COMPAT_SET_COMPARE_OBJECTS_HANDLER(timestamp);
+	php_phongo_handler_timestamp.clone_obj      = php_phongo_timestamp_clone_object;
+	php_phongo_handler_timestamp.get_debug_info = php_phongo_timestamp_get_debug_info;
+	php_phongo_handler_timestamp.get_properties = php_phongo_timestamp_get_properties;
+	php_phongo_handler_timestamp.free_obj       = php_phongo_timestamp_free_object;
+	php_phongo_handler_timestamp.offset         = XtOffsetOf(php_phongo_timestamp_t, std);
 } /* }}} */
 
 /*

--- a/src/BSON/UTCDateTime.c
+++ b/src/BSON/UTCDateTime.c
@@ -45,12 +45,12 @@ static bool php_phongo_utcdatetime_init(php_phongo_utcdatetime_t* intern, int64_
 
 /* Initialize the object from a numeric string and return whether it was
  * successful. An exception will be thrown on error. */
-static bool php_phongo_utcdatetime_init_from_string(php_phongo_utcdatetime_t* intern, const char* s_milliseconds, size_t s_milliseconds_len TSRMLS_DC) /* {{{ */
+static bool php_phongo_utcdatetime_init_from_string(php_phongo_utcdatetime_t* intern, const char* s_milliseconds, size_t s_milliseconds_len) /* {{{ */
 {
 	int64_t milliseconds;
 
 	if (!php_phongo_parse_int64(&milliseconds, s_milliseconds, s_milliseconds_len)) {
-		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Error parsing \"%s\" as 64-bit integer for %s initialization", s_milliseconds, ZSTR_VAL(php_phongo_utcdatetime_ce->name));
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Error parsing \"%s\" as 64-bit integer for %s initialization", s_milliseconds, ZSTR_VAL(php_phongo_utcdatetime_ce->name));
 		return false;
 	}
 
@@ -59,7 +59,7 @@ static bool php_phongo_utcdatetime_init_from_string(php_phongo_utcdatetime_t* in
 
 /* Initialize the object from a HashTable and return whether it was successful.
  * An exception will be thrown on error. */
-static bool php_phongo_utcdatetime_init_from_hash(php_phongo_utcdatetime_t* intern, HashTable* props TSRMLS_DC) /* {{{ */
+static bool php_phongo_utcdatetime_init_from_hash(php_phongo_utcdatetime_t* intern, HashTable* props) /* {{{ */
 {
 	zval* milliseconds;
 
@@ -68,10 +68,10 @@ static bool php_phongo_utcdatetime_init_from_hash(php_phongo_utcdatetime_t* inte
 	}
 
 	if ((milliseconds = zend_hash_str_find(props, "milliseconds", sizeof("milliseconds") - 1)) && Z_TYPE_P(milliseconds) == IS_STRING) {
-		return php_phongo_utcdatetime_init_from_string(intern, Z_STRVAL_P(milliseconds), Z_STRLEN_P(milliseconds) TSRMLS_CC);
+		return php_phongo_utcdatetime_init_from_string(intern, Z_STRVAL_P(milliseconds), Z_STRLEN_P(milliseconds));
 	}
 
-	phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "%s initialization requires \"milliseconds\" integer or numeric string field", ZSTR_VAL(php_phongo_utcdatetime_ce->name));
+	phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "%s initialization requires \"milliseconds\" integer or numeric string field", ZSTR_VAL(php_phongo_utcdatetime_ce->name));
 	return false;
 } /* }}} */
 
@@ -122,14 +122,14 @@ static PHP_METHOD(UTCDateTime, __construct)
 	zend_error_handling       error_handling;
 	zval*                     milliseconds = NULL;
 
-	zend_replace_error_handling(EH_THROW, phongo_exception_from_phongo_domain(PHONGO_ERROR_INVALID_ARGUMENT), &error_handling TSRMLS_CC);
+	zend_replace_error_handling(EH_THROW, phongo_exception_from_phongo_domain(PHONGO_ERROR_INVALID_ARGUMENT), &error_handling);
 	intern = Z_UTCDATETIME_OBJ_P(getThis());
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|z!", &milliseconds) == FAILURE) {
-		zend_restore_error_handling(&error_handling TSRMLS_CC);
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|z!", &milliseconds) == FAILURE) {
+		zend_restore_error_handling(&error_handling);
 		return;
 	}
-	zend_restore_error_handling(&error_handling TSRMLS_CC);
+	zend_restore_error_handling(&error_handling);
 
 	if (milliseconds == NULL) {
 		php_phongo_utcdatetime_init_from_current_time(intern);
@@ -137,12 +137,12 @@ static PHP_METHOD(UTCDateTime, __construct)
 	}
 
 	if (Z_TYPE_P(milliseconds) == IS_OBJECT) {
-		if (instanceof_function(Z_OBJCE_P(milliseconds), php_date_get_date_ce() TSRMLS_CC) ||
-			(php_phongo_date_immutable_ce && instanceof_function(Z_OBJCE_P(milliseconds), php_phongo_date_immutable_ce TSRMLS_CC))) {
+		if (instanceof_function(Z_OBJCE_P(milliseconds), php_date_get_date_ce()) ||
+			(php_phongo_date_immutable_ce && instanceof_function(Z_OBJCE_P(milliseconds), php_phongo_date_immutable_ce))) {
 
 			php_phongo_utcdatetime_init_from_date(intern, Z_PHPDATE_P(milliseconds));
 		} else {
-			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Expected instance of DateTimeInterface, %s given", ZSTR_VAL(Z_OBJCE_P(milliseconds)->name));
+			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected instance of DateTimeInterface, %s given", ZSTR_VAL(Z_OBJCE_P(milliseconds)->name));
 		}
 		return;
 	}
@@ -158,16 +158,16 @@ static PHP_METHOD(UTCDateTime, __construct)
 
 		tmp_len = snprintf(tmp, sizeof(tmp), "%.0f", Z_DVAL_P(milliseconds) > 0 ? floor(Z_DVAL_P(milliseconds)) : ceil(Z_DVAL_P(milliseconds)));
 
-		php_phongo_utcdatetime_init_from_string(intern, tmp, tmp_len TSRMLS_CC);
+		php_phongo_utcdatetime_init_from_string(intern, tmp, tmp_len);
 		return;
 	}
 
 	if (Z_TYPE_P(milliseconds) != IS_STRING) {
-		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "Expected integer or string, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(milliseconds));
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected integer or string, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(milliseconds));
 		return;
 	}
 
-	php_phongo_utcdatetime_init_from_string(intern, Z_STRVAL_P(milliseconds), Z_STRLEN_P(milliseconds) TSRMLS_CC);
+	php_phongo_utcdatetime_init_from_string(intern, Z_STRVAL_P(milliseconds), Z_STRLEN_P(milliseconds));
 } /* }}} */
 
 /* {{{ proto void MongoDB\BSON\UTCDateTime::__set_state(array $properties)
@@ -178,7 +178,7 @@ static PHP_METHOD(UTCDateTime, __set_state)
 	HashTable*                props;
 	zval*                     array;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "a", &array) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "a", &array) == FAILURE) {
 		RETURN_FALSE;
 	}
 
@@ -187,7 +187,7 @@ static PHP_METHOD(UTCDateTime, __set_state)
 	intern = Z_UTCDATETIME_OBJ_P(return_value);
 	props  = Z_ARRVAL_P(array);
 
-	php_phongo_utcdatetime_init_from_hash(intern, props TSRMLS_CC);
+	php_phongo_utcdatetime_init_from_hash(intern, props);
 } /* }}} */
 
 /* {{{ proto string MongoDB\BSON\UTCDateTime::__toString()
@@ -224,7 +224,7 @@ static PHP_METHOD(UTCDateTime, toDateTime)
 	datetime_obj = Z_PHPDATE_P(return_value);
 
 	sec_len = spprintf(&sec, 0, "@%" PRId64, intern->milliseconds / 1000);
-	php_date_initialize(datetime_obj, sec, sec_len, NULL, NULL, 0 TSRMLS_CC);
+	php_date_initialize(datetime_obj, sec, sec_len, NULL, NULL, 0);
 	efree(sec);
 
 #if PHP_VERSION_ID >= 70200
@@ -277,7 +277,7 @@ static PHP_METHOD(UTCDateTime, serialize)
 	ADD_ASSOC_INT64_AS_STRING(&retval, "milliseconds", intern->milliseconds);
 
 	PHP_VAR_SERIALIZE_INIT(var_hash);
-	php_var_serialize(&buf, &retval, &var_hash TSRMLS_CC);
+	php_var_serialize(&buf, &retval, &var_hash);
 	smart_str_0(&buf);
 	PHP_VAR_SERIALIZE_DESTROY(var_hash);
 
@@ -300,25 +300,25 @@ static PHP_METHOD(UTCDateTime, unserialize)
 
 	intern = Z_UTCDATETIME_OBJ_P(getThis());
 
-	zend_replace_error_handling(EH_THROW, phongo_exception_from_phongo_domain(PHONGO_ERROR_INVALID_ARGUMENT), &error_handling TSRMLS_CC);
+	zend_replace_error_handling(EH_THROW, phongo_exception_from_phongo_domain(PHONGO_ERROR_INVALID_ARGUMENT), &error_handling);
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &serialized, &serialized_len) == FAILURE) {
-		zend_restore_error_handling(&error_handling TSRMLS_CC);
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &serialized, &serialized_len) == FAILURE) {
+		zend_restore_error_handling(&error_handling);
 		return;
 	}
-	zend_restore_error_handling(&error_handling TSRMLS_CC);
+	zend_restore_error_handling(&error_handling);
 
 	PHP_VAR_UNSERIALIZE_INIT(var_hash);
-	if (!php_var_unserialize(&props, (const unsigned char**) &serialized, (unsigned char*) serialized + serialized_len, &var_hash TSRMLS_CC)) {
+	if (!php_var_unserialize(&props, (const unsigned char**) &serialized, (unsigned char*) serialized + serialized_len, &var_hash)) {
 		zval_ptr_dtor(&props);
-		phongo_throw_exception(PHONGO_ERROR_UNEXPECTED_VALUE TSRMLS_CC, "%s unserialization failed", ZSTR_VAL(php_phongo_utcdatetime_ce->name));
+		phongo_throw_exception(PHONGO_ERROR_UNEXPECTED_VALUE, "%s unserialization failed", ZSTR_VAL(php_phongo_utcdatetime_ce->name));
 
 		PHP_VAR_UNSERIALIZE_DESTROY(var_hash);
 		return;
 	}
 	PHP_VAR_UNSERIALIZE_DESTROY(var_hash);
 
-	php_phongo_utcdatetime_init_from_hash(intern, HASH_OF(&props) TSRMLS_CC);
+	php_phongo_utcdatetime_init_from_hash(intern, HASH_OF(&props));
 	zval_ptr_dtor(&props);
 } /* }}} */
 
@@ -355,11 +355,11 @@ static zend_function_entry php_phongo_utcdatetime_me[] = {
 /* {{{ MongoDB\BSON\UTCDateTime object handlers */
 static zend_object_handlers php_phongo_handler_utcdatetime;
 
-static void php_phongo_utcdatetime_free_object(zend_object* object TSRMLS_DC) /* {{{ */
+static void php_phongo_utcdatetime_free_object(zend_object* object) /* {{{ */
 {
 	php_phongo_utcdatetime_t* intern = Z_OBJ_UTCDATETIME(object);
 
-	zend_object_std_dtor(&intern->std TSRMLS_CC);
+	zend_object_std_dtor(&intern->std);
 
 	if (intern->properties) {
 		zend_hash_destroy(intern->properties);
@@ -367,13 +367,13 @@ static void php_phongo_utcdatetime_free_object(zend_object* object TSRMLS_DC) /*
 	}
 } /* }}} */
 
-static zend_object* php_phongo_utcdatetime_create_object(zend_class_entry* class_type TSRMLS_DC) /* {{{ */
+static zend_object* php_phongo_utcdatetime_create_object(zend_class_entry* class_type) /* {{{ */
 {
 	php_phongo_utcdatetime_t* intern = NULL;
 
 	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_utcdatetime_t, class_type);
 
-	zend_object_std_init(&intern->std, class_type TSRMLS_CC);
+	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
 
 	intern->std.handlers = &php_phongo_handler_utcdatetime;
@@ -381,26 +381,28 @@ static zend_object* php_phongo_utcdatetime_create_object(zend_class_entry* class
 	return &intern->std;
 } /* }}} */
 
-static zend_object* php_phongo_utcdatetime_clone_object(zval* object TSRMLS_DC) /* {{{ */
+static zend_object* php_phongo_utcdatetime_clone_object(phongo_compat_object_handler_type* object) /* {{{ */
 {
 	php_phongo_utcdatetime_t* intern;
 	php_phongo_utcdatetime_t* new_intern;
 	zend_object*              new_object;
 
-	intern     = Z_UTCDATETIME_OBJ_P(object);
-	new_object = php_phongo_utcdatetime_create_object(Z_OBJCE_P(object) TSRMLS_CC);
+	intern     = Z_OBJ_UTCDATETIME(PHONGO_COMPAT_GET_OBJ(object));
+	new_object = php_phongo_utcdatetime_create_object(PHONGO_COMPAT_GET_OBJ(object)->ce);
 
 	new_intern = Z_OBJ_UTCDATETIME(new_object);
-	zend_objects_clone_members(&new_intern->std, &intern->std TSRMLS_CC);
+	zend_objects_clone_members(&new_intern->std, &intern->std);
 
 	php_phongo_utcdatetime_init(new_intern, intern->milliseconds);
 
 	return new_object;
 } /* }}} */
 
-static int php_phongo_utcdatetime_compare_objects(zval* o1, zval* o2 TSRMLS_DC) /* {{{ */
+static int php_phongo_utcdatetime_compare_objects(zval* o1, zval* o2) /* {{{ */
 {
 	php_phongo_utcdatetime_t *intern1, *intern2;
+
+	ZEND_COMPARE_OBJECTS_FALLBACK(o1, o2);
 
 	intern1 = Z_UTCDATETIME_OBJ_P(o1);
 	intern2 = Z_UTCDATETIME_OBJ_P(o2);
@@ -412,12 +414,12 @@ static int php_phongo_utcdatetime_compare_objects(zval* o1, zval* o2 TSRMLS_DC) 
 	return 0;
 } /* }}} */
 
-static HashTable* php_phongo_utcdatetime_get_properties_hash(zval* object, bool is_debug TSRMLS_DC) /* {{{ */
+static HashTable* php_phongo_utcdatetime_get_properties_hash(phongo_compat_object_handler_type* object, bool is_debug) /* {{{ */
 {
 	php_phongo_utcdatetime_t* intern;
 	HashTable*                props;
 
-	intern = Z_UTCDATETIME_OBJ_P(object);
+	intern = Z_OBJ_UTCDATETIME(PHONGO_COMPAT_GET_OBJ(object));
 
 	PHONGO_GET_PROPERTY_HASH_INIT_PROPS(is_debug, intern, props, 1);
 
@@ -435,15 +437,15 @@ static HashTable* php_phongo_utcdatetime_get_properties_hash(zval* object, bool 
 	return props;
 } /* }}} */
 
-static HashTable* php_phongo_utcdatetime_get_debug_info(zval* object, int* is_temp TSRMLS_DC) /* {{{ */
+static HashTable* php_phongo_utcdatetime_get_debug_info(phongo_compat_object_handler_type* object, int* is_temp) /* {{{ */
 {
 	*is_temp = 1;
-	return php_phongo_utcdatetime_get_properties_hash(object, true TSRMLS_CC);
+	return php_phongo_utcdatetime_get_properties_hash(object, true);
 } /* }}} */
 
-static HashTable* php_phongo_utcdatetime_get_properties(zval* object TSRMLS_DC) /* {{{ */
+static HashTable* php_phongo_utcdatetime_get_properties(phongo_compat_object_handler_type* object) /* {{{ */
 {
-	return php_phongo_utcdatetime_get_properties_hash(object, false TSRMLS_CC);
+	return php_phongo_utcdatetime_get_properties_hash(object, false);
 } /* }}} */
 /* }}} */
 
@@ -452,22 +454,22 @@ void php_phongo_utcdatetime_init_ce(INIT_FUNC_ARGS) /* {{{ */
 	zend_class_entry ce;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "UTCDateTime", php_phongo_utcdatetime_me);
-	php_phongo_utcdatetime_ce                = zend_register_internal_class(&ce TSRMLS_CC);
+	php_phongo_utcdatetime_ce                = zend_register_internal_class(&ce);
 	php_phongo_utcdatetime_ce->create_object = php_phongo_utcdatetime_create_object;
 	PHONGO_CE_FINAL(php_phongo_utcdatetime_ce);
 
-	zend_class_implements(php_phongo_utcdatetime_ce TSRMLS_CC, 1, php_phongo_utcdatetime_interface_ce);
-	zend_class_implements(php_phongo_utcdatetime_ce TSRMLS_CC, 1, php_phongo_json_serializable_ce);
-	zend_class_implements(php_phongo_utcdatetime_ce TSRMLS_CC, 1, php_phongo_type_ce);
-	zend_class_implements(php_phongo_utcdatetime_ce TSRMLS_CC, 1, zend_ce_serializable);
+	zend_class_implements(php_phongo_utcdatetime_ce, 1, php_phongo_utcdatetime_interface_ce);
+	zend_class_implements(php_phongo_utcdatetime_ce, 1, php_phongo_json_serializable_ce);
+	zend_class_implements(php_phongo_utcdatetime_ce, 1, php_phongo_type_ce);
+	zend_class_implements(php_phongo_utcdatetime_ce, 1, zend_ce_serializable);
 
 	memcpy(&php_phongo_handler_utcdatetime, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	php_phongo_handler_utcdatetime.clone_obj       = php_phongo_utcdatetime_clone_object;
-	php_phongo_handler_utcdatetime.compare_objects = php_phongo_utcdatetime_compare_objects;
-	php_phongo_handler_utcdatetime.get_debug_info  = php_phongo_utcdatetime_get_debug_info;
-	php_phongo_handler_utcdatetime.get_properties  = php_phongo_utcdatetime_get_properties;
-	php_phongo_handler_utcdatetime.free_obj        = php_phongo_utcdatetime_free_object;
-	php_phongo_handler_utcdatetime.offset          = XtOffsetOf(php_phongo_utcdatetime_t, std);
+	PHONGO_COMPAT_SET_COMPARE_OBJECTS_HANDLER(utcdatetime);
+	php_phongo_handler_utcdatetime.clone_obj      = php_phongo_utcdatetime_clone_object;
+	php_phongo_handler_utcdatetime.get_debug_info = php_phongo_utcdatetime_get_debug_info;
+	php_phongo_handler_utcdatetime.get_properties = php_phongo_utcdatetime_get_properties;
+	php_phongo_handler_utcdatetime.free_obj       = php_phongo_utcdatetime_free_object;
+	php_phongo_handler_utcdatetime.offset         = XtOffsetOf(php_phongo_utcdatetime_t, std);
 } /* }}} */
 
 /*

--- a/src/MongoDB/BulkWrite.c
+++ b/src/MongoDB/BulkWrite.c
@@ -586,13 +586,13 @@ static zend_object* php_phongo_bulkwrite_create_object(zend_class_entry* class_t
 	return &intern->std;
 } /* }}} */
 
-static HashTable* php_phongo_bulkwrite_get_debug_info(zval* object, int* is_temp) /* {{{ */
+static HashTable* php_phongo_bulkwrite_get_debug_info(phongo_compat_object_handler_type* object, int* is_temp) /* {{{ */
 {
 	zval                    retval = ZVAL_STATIC_INIT;
 	php_phongo_bulkwrite_t* intern = NULL;
 
 	*is_temp = 1;
-	intern   = Z_BULKWRITE_OBJ_P(object);
+	intern   = Z_OBJ_BULKWRITE(PHONGO_COMPAT_GET_OBJ(object));
 	array_init(&retval);
 
 	if (intern->database) {

--- a/src/MongoDB/ClientEncryption.c
+++ b/src/MongoDB/ClientEncryption.c
@@ -149,13 +149,13 @@ static zend_object* php_phongo_clientencryption_create_object(zend_class_entry* 
 	return &intern->std;
 } /* }}} */
 
-static HashTable* php_phongo_clientencryption_get_debug_info(zval* object, int* is_temp) /* {{{ */
+static HashTable* php_phongo_clientencryption_get_debug_info(phongo_compat_object_handler_type* object, int* is_temp) /* {{{ */
 {
 	php_phongo_clientencryption_t* intern = NULL;
 	zval                           retval = ZVAL_STATIC_INIT;
 
 	*is_temp = 1;
-	intern   = Z_CLIENTENCRYPTION_OBJ_P(object);
+	intern   = Z_OBJ_CLIENTENCRYPTION(PHONGO_COMPAT_GET_OBJ(object));
 
 	array_init(&retval);
 

--- a/src/MongoDB/Command.c
+++ b/src/MongoDB/Command.c
@@ -121,6 +121,7 @@ static PHP_METHOD(Command, __construct)
 /* {{{ MongoDB\Driver\Command function entries */
 ZEND_BEGIN_ARG_INFO_EX(ai_Command___construct, 0, 0, 1)
 	ZEND_ARG_INFO(0, document)
+	ZEND_ARG_ARRAY_INFO(0, options, 1)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_Command_void, 0, 0, 0)

--- a/src/MongoDB/Command.c
+++ b/src/MongoDB/Command.c
@@ -163,13 +163,13 @@ static zend_object* php_phongo_command_create_object(zend_class_entry* class_typ
 	return &intern->std;
 } /* }}} */
 
-static HashTable* php_phongo_command_get_debug_info(zval* object, int* is_temp) /* {{{ */
+static HashTable* php_phongo_command_get_debug_info(phongo_compat_object_handler_type* object, int* is_temp) /* {{{ */
 {
 	php_phongo_command_t* intern;
 	zval                  retval = ZVAL_STATIC_INIT;
 
 	*is_temp = 1;
-	intern   = Z_COMMAND_OBJ_P(object);
+	intern   = Z_OBJ_COMMAND(PHONGO_COMPAT_GET_OBJ(object));
 
 	array_init_size(&retval, 1);
 

--- a/src/MongoDB/Cursor.c
+++ b/src/MongoDB/Cursor.c
@@ -333,6 +333,17 @@ static PHP_METHOD(Cursor, isDead)
 	RETURN_BOOL(!mongoc_cursor_more(intern->cursor));
 } /* }}} */
 
+#if PHP_VERSION_ID >= 80000
+static PHP_METHOD(Cursor, getIterator)
+{
+	if (zend_parse_parameters_none() == FAILURE) {
+		return;
+	}
+
+	zend_create_internal_iterator_zval(return_value, getThis());
+}
+#endif
+
 /* {{{ MongoDB\Driver\Cursor function entries */
 ZEND_BEGIN_ARG_INFO_EX(ai_Cursor_setTypeMap, 0, 0, 1)
 	ZEND_ARG_ARRAY_INFO(0, typemap, 0)
@@ -348,6 +359,9 @@ static zend_function_entry php_phongo_cursor_me[] = {
 	PHP_ME(Cursor, getId, ai_Cursor_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(Cursor, getServer, ai_Cursor_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(Cursor, isDead, ai_Cursor_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
+#if PHP_VERSION_ID >= 80000
+	PHP_ME(Cursor, getIterator, ai_Cursor_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
+#endif
 	ZEND_NAMED_ME(__construct, PHP_FN(MongoDB_disabled___construct), ai_Cursor_void, ZEND_ACC_PRIVATE | ZEND_ACC_FINAL)
 	ZEND_NAMED_ME(__wakeup, PHP_FN(MongoDB_disabled___wakeup), ai_Cursor_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_FE_END
@@ -502,6 +516,9 @@ void php_phongo_cursor_init_ce(INIT_FUNC_ARGS) /* {{{ */
 	PHONGO_CE_DISABLE_SERIALIZATION(php_phongo_cursor_ce);
 	php_phongo_cursor_ce->get_iterator = php_phongo_cursor_get_iterator;
 
+#if PHP_VERSION_ID >= 80000
+	zend_class_implements(php_phongo_cursor_ce, 1, zend_ce_aggregate);
+#endif
 	zend_class_implements(php_phongo_cursor_ce, 1, php_phongo_cursor_interface_ce);
 
 	memcpy(&php_phongo_handler_cursor, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));

--- a/src/MongoDB/Cursor.c
+++ b/src/MongoDB/Cursor.c
@@ -418,13 +418,13 @@ static zend_object* php_phongo_cursor_create_object(zend_class_entry* class_type
 	return &intern->std;
 } /* }}} */
 
-static HashTable* php_phongo_cursor_get_debug_info(zval* object, int* is_temp) /* {{{ */
+static HashTable* php_phongo_cursor_get_debug_info(phongo_compat_object_handler_type* object, int* is_temp) /* {{{ */
 {
 	php_phongo_cursor_t* intern;
 	zval                 retval = ZVAL_STATIC_INIT;
 
 	*is_temp = 1;
-	intern   = Z_CURSOR_OBJ_P(object);
+	intern   = Z_OBJ_CURSOR(PHONGO_COMPAT_GET_OBJ(object));
 
 	array_init_size(&retval, 10);
 

--- a/src/MongoDB/CursorId.c
+++ b/src/MongoDB/CursorId.c
@@ -184,13 +184,13 @@ static zend_object* php_phongo_cursorid_create_object(zend_class_entry* class_ty
 	return &intern->std;
 } /* }}} */
 
-static HashTable* php_phongo_cursorid_get_debug_info(zval* object, int* is_temp) /* {{{ */
+static HashTable* php_phongo_cursorid_get_debug_info(phongo_compat_object_handler_type* object, int* is_temp) /* {{{ */
 {
 	php_phongo_cursorid_t* intern;
 	zval                   retval = ZVAL_STATIC_INIT;
 
 	*is_temp = 1;
-	intern   = Z_CURSORID_OBJ_P(object);
+	intern   = Z_OBJ_CURSORID(PHONGO_COMPAT_GET_OBJ(object));
 
 	array_init(&retval);
 

--- a/src/MongoDB/Exception/CommandException.c
+++ b/src/MongoDB/Exception/CommandException.c
@@ -36,7 +36,7 @@ static PHP_METHOD(CommandException, getResultDocument)
 		return;
 	}
 
-	resultdocument = zend_read_property(php_phongo_commandexception_ce, getThis(), ZEND_STRL("resultDocument"), 0, &rv);
+	resultdocument = zend_read_property(php_phongo_commandexception_ce, PHONGO_COMPAT_OBJ_P(getThis()), ZEND_STRL("resultDocument"), 0, &rv);
 
 	RETURN_ZVAL(resultdocument, 1, 0);
 } /* }}} */

--- a/src/MongoDB/Exception/RuntimeException.c
+++ b/src/MongoDB/Exception/RuntimeException.c
@@ -65,7 +65,7 @@ static PHP_METHOD(RuntimeException, hasErrorLabel)
 		return;
 	}
 
-	error_labels = zend_read_property(php_phongo_runtimeexception_ce, getThis(), ZEND_STRL("errorLabels"), 0, &rv);
+	error_labels = zend_read_property(php_phongo_runtimeexception_ce, PHONGO_COMPAT_OBJ_P(getThis()), ZEND_STRL("errorLabels"), 0, &rv);
 
 	RETURN_BOOL(php_phongo_has_string_array_element(error_labels, label));
 } /* }}} */

--- a/src/MongoDB/Exception/WriteException.c
+++ b/src/MongoDB/Exception/WriteException.c
@@ -36,7 +36,7 @@ static PHP_METHOD(WriteException, getWriteResult)
 		return;
 	}
 
-	writeresult = zend_read_property(php_phongo_writeexception_ce, getThis(), ZEND_STRL("writeResult"), 0, &rv);
+	writeresult = zend_read_property(php_phongo_writeexception_ce, PHONGO_COMPAT_OBJ_P(getThis()), ZEND_STRL("writeResult"), 0, &rv);
 
 	RETURN_ZVAL(writeresult, 1, 0);
 } /* }}} */

--- a/src/MongoDB/Manager.c
+++ b/src/MongoDB/Manager.c
@@ -823,7 +823,7 @@ static zend_object* php_phongo_manager_create_object(zend_class_entry* class_typ
 	return &intern->std;
 } /* }}} */
 
-static HashTable* php_phongo_manager_get_debug_info(zval* object, int* is_temp) /* {{{ */
+static HashTable* php_phongo_manager_get_debug_info(phongo_compat_object_handler_type* object, int* is_temp) /* {{{ */
 {
 	php_phongo_manager_t*         intern;
 	mongoc_server_description_t** sds;
@@ -832,7 +832,7 @@ static HashTable* php_phongo_manager_get_debug_info(zval* object, int* is_temp) 
 	zval                          cluster;
 
 	*is_temp = 1;
-	intern   = Z_MANAGER_OBJ_P(object);
+	intern   = Z_OBJ_MANAGER(PHONGO_COMPAT_GET_OBJ(object));
 
 	array_init_size(&retval, 2);
 

--- a/src/MongoDB/Monitoring/CommandFailedEvent.c
+++ b/src/MongoDB/Monitoring/CommandFailedEvent.c
@@ -205,7 +205,7 @@ static zend_object* php_phongo_commandfailedevent_create_object(zend_class_entry
 	return &intern->std;
 } /* }}} */
 
-static HashTable* php_phongo_commandfailedevent_get_debug_info(zval* object, int* is_temp) /* {{{ */
+static HashTable* php_phongo_commandfailedevent_get_debug_info(phongo_compat_object_handler_type* object, int* is_temp) /* {{{ */
 {
 	php_phongo_commandfailedevent_t* intern;
 	zval                             retval = ZVAL_STATIC_INIT;
@@ -214,7 +214,7 @@ static HashTable* php_phongo_commandfailedevent_get_debug_info(zval* object, int
 
 	PHONGO_BSON_INIT_STATE(reply_state);
 
-	intern   = Z_COMMANDFAILEDEVENT_OBJ_P(object);
+	intern   = Z_OBJ_COMMANDFAILEDEVENT(PHONGO_COMPAT_GET_OBJ(object));
 	*is_temp = 1;
 	array_init_size(&retval, 6);
 

--- a/src/MongoDB/Monitoring/CommandStartedEvent.c
+++ b/src/MongoDB/Monitoring/CommandStartedEvent.c
@@ -187,7 +187,7 @@ static zend_object* php_phongo_commandstartedevent_create_object(zend_class_entr
 	return &intern->std;
 } /* }}} */
 
-static HashTable* php_phongo_commandstartedevent_get_debug_info(zval* object, int* is_temp) /* {{{ */
+static HashTable* php_phongo_commandstartedevent_get_debug_info(phongo_compat_object_handler_type* object, int* is_temp) /* {{{ */
 {
 	php_phongo_commandstartedevent_t* intern;
 	zval                              retval = ZVAL_STATIC_INIT;
@@ -196,7 +196,7 @@ static HashTable* php_phongo_commandstartedevent_get_debug_info(zval* object, in
 
 	PHONGO_BSON_INIT_STATE(command_state);
 
-	intern   = Z_COMMANDSTARTEDEVENT_OBJ_P(object);
+	intern   = Z_OBJ_COMMANDSTARTEDEVENT(PHONGO_COMPAT_GET_OBJ(object));
 	*is_temp = 1;
 	array_init_size(&retval, 6);
 

--- a/src/MongoDB/Monitoring/CommandSucceededEvent.c
+++ b/src/MongoDB/Monitoring/CommandSucceededEvent.c
@@ -184,7 +184,7 @@ static zend_object* php_phongo_commandsucceededevent_create_object(zend_class_en
 	return &intern->std;
 } /* }}} */
 
-static HashTable* php_phongo_commandsucceededevent_get_debug_info(zval* object, int* is_temp) /* {{{ */
+static HashTable* php_phongo_commandsucceededevent_get_debug_info(phongo_compat_object_handler_type* object, int* is_temp) /* {{{ */
 {
 	php_phongo_commandsucceededevent_t* intern;
 	zval                                retval = ZVAL_STATIC_INIT;
@@ -193,7 +193,7 @@ static HashTable* php_phongo_commandsucceededevent_get_debug_info(zval* object, 
 
 	PHONGO_BSON_INIT_STATE(reply_state);
 
-	intern   = Z_COMMANDSUCCEEDEDEVENT_OBJ_P(object);
+	intern   = Z_OBJ_COMMANDSUCCEEDEDEVENT(PHONGO_COMPAT_GET_OBJ(object));
 	*is_temp = 1;
 	array_init_size(&retval, 6);
 

--- a/src/MongoDB/Query.c
+++ b/src/MongoDB/Query.c
@@ -423,13 +423,13 @@ static zend_object* php_phongo_query_create_object(zend_class_entry* class_type)
 	return &intern->std;
 } /* }}} */
 
-static HashTable* php_phongo_query_get_debug_info(zval* object, int* is_temp) /* {{{ */
+static HashTable* php_phongo_query_get_debug_info(phongo_compat_object_handler_type* object, int* is_temp) /* {{{ */
 {
 	php_phongo_query_t* intern;
 	zval                retval = ZVAL_STATIC_INIT;
 
 	*is_temp = 1;
-	intern   = Z_QUERY_OBJ_P(object);
+	intern   = Z_OBJ_QUERY(PHONGO_COMPAT_GET_OBJ(object));
 
 	array_init_size(&retval, 3);
 

--- a/src/MongoDB/ReadConcern.c
+++ b/src/MongoDB/ReadConcern.c
@@ -137,13 +137,13 @@ static PHP_METHOD(ReadConcern, isDefault)
 	RETURN_BOOL(mongoc_read_concern_is_default(intern->read_concern));
 } /* }}} */
 
-static HashTable* php_phongo_read_concern_get_properties_hash(zval* object, bool is_debug) /* {{{ */
+static HashTable* php_phongo_read_concern_get_properties_hash(phongo_compat_object_handler_type* object, bool is_debug) /* {{{ */
 {
 	php_phongo_readconcern_t* intern;
 	HashTable*                props;
 	const char*               level;
 
-	intern = Z_READCONCERN_OBJ_P(object);
+	intern = Z_OBJ_READCONCERN(PHONGO_COMPAT_GET_OBJ(object));
 
 	PHONGO_GET_PROPERTY_HASH_INIT_PROPS(is_debug, intern, props, 1);
 
@@ -171,7 +171,7 @@ static PHP_METHOD(ReadConcern, bsonSerialize)
 		return;
 	}
 
-	ZVAL_ARR(return_value, php_phongo_read_concern_get_properties_hash(getThis(), true));
+	ZVAL_ARR(return_value, php_phongo_read_concern_get_properties_hash(PHONGO_COMPAT_OBJ_P(getThis()), true));
 	convert_to_object(return_value);
 } /* }}} */
 
@@ -317,13 +317,13 @@ static zend_object* php_phongo_readconcern_create_object(zend_class_entry* class
 	return &intern->std;
 } /* }}} */
 
-static HashTable* php_phongo_readconcern_get_debug_info(zval* object, int* is_temp) /* {{{ */
+static HashTable* php_phongo_readconcern_get_debug_info(phongo_compat_object_handler_type* object, int* is_temp) /* {{{ */
 {
 	*is_temp = 1;
 	return php_phongo_read_concern_get_properties_hash(object, true);
 } /* }}} */
 
-static HashTable* php_phongo_readconcern_get_properties(zval* object) /* {{{ */
+static HashTable* php_phongo_readconcern_get_properties(phongo_compat_object_handler_type* object) /* {{{ */
 {
 	return php_phongo_read_concern_get_properties_hash(object, false);
 } /* }}} */

--- a/src/MongoDB/ReadPreference.c
+++ b/src/MongoDB/ReadPreference.c
@@ -440,7 +440,7 @@ static PHP_METHOD(ReadPreference, getTagSets)
 	}
 } /* }}} */
 
-static HashTable* php_phongo_readpreference_get_properties_hash(zval* object, bool is_debug) /* {{{ */
+static HashTable* php_phongo_readpreference_get_properties_hash(phongo_compat_object_handler_type* object, bool is_debug) /* {{{ */
 {
 	php_phongo_readpreference_t* intern;
 	HashTable*                   props;
@@ -449,7 +449,7 @@ static HashTable* php_phongo_readpreference_get_properties_hash(zval* object, bo
 	const bson_t*                hedge;
 	mongoc_read_mode_t           mode;
 
-	intern = Z_READPREFERENCE_OBJ_P(object);
+	intern = Z_OBJ_READPREFERENCE(PHONGO_COMPAT_GET_OBJ(object));
 
 	PHONGO_GET_PROPERTY_HASH_INIT_PROPS(is_debug, intern, props, 4);
 
@@ -518,7 +518,7 @@ static PHP_METHOD(ReadPreference, bsonSerialize)
 		return;
 	}
 
-	ZVAL_ARR(return_value, php_phongo_readpreference_get_properties_hash(getThis(), true));
+	ZVAL_ARR(return_value, php_phongo_readpreference_get_properties_hash(PHONGO_COMPAT_OBJ_P(getThis()), true));
 	convert_to_object(return_value);
 } /* }}} */
 
@@ -706,13 +706,13 @@ static zend_object* php_phongo_readpreference_create_object(zend_class_entry* cl
 	return &intern->std;
 } /* }}} */
 
-static HashTable* php_phongo_readpreference_get_debug_info(zval* object, int* is_temp) /* {{{ */
+static HashTable* php_phongo_readpreference_get_debug_info(phongo_compat_object_handler_type* object, int* is_temp) /* {{{ */
 {
 	*is_temp = 1;
 	return php_phongo_readpreference_get_properties_hash(object, true);
 } /* }}} */
 
-static HashTable* php_phongo_readpreference_get_properties(zval* object) /* {{{ */
+static HashTable* php_phongo_readpreference_get_properties(phongo_compat_object_handler_type* object) /* {{{ */
 {
 	return php_phongo_readpreference_get_properties_hash(object, false);
 } /* }}} */

--- a/src/MongoDB/Server.c
+++ b/src/MongoDB/Server.c
@@ -540,6 +540,8 @@ static int php_phongo_server_compare_objects(zval* o1, zval* o2) /* {{{ */
 	mongoc_server_description_t *sd1, *sd2;
 	int                          retval = 0;
 
+	ZEND_COMPARE_OBJECTS_FALLBACK(o1, o2);
+
 	intern1 = Z_SERVER_OBJ_P(o1);
 	intern2 = Z_SERVER_OBJ_P(o2);
 
@@ -586,14 +588,14 @@ static zend_object* php_phongo_server_create_object(zend_class_entry* class_type
 	return &intern->std;
 } /* }}} */
 
-static HashTable* php_phongo_server_get_debug_info(zval* object, int* is_temp) /* {{{ */
+static HashTable* php_phongo_server_get_debug_info(phongo_compat_object_handler_type* object, int* is_temp) /* {{{ */
 {
 	php_phongo_server_t*         intern = NULL;
 	zval                         retval = ZVAL_STATIC_INIT;
 	mongoc_server_description_t* sd;
 
 	*is_temp = 1;
-	intern   = Z_SERVER_OBJ_P(object);
+	intern   = Z_OBJ_SERVER(PHONGO_COMPAT_GET_OBJ(object));
 
 	if (!(sd = mongoc_client_get_server_description(intern->client, intern->server_id))) {
 		phongo_throw_exception(PHONGO_ERROR_RUNTIME, "Failed to get server description");
@@ -618,10 +620,10 @@ void php_phongo_server_init_ce(INIT_FUNC_ARGS) /* {{{ */
 	PHONGO_CE_DISABLE_SERIALIZATION(php_phongo_server_ce);
 
 	memcpy(&php_phongo_handler_server, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	php_phongo_handler_server.compare_objects = php_phongo_server_compare_objects;
-	php_phongo_handler_server.get_debug_info  = php_phongo_server_get_debug_info;
-	php_phongo_handler_server.free_obj        = php_phongo_server_free_object;
-	php_phongo_handler_server.offset          = XtOffsetOf(php_phongo_server_t, std);
+	PHONGO_COMPAT_SET_COMPARE_OBJECTS_HANDLER(server);
+	php_phongo_handler_server.get_debug_info = php_phongo_server_get_debug_info;
+	php_phongo_handler_server.free_obj       = php_phongo_server_free_object;
+	php_phongo_handler_server.offset         = XtOffsetOf(php_phongo_server_t, std);
 
 	zend_declare_class_constant_long(php_phongo_server_ce, ZEND_STRL("TYPE_UNKNOWN"), PHONGO_SERVER_UNKNOWN);
 	zend_declare_class_constant_long(php_phongo_server_ce, ZEND_STRL("TYPE_STANDALONE"), PHONGO_SERVER_STANDALONE);

--- a/src/MongoDB/Session.c
+++ b/src/MongoDB/Session.c
@@ -50,13 +50,13 @@ static bool php_phongo_session_get_timestamp_parts(zval* obj, uint32_t* timestam
 	zval ztimestamp = ZVAL_STATIC_INIT;
 	zval zincrement = ZVAL_STATIC_INIT;
 
-	zend_call_method_with_0_params(obj, NULL, NULL, "getTimestamp", &ztimestamp);
+	zend_call_method_with_0_params(PHONGO_COMPAT_OBJ_P(obj), NULL, NULL, "getTimestamp", &ztimestamp);
 
 	if (Z_ISUNDEF(ztimestamp) || EG(exception)) {
 		goto cleanup;
 	}
 
-	zend_call_method_with_0_params(obj, NULL, NULL, "getIncrement", &zincrement);
+	zend_call_method_with_0_params(PHONGO_COMPAT_OBJ_P(obj), NULL, NULL, "getIncrement", &zincrement);
 
 	if (Z_ISUNDEF(zincrement) || EG(exception)) {
 		goto cleanup;
@@ -616,14 +616,14 @@ static zend_object* php_phongo_session_create_object(zend_class_entry* class_typ
 	return &intern->std;
 } /* }}} */
 
-static HashTable* php_phongo_session_get_debug_info(zval* object, int* is_temp) /* {{{ */
+static HashTable* php_phongo_session_get_debug_info(phongo_compat_object_handler_type* object, int* is_temp) /* {{{ */
 {
 	php_phongo_session_t*       intern = NULL;
 	const mongoc_session_opt_t* cs_opts;
 	zval                        retval = ZVAL_STATIC_INIT;
 
 	*is_temp = 1;
-	intern   = Z_SESSION_OBJ_P(object);
+	intern   = Z_OBJ_SESSION(PHONGO_COMPAT_GET_OBJ(object));
 
 	array_init(&retval);
 

--- a/src/MongoDB/WriteConcern.c
+++ b/src/MongoDB/WriteConcern.c
@@ -277,7 +277,7 @@ static PHP_METHOD(WriteConcern, isDefault)
 	RETURN_BOOL(mongoc_write_concern_is_default(intern->write_concern));
 } /* }}} */
 
-static HashTable* php_phongo_write_concern_get_properties_hash(zval* object, bool is_debug, bool is_bson) /* {{{ */
+static HashTable* php_phongo_write_concern_get_properties_hash(phongo_compat_object_handler_type* object, bool is_debug, bool is_bson) /* {{{ */
 {
 	php_phongo_writeconcern_t* intern;
 	HashTable*                 props;
@@ -285,7 +285,7 @@ static HashTable* php_phongo_write_concern_get_properties_hash(zval* object, boo
 	int32_t                    w;
 	int64_t                    wtimeout;
 
-	intern = Z_WRITECONCERN_OBJ_P(object);
+	intern = Z_OBJ_WRITECONCERN(PHONGO_COMPAT_GET_OBJ(object));
 
 	PHONGO_GET_PROPERTY_HASH_INIT_PROPS(is_debug, intern, props, 4);
 
@@ -350,7 +350,7 @@ static PHP_METHOD(WriteConcern, bsonSerialize)
 		return;
 	}
 
-	ZVAL_ARR(return_value, php_phongo_write_concern_get_properties_hash(getThis(), true, true));
+	ZVAL_ARR(return_value, php_phongo_write_concern_get_properties_hash(PHONGO_COMPAT_OBJ_P(getThis()), true, true));
 	convert_to_object(return_value);
 } /* }}} */
 
@@ -519,13 +519,13 @@ static zend_object* php_phongo_writeconcern_create_object(zend_class_entry* clas
 	return &intern->std;
 } /* }}} */
 
-static HashTable* php_phongo_writeconcern_get_debug_info(zval* object, int* is_temp) /* {{{ */
+static HashTable* php_phongo_writeconcern_get_debug_info(phongo_compat_object_handler_type* object, int* is_temp) /* {{{ */
 {
 	*is_temp = 1;
 	return php_phongo_write_concern_get_properties_hash(object, true, false);
 } /* }}} */
 
-static HashTable* php_phongo_writeconcern_get_properties(zval* object) /* {{{ */
+static HashTable* php_phongo_writeconcern_get_properties(phongo_compat_object_handler_type* object) /* {{{ */
 {
 	return php_phongo_write_concern_get_properties_hash(object, false, false);
 } /* }}} */

--- a/src/MongoDB/WriteConcernError.c
+++ b/src/MongoDB/WriteConcernError.c
@@ -121,13 +121,13 @@ static zend_object* php_phongo_writeconcernerror_create_object(zend_class_entry*
 	return &intern->std;
 } /* }}} */
 
-static HashTable* php_phongo_writeconcernerror_get_debug_info(zval* object, int* is_temp) /* {{{ */
+static HashTable* php_phongo_writeconcernerror_get_debug_info(phongo_compat_object_handler_type* object, int* is_temp) /* {{{ */
 {
 	php_phongo_writeconcernerror_t* intern;
 	zval                            retval = ZVAL_STATIC_INIT;
 
 	*is_temp = 1;
-	intern   = Z_WRITECONCERNERROR_OBJ_P(object);
+	intern   = Z_OBJ_WRITECONCERNERROR(PHONGO_COMPAT_GET_OBJ(object));
 
 	array_init_size(&retval, 3);
 	ADD_ASSOC_STRING(&retval, "message", intern->message);

--- a/src/MongoDB/WriteError.c
+++ b/src/MongoDB/WriteError.c
@@ -138,13 +138,13 @@ static zend_object* php_phongo_writeerror_create_object(zend_class_entry* class_
 	return &intern->std;
 } /* }}} */
 
-static HashTable* php_phongo_writeerror_get_debug_info(zval* object, int* is_temp) /* {{{ */
+static HashTable* php_phongo_writeerror_get_debug_info(phongo_compat_object_handler_type* object, int* is_temp) /* {{{ */
 {
 	php_phongo_writeerror_t* intern;
 	zval                     retval = ZVAL_STATIC_INIT;
 
 	*is_temp = 1;
-	intern   = Z_WRITEERROR_OBJ_P(object);
+	intern   = Z_OBJ_WRITEERROR(PHONGO_COMPAT_GET_OBJ(object));
 
 	array_init_size(&retval, 3);
 	ADD_ASSOC_STRING(&retval, "message", intern->message);

--- a/src/MongoDB/WriteResult.c
+++ b/src/MongoDB/WriteResult.c
@@ -344,13 +344,13 @@ static zend_object* php_phongo_writeresult_create_object(zend_class_entry* class
 	return &intern->std;
 } /* }}} */
 
-static HashTable* php_phongo_writeresult_get_debug_info(zval* object, int* is_temp) /* {{{ */
+static HashTable* php_phongo_writeresult_get_debug_info(phongo_compat_object_handler_type* object, int* is_temp) /* {{{ */
 {
 	php_phongo_writeresult_t* intern;
 	zval                      retval = ZVAL_STATIC_INIT;
 	bson_iter_t               iter;
 
-	intern   = Z_WRITERESULT_OBJ_P(object);
+	intern   = Z_OBJ_WRITERESULT(PHONGO_COMPAT_GET_OBJ(object));
 	*is_temp = 1;
 	array_init_size(&retval, 9);
 

--- a/src/bson-encode.c
+++ b/src/bson-encode.c
@@ -102,7 +102,7 @@ static void php_phongo_bson_append_object(bson_t* bson, php_phongo_field_path* f
 			zval   obj_data;
 			bson_t child;
 
-			zend_call_method_with_0_params(object, NULL, NULL, BSON_SERIALIZE_FUNC_NAME, &obj_data);
+			zend_call_method_with_0_params(PHONGO_COMPAT_OBJ_P(object), NULL, NULL, BSON_SERIALIZE_FUNC_NAME, &obj_data);
 
 			if (Z_ISUNDEF(obj_data)) {
 				/* zend_call_method() failed or bsonSerialize() threw an
@@ -361,7 +361,7 @@ static void php_phongo_zval_to_bson_internal(zval* data, php_phongo_field_path* 
 	switch (Z_TYPE_P(data)) {
 		case IS_OBJECT:
 			if (instanceof_function(Z_OBJCE_P(data), php_phongo_serializable_ce)) {
-				zend_call_method_with_0_params(data, NULL, NULL, BSON_SERIALIZE_FUNC_NAME, &obj_data);
+				zend_call_method_with_0_params(PHONGO_COMPAT_OBJ_P(data), NULL, NULL, BSON_SERIALIZE_FUNC_NAME, &obj_data);
 
 				if (Z_ISUNDEF(obj_data)) {
 					/* zend_call_method() failed or bsonSerialize() threw an
@@ -397,7 +397,7 @@ static void php_phongo_zval_to_bson_internal(zval* data, php_phongo_field_path* 
 				return;
 			}
 
-			ht_data                 = Z_OBJ_HT_P(data)->get_properties(data);
+			ht_data                 = Z_OBJ_HT_P(data)->get_properties(PHONGO_COMPAT_OBJ_P(data));
 			ht_data_from_properties = true;
 			break;
 

--- a/src/bson.c
+++ b/src/bson.c
@@ -814,7 +814,7 @@ static bool php_phongo_bson_visit_document(const bson_iter_t* iter ARG_UNUSED, c
 					zval obj;
 
 					object_init_ex(&obj, state.odm ? state.odm : state.map.document);
-					zend_call_method_with_1_params(&obj, NULL, NULL, BSON_UNSERIALIZE_FUNC_NAME, NULL, &state.zchild);
+					zend_call_method_with_1_params(PHONGO_COMPAT_OBJ_P(&obj), NULL, NULL, BSON_UNSERIALIZE_FUNC_NAME, NULL, &state.zchild);
 					if (((php_phongo_bson_state*) data)->is_visiting_array) {
 						add_next_index_zval(retval, &obj);
 					} else {
@@ -881,7 +881,7 @@ static bool php_phongo_bson_visit_array(const bson_iter_t* iter ARG_UNUSED, cons
 					zval obj;
 
 					object_init_ex(&obj, state.map.array);
-					zend_call_method_with_1_params(&obj, NULL, NULL, BSON_UNSERIALIZE_FUNC_NAME, NULL, &state.zchild);
+					zend_call_method_with_1_params(PHONGO_COMPAT_OBJ_P(&obj), NULL, NULL, BSON_UNSERIALIZE_FUNC_NAME, NULL, &state.zchild);
 					if (((php_phongo_bson_state*) data)->is_visiting_array) {
 						add_next_index_zval(retval, &obj);
 					} else {
@@ -1044,7 +1044,7 @@ bool php_phongo_bson_to_zval_ex(const unsigned char* data, int data_len, php_pho
 			zval obj;
 
 			object_init_ex(&obj, state->odm ? state->odm : state->map.root);
-			zend_call_method_with_1_params(&obj, NULL, NULL, BSON_UNSERIALIZE_FUNC_NAME, NULL, &state->zchild);
+			zend_call_method_with_1_params(PHONGO_COMPAT_OBJ_P(&obj), NULL, NULL, BSON_UNSERIALIZE_FUNC_NAME, NULL, &state->zchild);
 			zval_ptr_dtor(&state->zchild);
 			ZVAL_COPY_VALUE(&state->zchild, &obj);
 

--- a/tests/apm/bug0950-002.phpt
+++ b/tests/apm/bug0950-002.phpt
@@ -2,11 +2,15 @@
 PHPC-950: Segfault killing cursor after subscriber HashTable is destroyed (one subscriber)
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_php_version('>=', '7.99'); ?>
 <?php skip_if_not_live(); ?>
 <?php skip_if_not_clean(); ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";
+
+/* Note: this test is skipped on PHP 8 because the CommandSubscriber ends up
+ * observing the killCursors command invoked from the Cursor's dtor. */
 
 class MySubscriber implements MongoDB\Driver\Monitoring\CommandSubscriber
 {
@@ -39,7 +43,7 @@ MongoDB\Driver\Monitoring\addSubscriber(new MySubscriber);
 $cursor = $manager->executeQuery(NS, new MongoDB\Driver\Query([], ['batchSize' => 2]));
 
 /* Exiting during iteration on a live cursor will result in
- * php_phongo_command_started() being invoked for the killCursor command after
+ * php_phongo_command_started() being invoked for the killCursors command after
  * RSHUTDOWN has already destroyed the subscriber HashTable */
 foreach ($cursor as $data) {
     echo "Exiting during first iteration on cursor\n";

--- a/tests/bson/bson-binary_error-001.phpt
+++ b/tests/bson/bson-binary_error-001.phpt
@@ -1,5 +1,8 @@
 --TEST--
 MongoDB\BSON\Binary #001 error
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_php_version('>=', '7.99'); ?>
 --FILE--
 <?php
 

--- a/tests/bson/bson-decimal128_error-001.phpt
+++ b/tests/bson/bson-decimal128_error-001.phpt
@@ -1,6 +1,8 @@
 --TEST--
 MongoDB\BSON\Decimal128 requires valid decimal string
 --SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_php_version('>=', '7.99'); ?>
 <?php if (!class_exists('MongoDB\BSON\Decimal128')) { die('skip MongoDB\BSON\Decimal128 is not available'); } ?>
 --FILE--
 <?php

--- a/tests/bson/bson-javascript_error-001.phpt
+++ b/tests/bson/bson-javascript_error-001.phpt
@@ -1,5 +1,8 @@
 --TEST--
 MongoDB\BSON\Javascript #001 error
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_php_version('>=', '7.99'); ?>
 --FILE--
 <?php
 

--- a/tests/bson/bson-objectid-001.phpt
+++ b/tests/bson/bson-objectid-001.phpt
@@ -55,11 +55,6 @@ throws(function() {
     $id = new MongoDB\BSON\ObjectId(" 3e28b650640fd3162152da1");
 }, "MongoDB\\Driver\\Exception\\InvalidArgumentException");
 
-
-
-raises(function() use($pregenerated) {
-    $pregenerated->__toString(1);
-}, E_WARNING);
 ?>
 ===DONE===
 <?php exit(0); ?>
@@ -88,5 +83,4 @@ OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-OK: Got E_WARNING
 ===DONE===

--- a/tests/bson/bson-objectid-tostring_error-001.phpt
+++ b/tests/bson/bson-objectid-tostring_error-001.phpt
@@ -1,0 +1,22 @@
+--TEST--
+MongoDB\BSON\ObjectId raises warning on invalid arguments
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_php_version('>=', '7.99'); ?>
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/tools.php';
+
+$pregenerated = new MongoDB\BSON\ObjectId("53e28b650640fd3162152de1");
+
+raises(function() use($pregenerated) {
+    $pregenerated->__toString(1);
+}, E_WARNING);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+OK: Got E_WARNING
+===DONE===

--- a/tests/bson/bson-objectid_error-001.phpt
+++ b/tests/bson/bson-objectid_error-001.phpt
@@ -1,5 +1,8 @@
 --TEST--
 MongoDB\BSON\ObjectId #001 error
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_php_version('>=', '7.99'); ?>
 --FILE--
 <?php
 

--- a/tests/bson/bson-regex_error-001.phpt
+++ b/tests/bson/bson-regex_error-001.phpt
@@ -1,5 +1,8 @@
 --TEST--
 MongoDB\BSON\Regex #001 error
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_php_version('>=', '7.99'); ?>
 --FILE--
 <?php
 

--- a/tests/bson/bson-timestamp_error-001.phpt
+++ b/tests/bson/bson-timestamp_error-001.phpt
@@ -1,5 +1,8 @@
 --TEST--
 MongoDB\BSON\Timestamp #001 error
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_php_version('>=', '7.99'); ?>
 --FILE--
 <?php
 

--- a/tests/bson/bug0939-001.phpt
+++ b/tests/bson/bug0939-001.phpt
@@ -21,7 +21,7 @@ foreach ($tests as $test) {
     var_dump($object);
 
     foreach ($properties as $property) {
-        var_dump($object->{$property});
+        printf("%s::$%s exists: %s\n", get_class($object), $property, property_exists($object, $property) ? 'yes' : 'no');
     }
 
     echo "\n";
@@ -31,26 +31,21 @@ foreach ($tests as $test) {
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+
 object(MongoDB\BSON\Binary)#%d (%d) {
   ["data"]=>
   string(3) "foo"
   ["type"]=>
   int(0)
 }
-
-Notice: Undefined property: MongoDB\BSON\Binary::$data in %s on line %d
-NULL
-
-Notice: Undefined property: MongoDB\BSON\Binary::$type in %s on line %d
-NULL
+MongoDB\BSON\Binary::$data exists: no
+MongoDB\BSON\Binary::$type exists: no
 
 object(MongoDB\BSON\Decimal128)#%d (%d) {
   ["dec"]=>
   string(4) "3.14"
 }
-
-Notice: Undefined property: MongoDB\BSON\Decimal128::$dec in %s on line %d
-NULL
+MongoDB\BSON\Decimal128::$dec exists: no
 
 object(MongoDB\BSON\Javascript)#%d (%d) {
   ["code"]=>
@@ -61,12 +56,8 @@ object(MongoDB\BSON\Javascript)#%d (%d) {
     int(42)
   }
 }
-
-Notice: Undefined property: MongoDB\BSON\Javascript::$code in %s on line %d
-NULL
-
-Notice: Undefined property: MongoDB\BSON\Javascript::$scope in %s on line %d
-NULL
+MongoDB\BSON\Javascript::$code exists: no
+MongoDB\BSON\Javascript::$scope exists: no
 
 object(MongoDB\BSON\MaxKey)#%d (%d) {
 }
@@ -78,9 +69,7 @@ object(MongoDB\BSON\ObjectId)#%d (%d) {
   ["oid"]=>
   string(24) "%x"
 }
-
-Notice: Undefined property: MongoDB\BSON\ObjectId::$oid in %s on line %d
-NULL
+MongoDB\BSON\ObjectId::$oid exists: no
 
 object(MongoDB\BSON\Regex)#%d (%d) {
   ["pattern"]=>
@@ -88,12 +77,8 @@ object(MongoDB\BSON\Regex)#%d (%d) {
   ["flags"]=>
   string(1) "i"
 }
-
-Notice: Undefined property: MongoDB\BSON\Regex::$pattern in %s on line %d
-NULL
-
-Notice: Undefined property: MongoDB\BSON\Regex::$flags in %s on line %d
-NULL
+MongoDB\BSON\Regex::$pattern exists: no
+MongoDB\BSON\Regex::$flags exists: no
 
 object(MongoDB\BSON\Timestamp)#%d (%d) {
   ["increment"]=>
@@ -101,19 +86,13 @@ object(MongoDB\BSON\Timestamp)#%d (%d) {
   ["timestamp"]=>
   string(4) "5678"
 }
-
-Notice: Undefined property: MongoDB\BSON\Timestamp::$increment in %s on line %d
-NULL
-
-Notice: Undefined property: MongoDB\BSON\Timestamp::$timestamp in %s on line %d
-NULL
+MongoDB\BSON\Timestamp::$increment exists: no
+MongoDB\BSON\Timestamp::$timestamp exists: no
 
 object(MongoDB\BSON\UTCDateTime)#%d (%d) {
   ["milliseconds"]=>
   string(%d) "%d"
 }
-
-Notice: Undefined property: MongoDB\BSON\UTCDateTime::$milliseconds in %s on line %d
-NULL
+MongoDB\BSON\UTCDateTime::$milliseconds exists: no
 
 ===DONE===

--- a/tests/cursor/bug1050-002.phpt
+++ b/tests/cursor/bug1050-002.phpt
@@ -2,6 +2,7 @@
 PHPC-1050: Command cursor should not invoke getMore at execution (rewind omitted)
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_php_version('>', '7.99'); ?>
 <?php skip_if_not_replica_set(); ?>
 <?php skip_if_not_clean(); ?>
 <?php skip_if_server_version('<', '3.6'); ?>
@@ -9,6 +10,38 @@ PHPC-1050: Command cursor should not invoke getMore at execution (rewind omitted
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";
+
+/* Note: this test is skipped on PHP 8 because the InternalIterator class
+ * returned by Cursor::getIterator() has logic to ensure rewind() is always
+ * called. That causes and additional getMore to be observed when starting
+ * iteration with next(), since rewind() and next() both trigger a getMore.
+ * We may be able to resume running this test on PHP 8 if Cursor implements
+ * Iterator directly and allow rewind() to be optional (see: PHPC-1691). */
+
+class CommandLogger implements MongoDB\Driver\Monitoring\CommandSubscriber
+{
+    public function commandStarted(MongoDB\Driver\Monitoring\CommandStartedEvent $event)
+    {
+        if ($event->getCommandName() !== 'aggregate' && $event->getCommandName() !== 'getMore') {
+            return;
+        }
+
+        printf("Executing command: %s\n", $event->getCommandName());
+    }
+
+    public function commandSucceeded(MongoDB\Driver\Monitoring\CommandSucceededEvent $event)
+    {
+        if ($event->getCommandName() !== 'aggregate' && $event->getCommandName() !== 'getMore') {
+            return;
+        }
+
+        printf("Executing command took %0.6f seconds\n", $event->getDurationMicros() / 1000000);
+    }
+
+    public function commandFailed(MongoDB\Driver\Monitoring\CommandFailedEvent $event)
+    {
+    }
+}
 
 $manager = new MongoDB\Driver\Manager(URI);
 
@@ -25,27 +58,27 @@ $cmd = new MongoDB\Driver\Command(
     ]
 );
 
-$start = microtime(true);
+MongoDB\Driver\Monitoring\addSubscriber(new CommandLogger);
+
 $cursor = $manager->executeReadCommand(DATABASE_NAME, $cmd);
-printf("Executing command took %0.6f seconds\n", microtime(true) - $start);
 
 $it = new IteratorIterator($cursor);
 
-printf("Current position is valid: %s\n", $it->valid() ? 'yes' : 'no');
+printf("Current position is valid: %s\n\n", $it->valid() ? 'yes' : 'no');
 
-$start = microtime(true);
+echo "Advancing cursor\n";
 $it->next();
-printf("Advancing cursor took %0.6f seconds\n", microtime(true) - $start);
-printf("Current position is valid: %s\n", $it->valid() ? 'yes' : 'no');
+
+printf("Current position is valid: %s\n\n", $it->valid() ? 'yes' : 'no');
 
 $bulk = new MongoDB\Driver\BulkWrite;
 $bulk->insert(['x' => 1]);
 $manager->executeBulkWrite(NS, $bulk);
 
-$start = microtime(true);
+echo "Advancing cursor\n";
 $it->next();
-printf("Advancing cursor took %0.6f seconds\n", microtime(true) - $start);
-printf("Current position is valid: %s\n", $it->valid() ? 'yes' : 'no');
+
+printf("Current position is valid: %s\n\n", $it->valid() ? 'yes' : 'no');
 
 $document = $it->current();
 
@@ -58,12 +91,20 @@ if (isset($document)) {
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+Executing command: aggregate
 Executing command took 0.%d seconds
 Current position is valid: no
-Advancing cursor took 0.%r(4|5)%r%d seconds
+
+Advancing cursor
+Executing command: getMore
+Executing command took 0.%r(4|5)%r%d seconds
 Current position is valid: no
-Advancing cursor took %d.%d seconds
+
+Advancing cursor
+Executing command: getMore
+Executing command took 0.%d seconds
 Current position is valid: yes
+
 Operation type: insert
 object(stdClass)#%d (%d) {
   ["_id"]=>

--- a/tests/manager/manager-ctor_error-001.phpt
+++ b/tests/manager/manager-ctor_error-001.phpt
@@ -1,5 +1,8 @@
 --TEST--
 MongoDB\Driver\Manager::__construct(): too many arguments
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_php_version('>=', '7.99'); ?>
 --FILE--
 <?php
 

--- a/tests/manager/manager-wakeup.phpt
+++ b/tests/manager/manager-wakeup.phpt
@@ -1,5 +1,8 @@
 --TEST--
 MongoDB\Driver\Manager: Manager cannot be woken up
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_php_version('>=', '7.99'); ?>
 --FILE--
 <?php
 

--- a/tests/readConcern/readconcern-ctor_error-001.phpt
+++ b/tests/readConcern/readconcern-ctor_error-001.phpt
@@ -1,5 +1,8 @@
 --TEST--
 MongoDB\Driver\ReadConcern construction (invalid arguments)
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_php_version('>=', '7.99'); ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";

--- a/tests/readConcern/readconcern-ctor_error-002.phpt
+++ b/tests/readConcern/readconcern-ctor_error-002.phpt
@@ -1,5 +1,8 @@
 --TEST--
 MongoDB\Driver\ReadConcern construction (invalid level type)
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_php_version('>=', '7.99'); ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";

--- a/tests/server/server-errors.phpt
+++ b/tests/server/server-errors.phpt
@@ -2,6 +2,7 @@
 MongoDB\Driver\Server::executeQuery() with sort and empty filter
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_php_version('>=', '7.99'); ?>
 <?php skip_if_not_live(); ?>
 <?php skip_if_not_clean(); ?>
 --FILE--

--- a/tests/session/session_error-001.phpt
+++ b/tests/session/session_error-001.phpt
@@ -43,12 +43,6 @@ foreach ($options as $txnOptions) {
     }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 }
 
-echo raises(function() use ($manager) {
-    $manager->startSession([
-        'defaultTransactionOptions' => [ 'maxCommitTimeMS' => new stdClass ]
-    ]);
-}, E_NOTICE), "\n";
-
 ?>
 ===DONE===
 <?php exit(0); ?>
@@ -83,6 +77,4 @@ OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected "defaultTransactionOptions" option to be an array, int%S given
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected "defaultTransactionOptions" option to be an array, stdClass given
-OK: Got E_NOTICE
-Object of class stdClass could not be converted to int
 ===DONE===

--- a/tests/session/session_error-002.phpt
+++ b/tests/session/session_error-002.phpt
@@ -1,0 +1,24 @@
+--TEST--
+MongoDB\Driver\Session with wrong defaultTransactionOptions
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_php_version('>=', '7.99'); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager();
+
+echo raises(function() use ($manager) {
+    $manager->startSession([
+        'defaultTransactionOptions' => [ 'maxCommitTimeMS' => new stdClass ]
+    ]);
+}, E_NOTICE), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+OK: Got E_NOTICE
+Object of class stdClass could not be converted to int
+===DONE===

--- a/tests/utils/tools.php
+++ b/tests/utils/tools.php
@@ -573,7 +573,7 @@ function severityToString($type) {
     }
 }
 function raises($function, $type, $infunction = null) {
-    $errhandler = function($severity, $message, $file, $line, $errcontext) {
+    $errhandler = function($severity, $message, $file, $line) {
         throw new ErrorException($message, 0, $severity, $file, $line);
     };
 

--- a/tests/writeConcern/writeconcern-ctor_error-001.phpt
+++ b/tests/writeConcern/writeconcern-ctor_error-001.phpt
@@ -1,5 +1,8 @@
 --TEST--
 MongoDB\Driver\WriteConcern construction (invalid arguments)
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_php_version('>=', '7.99'); ?>
 --FILE--
 <?php
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1631

This is rebased on https://github.com/mongodb/mongo-php-driver/pull/1167 for a memory leak fix that turned up while testing.

@alcaeus: When merging, please squash commits into one per issue so various bug fixes get cross-referenced accordingly. The bulk of changes for PHPC-1689 can be rolled up into one commit, though.