### PR TITLE
Fix running auth tests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -513,7 +513,7 @@ tasks:
         - func: "bootstrap mongo-orchestration"
           vars:
             TOPOLOGY: "server"
-            AUTH: "yes"
+            AUTH: "auth"
         - func: "run tests"
 
     - name: "test-standalone-ssl"
@@ -554,7 +554,7 @@ tasks:
         - func: "bootstrap mongo-orchestration"
           vars:
             TOPOLOGY: "replica_set"
-            AUTH: "yes"
+            AUTH: "auth"
         - func: "run tests"
 
     - name: "test-replicaset-old"

--- a/.evergreen/orchestration/configs/replica_sets/basic-ssl.json
+++ b/.evergreen/orchestration/configs/replica_sets/basic-ssl.json
@@ -1,0 +1,51 @@
+{
+  "id": "repl0",
+  "members": [
+    {
+      "procParams": {
+        "ipv6": true,
+        "bind_ip": "127.0.0.1,::1",
+        "journal": true,
+        "oplogSize": 500,
+        "port": 27017
+      },
+      "rsParams": {
+        "tags": {
+          "ordinal": "one",
+          "dc": "ny"
+        }
+      }
+    },
+    {
+      "procParams": {
+        "ipv6": true,
+        "bind_ip": "127.0.0.1,::1",
+        "journal": true,
+        "oplogSize": 500,
+        "port": 27018
+      },
+      "rsParams": {
+        "tags": {
+          "ordinal": "two",
+          "dc": "pa"
+        }
+      }
+    },
+    {
+      "procParams": {
+        "ipv6": true,
+        "bind_ip": "127.0.0.1,::1",
+        "journal": true,
+        "port": 27019
+      },
+      "rsParams": {
+      }
+    }
+  ],
+  "sslParams": {
+      "sslOnNormalPorts": true,
+      "sslPEMKeyFile": "ABSOLUTE_PATH_REPLACEMENT_TOKEN/.evergreen/x509gen/server.pem",
+      "sslCAFile": "ABSOLUTE_PATH_REPLACEMENT_TOKEN/.evergreen/x509gen/ca.pem",
+      "sslWeakCertificateValidation" : true
+  }
+}

--- a/.evergreen/orchestration/configs/replica_sets/basic.json
+++ b/.evergreen/orchestration/configs/replica_sets/basic.json
@@ -1,0 +1,45 @@
+{
+  "id": "repl0",
+  "members": [
+    {
+      "procParams": {
+        "ipv6": true,
+        "bind_ip": "127.0.0.1,::1",
+        "journal": true,
+        "oplogSize": 500,
+        "port": 27017
+      },
+      "rsParams": {
+        "tags": {
+          "ordinal": "one",
+          "dc": "ny"
+        }
+      }
+    },
+    {
+      "procParams": {
+        "ipv6": true,
+        "bind_ip": "127.0.0.1,::1",
+        "journal": true,
+        "oplogSize": 500,
+        "port": 27018
+      },
+      "rsParams": {
+        "tags": {
+          "ordinal": "two",
+          "dc": "pa"
+        }
+      }
+    },
+    {
+      "procParams": {
+        "ipv6": true,
+        "bind_ip": "127.0.0.1,::1",
+        "journal": true,
+        "port": 27019
+      },
+      "rsParams": {
+      }
+    }
+  ]
+}

--- a/tests/server/server-executeQuery-008.phpt
+++ b/tests/server/server-executeQuery-008.phpt
@@ -13,10 +13,11 @@ $manager = new MongoDB\Driver\Manager(URI);
 
 $primaryRp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY);
 $primary = $manager->selectServer($primaryRp);
+$serverCount = count($manager->getServers());
 
 $bulk = new \MongoDB\Driver\BulkWrite;
 $bulk->insert(['_id' => 1, 'x' => 1]);
-$primary->executeBulkWrite(NS, $bulk, new MongoDB\Driver\WriteConcern(MongoDB\Driver\WriteConcern::MAJORITY));
+$primary->executeBulkWrite(NS, $bulk, new MongoDB\Driver\WriteConcern($serverCount));
 
 $secondaryRp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY);
 $secondary = $manager->selectServer($secondaryRp);

--- a/tests/server/server-getTags-002.phpt
+++ b/tests/server/server-getTags-002.phpt
@@ -9,21 +9,23 @@ MongoDB\Driver\Server::getTags() with replica set
 require_once __DIR__ . "/../utils/basic.inc";
 
 $manager = new MongoDB\Driver\Manager(URI);
+$command = new MongoDB\Driver\Command(['ping' => 1]);
+$manager->executeCommand(DATABASE_NAME, $command);
 
-$tags = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY))->getTags();
-echo "dc: ", array_key_exists('dc', $tags) ? $tags['dc'] : 'not set', "\n";
-echo "ordinal: ", array_key_exists('ordinal', $tags) ? $tags['ordinal'] : 'not set', "\n";
-
-$tags = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY))->getTags();
-echo "dc: ", array_key_exists('dc', $tags) ? $tags['dc'] : 'not set', "\n";
-echo "ordinal: ", array_key_exists('ordinal', $tags) ? $tags['ordinal'] : 'not set', "\n";
+foreach ($manager->getServers() as $server) {
+    $tags = $server->getTags();
+    echo "dc: ", array_key_exists('dc', $tags) ? $tags['dc'] : 'not set', "\n";
+    echo "ordinal: ", array_key_exists('ordinal', $tags) ? $tags['ordinal'] : 'not set', "\n";
+}
 
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECTF--
+--EXPECT--
 dc: ny
 ordinal: one
 dc: pa
 ordinal: two
+dc: not set
+ordinal: not set
 ===DONE===


### PR DESCRIPTION
While changing test setup to rely on drivers-evergreen-tools, I missed that the `AUTH` variable needs to be "auth" for drivers-evergreen-tools while "yes" was used for our own scripts. This PR updates the build config and fixes a test that can be flaky due to potential elections in the replica set.