### PR TITLE
Write test results to junit log file

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -324,9 +324,11 @@ functions:
         display_name: "drivers-dir.tar.gz"
 
   "upload test results":
-    - command: attach.results
+    - command: attach.xunit_results
       params:
-        file_location: "${PROJECT_DIRECTORY}/test-results.json"
+        # Uploading test results does not work when using ${PROJECT_DIRECTORY},
+        # so we use an absolute path to work around this
+        file: "src/test-results.xml"
     - command: attach.results
       params:
         file_location: "${DRIVERS_TOOLS}/results.json"

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -23,10 +23,10 @@ fi
 
 echo "Running $AUTH tests, connecting to $MONGODB_URI"
 
-# Run the tests, and store the results in a Evergreen compatible JSON results file
+# Run the tests, and store the results in a junit result file
 case "$OS" in
    *)
-      TEST_PHP_ARGS="-q -x --show-diff -g FAIL,XFAIL,BORK,WARN,LEAK,SKIP" make test TESTS=$TESTS
+      TEST_PHP_JUNIT="${PROJECT_DIRECTORY}/test-results.xml" TEST_PHP_ARGS="-q -x --show-diff -g FAIL,XFAIL,BORK,WARN,LEAK,SKIP" make test TESTS=$TESTS
       ;;
 esac
 


### PR DESCRIPTION
I discovered this by pure accident. run-tests.php supports writing a junit output file, which we can attach on Evergreen to get a better overview over passing/failing tests.