### PR TITLE
PHPC-1700: Fix memory leak when read preference is invalid

### DIFF
--- a/src/MongoDB/ReadPreference.c
+++ b/src/MongoDB/ReadPreference.c
@@ -63,8 +63,13 @@ static bool php_phongo_readpreference_init_from_hash(php_phongo_readpreference_t
 	}
 
 	if ((tagSets = zend_hash_str_find(props, "tags", sizeof("tags") - 1))) {
+		ZVAL_DEREF(tagSets);
 		if (Z_TYPE_P(tagSets) == IS_ARRAY) {
 			bson_t* tags = bson_new();
+
+			/* Separate tagSets as php_phongo_read_preference_prep_tagsets may
+			 * modify these tags. */
+			SEPARATE_ZVAL_NOREF(tagSets);
 
 			php_phongo_read_preference_prep_tagsets(tagSets);
 			php_phongo_zval_to_bson(tagSets, PHONGO_BSON_NONE, (bson_t*) tags, NULL);

--- a/tests/manager/bug1701-001.phpt
+++ b/tests/manager/bug1701-001.phpt
@@ -1,0 +1,23 @@
+--TEST--
+PHPC-1701: prep_authmechanismproperties may leak if Manager ctor errors
+--FILE--
+<?php
+
+require_once __DIR__ . "/../utils/basic.inc";
+
+echo throws(function () {
+    // Using a stream context without SSL options causes an exception in the constructor, triggering the potential leak
+    new MongoDB\Driver\Manager(
+            null,
+            ['username' => 'username', 'authMechanism' => 'GSSAPI', 'authMechanismProperties' => ['canonicalize_host_name' => true]],
+            ['context' => stream_context_create([])]
+        );
+}, "MongoDB\Driver\Exception\InvalidArgumentException"), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Stream-Context resource does not contain "ssl" options array
+===DONE===

--- a/tests/readPreference/bug1698-001.phpt
+++ b/tests/readPreference/bug1698-001.phpt
@@ -39,7 +39,7 @@ array(2) {
   ["tags"]=>
   array(1) {
     [0]=>
-    object(stdClass)#%d (1) {
+    array(1) {
       ["dc"]=>
       string(2) "ny"
     }


### PR DESCRIPTION
PHPC-1700

This fixes a memory leak in `php_phongo_readpreference_init_from_hash` that is caused by not properly separating zvals before modifying read preference tags. The issue can be observed when `MongoDB\Driver\ReadPreference::__set_state` errors after preparing tag sets (e.g. because tags were combined with a primary mode). Contrary to the original issue, this problem does not affect other instances where the underlying logic from `php_phongo_read_preference_prep_tagsets` is used, as the same test (tags with primary read preference) does not leak in the ReadPreference constructor.

This PR also adds a regression test for PHPC-1701 that also assumed the same issue would apply when preparing properties for authentication mechanisms. This test does not leak since all involved zvals are separated, but the test is included to prevent regressions.