### PR TITLE
PHPC-1713: Ensure Cursor::current returns null on invalid positions

### DIFF
--- a/src/MongoDB/Cursor.c
+++ b/src/MongoDB/Cursor.c
@@ -312,7 +312,11 @@ PHP_METHOD(Cursor, current)
 	data = php_phongo_cursor_get_current_data(intern);
 
 	if (data) {
-		ZVAL_COPY_DEREF(return_value, data);
+		if (Z_ISUNDEF_P(data)) {
+			RETURN_NULL();
+		} else {
+			ZVAL_COPY_DEREF(return_value, data);
+		}
 	}
 }
 

--- a/src/MongoDB/Cursor.c
+++ b/src/MongoDB/Cursor.c
@@ -311,12 +311,10 @@ PHP_METHOD(Cursor, current)
 
 	data = php_phongo_cursor_get_current_data(intern);
 
-	if (data) {
-		if (Z_ISUNDEF_P(data)) {
-			RETURN_NULL();
-		} else {
-			ZVAL_COPY_DEREF(return_value, data);
-		}
+	if (Z_ISUNDEF_P(data)) {
+		RETURN_NULL();
+	} else {
+		ZVAL_COPY_DEREF(return_value, data);
 	}
 }
 

--- a/tests/cursor/bug1713-001.phpt
+++ b/tests/cursor/bug1713-001.phpt
@@ -1,9 +1,8 @@
 --TEST--
-MongoDB\Driver\Cursor PHPC-171: The cursor current method does not return anything
+PHPC-1713: MongoDB\Driver\Cursor::current() does not return anything
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_not_live(); ?>
-<?php skip_if_not_clean(); ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";

--- a/tests/cursor/bug1713-001.phpt
+++ b/tests/cursor/bug1713-001.phpt
@@ -1,0 +1,24 @@
+--TEST--
+MongoDB\Driver\Cursor PHPC-171: The cursor current method does not return anything
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_not_live(); ?>
+<?php skip_if_not_clean(); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(URI);
+
+$cursor = $manager->executeQuery(NS, new MongoDB\Driver\Query([]));
+
+var_dump($cursor->valid());
+var_dump($cursor->current());
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+bool(false)
+NULL
+===DONE===


### PR DESCRIPTION
PHPC-1713

Fixes #1183.