### PR TITLE
Automatically detect PHP patch version

### DIFF
--- a/.evergreen/compile-unix.sh
+++ b/.evergreen/compile-unix.sh
@@ -61,13 +61,8 @@ esac
 echo "MARCH: $MARCH"
 echo "RELEASE: $RELEASE"
 echo "OS: $OS"
-echo "PHP_VERSION: $PHP_VERSION"
+echo "PHP: $PHP_VERSION (`php --version | head -1`)"
 
-OLD_PATH=$PATH
-PATH=/opt/php/${PHP_VERSION}-64bit/bin:$OLD_PATH
-
-#cat `which phpize` | sed 's@/data/mci/.*/src@/opt@' > ./phpize
-#chmod +x ./phpize
 phpize
 ./configure --enable-mongodb-developer-flags
 make

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -71,9 +71,23 @@ functions:
               export PROJECT_DIRECTORY=$(cygpath -m $PROJECT_DIRECTORY)
            fi
 
+           if [ -d "/opt/php/${PHP_VERSION}-64bit/bin" ]; then
+              PHP_PATH="/opt/php/${PHP_VERSION}-64bit/bin"
+           else
+              # Try to find the newest version matching our constant
+              PHP_PATH=`find /opt/php/ -maxdepth 1 -type d -name '${PHP_VERSION}*-64bit' -print | sort -V -r | head -1`/bin
+           fi
+
+           if [ ! -d "$PHP_PATH" ]; then
+              echo "Could not find PHP binaries for version ${PHP_VERSION}. Listing available versions..."
+              ls -1 /opt/php
+              exit 1
+           fi
+
            export MONGO_ORCHESTRATION_HOME="$DRIVERS_TOOLS/.evergreen/orchestration"
            export MONGODB_BINARIES="$DRIVERS_TOOLS/mongodb/bin"
            export UPLOAD_BUCKET="${project}"
+           export PHP_VERSION="${PHP_VERSION}"
 
            cat <<EOT > expansion.yml
            CURRENT_VERSION: "$CURRENT_VERSION"
@@ -82,6 +96,7 @@ functions:
            MONGODB_BINARIES: "$MONGODB_BINARIES"
            UPLOAD_BUCKET: "$UPLOAD_BUCKET"
            PROJECT_DIRECTORY: "$PROJECT_DIRECTORY"
+
            PREPARE_SHELL: |
               set -o errexit
               set -o xtrace
@@ -92,8 +107,10 @@ functions:
               export PROJECT_DIRECTORY="$PROJECT_DIRECTORY"
 
               export TMPDIR="$MONGO_ORCHESTRATION_HOME/db"
-              export PATH="$MONGODB_BINARIES:$PATH"
+              export PATH="$PHP_PATH:$MONGODB_BINARIES:$PATH"
               export PROJECT="${project}"
+
+              export PHP_VERSION="$PHP_VERSION"
            EOT
            # See what we've done
            cat expansion.yml
@@ -185,7 +202,7 @@ functions:
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
-          PHP_VERSION=${PHP_VERSION} sh ${PROJECT_DIRECTORY}/.evergreen/compile-unix.sh
+          sh ${PROJECT_DIRECTORY}/.evergreen/compile-unix.sh
 
   "exec script" :
     - command: shell.exec
@@ -1023,22 +1040,26 @@ axes:
   - id: php-versions
     display_name: PHP Version
     values:
+      - id: "7.4"
+        display_name: "PHP 7.4"
+        variables:
+          PHP_VERSION: "7.4"
       - id: "7.3"
         display_name: "PHP 7.3"
         variables:
-          PHP_VERSION: "7.3.8"
+          PHP_VERSION: "7.3"
       - id: "7.2"
         display_name: "PHP 7.2"
         variables:
-          PHP_VERSION: "7.2.10"
+          PHP_VERSION: "7.2"
       - id: "7.1"
         display_name: "PHP 7.1"
         variables:
-          PHP_VERSION: "7.1.22"
+          PHP_VERSION: "7.1"
       - id: "7.0"
         display_name: "PHP 7.0"
         variables:
-          PHP_VERSION: "7.0.32"
+          PHP_VERSION: "7.0"
 
   - id: os-php7
     display_name: OS


### PR DESCRIPTION
This PR changes the evergreen build config to no longer set a specific patch version for PHP, instead only setting the minor version to be used (e.g. "7.4"). This reduces the workload associated with updating the PHP toolchain, since we no longer need to update the evergreen config when the toolchain brings new patch releases for PHP. The path to PHP binaries is now also prepended to the `PATH` environment variable.

The script will attempt to fetch the latest patch version for the requested PHP version (by using the version sort functionality of `sort`) and error if none was found. The logic will need adjusting if we want to start testing against thread-safe versions of PHP.

These changes will be ported to the PHPLIB evergreen config once they've been merged here.