### PR TITLE
PHPC-1703: Fix wrong assignment of MONGOC_HAVE_SS_FAMILY

### DIFF
--- a/scripts/autotools/libmongoc/FindDependencies.m4
+++ b/scripts/autotools/libmongoc/FindDependencies.m4
@@ -26,8 +26,8 @@ AC_CHECK_TYPE([socklen_t],
               [#include <sys/socket.h>])
 
 AC_CHECK_MEMBER([struct sockaddr_storage.ss_family],
-                [AC_SUBST(MONGOC_HAVE_SS_FAMILY, 0)],
                 [AC_SUBST(MONGOC_HAVE_SS_FAMILY, 1)],
+                [AC_SUBST(MONGOC_HAVE_SS_FAMILY, 0)],
                 [#include <sys/socket.h>])
 
 # Check for pthreads. libmongoc's original FindDependencies.m4 script did not


### PR DESCRIPTION
PHPC-1703. Closes #1168.

@NattyNarwhal pointed out that the check was reversed, and after a bit of critical thinking, I agree.
@jwoehr this should fix your issue. If you want to you can check out the head branch for this PR (or apply the patch manually) and retry compilation.