### PR TITLE
PHPC-1529: Reset libmongocrypt key vault client after forking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ modules
 run-tests.php
 tags
 .lvimrc
+mongocryptd.pid
 
 # phpt leftovers
 *.diff

--- a/php_phongo.c
+++ b/php_phongo.c
@@ -3596,6 +3596,11 @@ void php_phongo_client_reset_once(php_phongo_manager_t* manager, int pid)
 {
 	php_phongo_pclient_t* pclient;
 
+	/* Reset associated key vault client */
+	if (!Z_ISUNDEF(manager->key_vault_client_manager)) {
+		php_phongo_client_reset_once(Z_MANAGER_OBJ_P(&manager->key_vault_client_manager), pid);
+	}
+
 	if (manager->use_persistent_client) {
 		pclient = zend_hash_str_find_ptr(&MONGODB_G(persistent_clients), manager->client_hash, manager->client_hash_len);
 

--- a/tests/cursor/bug1529-001.phpt
+++ b/tests/cursor/bug1529-001.phpt
@@ -5,6 +5,7 @@ PHPC-1529: Resetting a client should also reset the keyVaultClient
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_not_live(); ?>
 <?php skip_if_not_clean(); ?>
+<?php skip_if_not_libmongocrypt(); ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";

--- a/tests/cursor/bug1529-001.phpt
+++ b/tests/cursor/bug1529-001.phpt
@@ -64,7 +64,7 @@ $cursor = $keyVaultClient->executeQuery(NS, $query);
 $childPid = pcntl_fork();
 
 if ($childPid === 0) {
-    /* Executing a query with the parent's client resets this client as well as
+    /* Executing any operation with the parent's client resets this client as well as
      * the keyVaultClient. Continuing iteration of the cursor opened on the
      * keyVaultClient before resetting it should then result in an error due to
      * the client having been reset. */

--- a/tests/cursor/bug1529-001.phpt
+++ b/tests/cursor/bug1529-001.phpt
@@ -1,0 +1,106 @@
+--TEST--
+PHPC-1529: Resetting a client should also reset the keyVaultClient
+--SKIPIF--
+<?php if (!function_exists('pcntl_fork')) { die('skip pcntl_fork() not available'); } ?>
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_not_live(); ?>
+<?php skip_if_not_clean(); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+class CommandLogger implements MongoDB\Driver\Monitoring\CommandSubscriber
+{
+    private $pid;
+
+    public function __construct()
+    {
+        $this->pid = getmypid();
+    }
+
+    public function commandStarted(MongoDB\Driver\Monitoring\CommandStartedEvent $event)
+    {
+        $command = $event->getCommand();
+        $commandName = $event->getCommandName();
+        $process = $this->pid === getmypid() ? 'Parent' : 'Child';
+
+        if ($commandName === 'find' || $commandName === 'getMore') {
+            printf("%s executes %s with batchSize: %d\n", $process, $commandName, $command->batchSize);
+            return;
+        }
+
+        printf("%s executes %s\n", $process, $commandName);
+    }
+
+    public function commandSucceeded(MongoDB\Driver\Monitoring\CommandSucceededEvent $event)
+    {
+    }
+
+    public function commandFailed(MongoDB\Driver\Monitoring\CommandFailedEvent $event)
+    {
+    }
+}
+
+$keyVaultClient = new MongoDB\Driver\Manager(URI, [], ['disableClientPersistence' => true]);
+$autoEncryptionOpts = [
+    'keyVaultClient' => $keyVaultClient,
+    'keyVaultNamespace' => 'default.keys',
+    'kmsProviders' => ['local' => ['key' => new MongoDB\BSON\Binary(str_repeat('0', 96), 0)]],
+];
+
+$manager = new MongoDB\Driver\Manager(URI, [], ['autoEncryption' => $autoEncryptionOpts, 'disableClientPersistence' => true]);
+
+$bulk = new MongoDB\Driver\BulkWrite();
+$bulk->insert(['x' => 1]);
+$bulk->insert(['x' => 2]);
+$bulk->insert(['x' => 3]);
+$manager->executeBulkWrite(NS, $bulk);
+
+MongoDB\Driver\Monitoring\addSubscriber(new CommandLogger);
+
+$query = new MongoDB\Driver\Query([], ['batchSize' => 2]);
+$cursor = $keyVaultClient->executeQuery(NS, $query);
+
+$childPid = pcntl_fork();
+
+if ($childPid === 0) {
+    /* Executing a query with the parent's client resets this client as well as
+     * the keyVaultClient. Continuing iteration of the cursor opened on the
+     * keyVaultClient before resetting it should then result in an error due to
+     * the client having been reset. */
+    $childCursor = $manager->executeQuery(NS, $query);
+
+    echo throws(
+        function () use ($cursor) { iterator_count($cursor); },
+        MongoDB\Driver\Exception\RuntimeException::class
+    ), "\n";
+
+    unset($childCursor);
+    echo "Child exits\n";
+    exit;
+}
+
+if ($childPid > 0) {
+    $waitPid = pcntl_waitpid($childPid, $status);
+
+    if ($waitPid === $childPid) {
+        echo "Parent waited for child to exit\n";
+    }
+
+    unset($cursor);
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+Parent executes find with batchSize: 2
+Child executes listCollections
+Child executes find with batchSize: 2
+OK: Got MongoDB\Driver\Exception\RuntimeException
+Cannot advance cursor after client reset
+Child executes killCursors
+Child exits
+Parent waited for child to exit
+Parent executes killCursors
+===DONE===

--- a/tests/cursor/bug1529-001.phpt
+++ b/tests/cursor/bug1529-001.phpt
@@ -5,6 +5,7 @@ PHPC-1529: Resetting a client should also reset the keyVaultClient
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_not_live(); ?>
 <?php skip_if_not_clean(); ?>
+<?php skip_if_server_version('<', '4.2'); ?>
 <?php skip_if_not_libmongocrypt(); ?>
 --FILE--
 <?php
@@ -55,7 +56,7 @@ $bulk = new MongoDB\Driver\BulkWrite();
 $bulk->insert(['x' => 1]);
 $bulk->insert(['x' => 2]);
 $bulk->insert(['x' => 3]);
-$manager->executeBulkWrite(NS, $bulk);
+$keyVaultClient->executeBulkWrite(NS, $bulk);
 
 MongoDB\Driver\Monitoring\addSubscriber(new CommandLogger);
 

--- a/tests/cursor/bug1529-001.phpt
+++ b/tests/cursor/bug1529-001.phpt
@@ -68,14 +68,13 @@ if ($childPid === 0) {
      * the keyVaultClient. Continuing iteration of the cursor opened on the
      * keyVaultClient before resetting it should then result in an error due to
      * the client having been reset. */
-    $childCursor = $manager->executeQuery(NS, $query);
+    $manager->executeCommand(DATABASE_NAME, new MongoDB\Driver\Command(['ping' => 1]));
 
     echo throws(
         function () use ($cursor) { iterator_count($cursor); },
         MongoDB\Driver\Exception\RuntimeException::class
     ), "\n";
 
-    unset($childCursor);
     echo "Child exits\n";
     exit;
 }
@@ -95,11 +94,9 @@ if ($childPid > 0) {
 <?php exit(0); ?>
 --EXPECT--
 Parent executes find with batchSize: 2
-Child executes listCollections
-Child executes find with batchSize: 2
+Child executes ping
 OK: Got MongoDB\Driver\Exception\RuntimeException
 Cannot advance cursor after client reset
-Child executes killCursors
 Child exits
 Parent waited for child to exit
 Parent executes killCursors


### PR DESCRIPTION
PHPC-1529

Fixing this in master to take advantage of the new disableClientPersistence option for tests. The test was a bit tricky to write, but I managed to verify that the keyVaultClient is reset by triggering a reset on the client (by running a query in the fork), then trying to iterate a cursor that was previously opened on the keyVaultClient. With the additional call to `php_phongo_client_reset_once` removed, this test fails as expected.