### PR TITLE
Fix build failures with clang 12

### DIFF
--- a/phongo_compat.h
+++ b/phongo_compat.h
@@ -54,6 +54,8 @@
 
 #if PHONGO_GNUC_CHECK_VERSION(7, 0)
 #define PHONGO_BREAK_INTENTIONALLY_MISSING __attribute__((fallthrough));
+#elif defined(__clang__) && __clang_major__ >= 12
+#define PHONGO_BREAK_INTENTIONALLY_MISSING __attribute__((fallthrough));
 #else
 #define PHONGO_BREAK_INTENTIONALLY_MISSING
 #endif


### PR DESCRIPTION
With clang 12, build failures appear due to an implicit fallthrough:
```
src/bson-encode.c:314:3: error: unannotated fall-through between switch labels [-Werror,-Wimplicit-fallthrough]
                case IS_OBJECT: {
                ^
src/bson-encode.c:314:3: note: insert '__attribute__((fallthrough));' to silence this warning
                case IS_OBJECT: {
                ^
                __attribute__((fallthrough)); 
src/bson-encode.c:314:3: note: insert 'break;' to avoid fall-through
                case IS_OBJECT: {
                ^
                break; 
1 error generated.
```