### PR TITLE
Don't try linking against libresolv on AIX

### DIFF
--- a/scripts/autotools/CheckHost.m4
+++ b/scripts/autotools/CheckHost.m4
@@ -9,6 +9,7 @@ os_linux=no
 os_solaris=no
 os_darwin=no
 os_gnu=no
+os_aix=no
 
 case "$host" in
     *-mingw*|*-*-cygwin*)
@@ -42,6 +43,10 @@ case "$host" in
         ;;
     *-*-darwin*)
         os_darwin=yes
+        TARGET_OS=unix
+        ;;
+    *-*-aix*|*-*-os400*)
+        os_aix=yes
         TARGET_OS=unix
         ;;
     gnu*|k*bsd*-gnu*)


### PR DESCRIPTION
On AIX, the resolver functions are in libc, so trying libresolv
will cause the checks to fail. The behaviour should be instead
like AC_SEARCH_LIBS.

This hardcodes a check not to use libresolv on AIX. Better than
nothing, but it may not compensate for other systems without a
libresolv.

Fixes  #1171