### PR TITLE
PHPC-1722: Destroy persistent clients in GSHUTDOWN

### DIFF
--- a/php_phongo.h
+++ b/php_phongo.h
@@ -42,7 +42,6 @@ typedef struct {
 ZEND_BEGIN_MODULE_GLOBALS(mongodb)
 	char*             debug;
 	FILE*             debug_fd;
-	bson_mem_vtable_t bsonMemVTable;
 	HashTable         persistent_clients;
 	HashTable*        request_clients;
 	HashTable*        subscribers;


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1722
https://jira.mongodb.org/browse/PHPC-1366
https://jira.mongodb.org/browse/PHPC-1367

This ensures persistent clients in all threads are freed, not just those in the main thread. Doing so also required that we call mongoc_cleanup and bson_mem_restore_vtable in the final GSHUTDOWN (tracked by an atomic counter).

This also moves the vtable to a local variable in MINIT and swaps the order of mongoc_init and bson_mem_set_vtable (and the corresponding teardown functions) so that PHP's allocators will be used for all of libmongoc.