### PR TITLE
PHPC-1774 Fix truncation of PHP_VERSION constant in handshake metadata

### DIFF
--- a/php_phongo.c
+++ b/php_phongo.c
@@ -76,6 +76,8 @@
 #define PHONGO_DEBUG_INI_DEFAULT ""
 #define PHONGO_METADATA_SEPARATOR " / "
 #define PHONGO_METADATA_SEPARATOR_LEN (sizeof(PHONGO_METADATA_SEPARATOR) - 1)
+#define PHONGO_METADATA_PHP_VERSION_PREFIX "PHP "
+#define PHONGO_METADATA_PHP_VERSION_PREFIX_LEN (sizeof(PHONGO_METADATA_PHP_VERSION_PREFIX) - 1)
 
 ZEND_DECLARE_MODULE_GLOBALS(mongodb)
 #if defined(ZTS) && defined(COMPILE_DL_MONGODB)
@@ -2569,7 +2571,7 @@ static char* php_phongo_concat_handshake_data(const char* default_value, const c
 	size_t ret_len = strlen(default_value) + 1;
 
 	if (custom_value) {
-		/* Increase the length by that of the custom value as well as one byte for the separator */
+		/* Increase the length by that of the custom value as well as the separator length */
 		ret_len += custom_value_len + PHONGO_METADATA_SEPARATOR_LEN;
 	}
 
@@ -2592,9 +2594,9 @@ static void php_phongo_handshake_data_append(const char* name, size_t name_len, 
 	char*  driver_version;
 	char*  full_platform;
 
-	php_version_string_len = strlen(PHP_VERSION);
-	php_version_string     = ecalloc(sizeof(char*), 4 + php_version_string_len);
-	snprintf(php_version_string, 4 + php_version_string_len, "PHP %s", PHP_VERSION);
+	php_version_string_len = strlen(PHP_VERSION) + PHONGO_METADATA_PHP_VERSION_PREFIX_LEN + 1;
+	php_version_string     = ecalloc(sizeof(char*), php_version_string_len);
+	snprintf(php_version_string, php_version_string_len, "%s%s", PHONGO_METADATA_PHP_VERSION_PREFIX, PHP_VERSION);
 
 	driver_name    = php_phongo_concat_handshake_data("ext-mongodb:PHP", name, name_len);
 	driver_version = php_phongo_concat_handshake_data(PHP_MONGODB_VERSION, version, version_len);

--- a/php_phongo.c
+++ b/php_phongo.c
@@ -2567,8 +2567,8 @@ static bool php_phongo_extract_handshake_data(zval* driver, const char* key, cha
 static char* php_phongo_concat_handshake_data(const char* default_value, const char* custom_value, size_t custom_value_len)
 {
 	char* ret;
-	/* Length of the returned value needs to include the trailing null byte */
-	size_t ret_len = strlen(default_value) + 1;
+	/* Length of the returned value needs to include a trailing space and null byte */
+	size_t ret_len = strlen(default_value) + 2;
 
 	if (custom_value) {
 		/* Increase the length by that of the custom value as well as the separator length */
@@ -2578,9 +2578,9 @@ static char* php_phongo_concat_handshake_data(const char* default_value, const c
 	ret = ecalloc(sizeof(char*), ret_len);
 
 	if (custom_value) {
-		snprintf(ret, ret_len, "%s%s%s", default_value, PHONGO_METADATA_SEPARATOR, custom_value);
+		snprintf(ret, ret_len, "%s%s%s ", default_value, PHONGO_METADATA_SEPARATOR, custom_value);
 	} else {
-		snprintf(ret, ret_len, "%s", default_value);
+		snprintf(ret, ret_len, "%s ", default_value);
 	}
 
 	return ret;
@@ -2603,7 +2603,7 @@ static void php_phongo_handshake_data_append(const char* name, size_t name_len, 
 	full_platform  = php_phongo_concat_handshake_data(php_version_string, platform, platform_len);
 
 	MONGOC_DEBUG(
-		"Setting driver handshake data: name %s, version %s, platform %s",
+		"Setting driver handshake data: { name: '%s', version: '%s', platform: '%s' }",
 		driver_name,
 		driver_version,
 		full_platform);

--- a/tests/manager/manager-ctor-driver-metadata-001.phpt
+++ b/tests/manager/manager-ctor-driver-metadata-001.phpt
@@ -1,5 +1,13 @@
 --TEST--
 MongoDB\Driver\Manager: Pass custom handshake data
+--DESCRIPTION--
+This test matches spaces at the end of the handshake data it appends. The only
+way to see final output is by checking against the binary socket communication:
+[2021-02-17T13:57:57.155166+00:00]     socket: TRACE   > 00100:  66 6f 72 6d 00 76 00 00  00 50 48 50 20 37 2e 34  f o r m . v . .  . P H P   7 . 4
+[2021-02-17T13:57:57.155182+00:00]     socket: TRACE   > 00110:  2e 31 35 20 2f 20 6d 69  6e 65 20 63 66 67 3d 30  . 1 5   /   m i  n e   c f g = 0
+
+Since matching this is not trivial, we're happy matching the trailing space at
+the end of each handshake data item.
 --INI--
 mongodb.debug=stderr
 --FILE--
@@ -12,6 +20,6 @@ $manager = new MongoDB\Driver\Manager(null, [], ['driver' => ['name' => 'test']]
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-%A[%s]     PHONGO: DEBUG   > Setting driver handshake data: name ext-mongodb:PHP / test, version %s / 0.1, platform PHP %s / mine
-%A[%s]     PHONGO: DEBUG   > Setting driver handshake data: name ext-mongodb:PHP / test, version %s, platform PHP %s
+%A[%s]     PHONGO: DEBUG   > Setting driver handshake data: { name: 'ext-mongodb:PHP / test ', version: '%s / 0.1 ', platform: 'PHP %s / mine ' }
+%A[%s]     PHONGO: DEBUG   > Setting driver handshake data: { name: 'ext-mongodb:PHP / test ', version: '%s ', platform: 'PHP %s ' }
 %A===DONE===%A


### PR DESCRIPTION
PHPC-1774

@jmikola testing this is notoriously difficult, as I can't add the expected value of `PHP_VERSION` into the `EXPECTF` block. If you have any suggestion how to prevent regressions against this, please let me know.