### PR TITLE
PHPC-1704: Check for standard and date extensions on Windows builds

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -65,8 +65,18 @@ ARG_WITH("mongodb-sasl", "MongoDB: Build against Cyrus-SASL", "yes");
 ARG_WITH("mongodb-client-side-encryption", "MongoDB: Enable client-side encryption", "yes");
 
 if (PHP_MONGODB != "no") {
-  /* Note: ADD_EXTENSION_DEP() cannot be used to declare that we depend on the
-   * date and standard extensions. Assume that they're always enabled. */
+  /* Note: ADD_EXTENSION_DEP() only reports the date and standard extensions as
+   * installed in PHP 7.3.25+, 7.4.13+, and 8.0.0+). On other versions, assume
+   * that they're always enabled. */
+  if (
+    PHP_VERSION == 8 ||
+    (PHP_VERSION == 7 && PHP_MINOR_VERSION == 3 && PHP_RELEASE_VERSION >= 25) ||
+    (PHP_VERSION == 7 && PHP_MINOR_VERSION == 4 && PHP_RELEASE_VERSION >= 13)
+  ) {
+    ADD_EXTENSION_DEP("mongodb", "date", false);
+    ADD_EXTENSION_DEP("mongodb", "standard", false);
+  }
+
   ADD_EXTENSION_DEP("mongodb", "json", false);
   ADD_EXTENSION_DEP("mongodb", "spl", false);
 

--- a/config.w32
+++ b/config.w32
@@ -69,7 +69,7 @@ if (PHP_MONGODB != "no") {
    * installed in PHP 7.3.25+, 7.4.13+, and 8.0.0+). On other versions, assume
    * that they're always enabled. */
   if (
-    PHP_VERSION == 8 ||
+    PHP_VERSION >= 8 ||
     (PHP_VERSION == 7 && PHP_MINOR_VERSION == 3 && PHP_RELEASE_VERSION >= 25) ||
     (PHP_VERSION == 7 && PHP_MINOR_VERSION == 4 && PHP_RELEASE_VERSION >= 13)
   ) {
@@ -375,4 +375,3 @@ if (PHP_MONGODB != "no") {
     mongodb_parse_version_file(configure_module_dirname + "/src/LIBMONGOC_VERSION_CURRENT", "MONGOC_")
   );
 }
-


### PR DESCRIPTION
PHPC-1704

In PHP 8, PHP 7.3.25+, and PHP 7.4.13+, ADD_EXTENSION_DEP can correctly check for the date and standard extensions. On older versions, we have to continue to assume that these extensions are in fact installed.

Note: I'll hold off on merging this until the release candidates for 7.3.25 and 7.4.13 are available, which they should be in a couple of days. Then I can confirm that these checks work as they should.