### PR TITLE
PHPC-1793: Use zend_ce_countable for PHP 8.1+ compat

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,7 @@ jobs:
         php-version:
           - "7.4"
           - "8.0"
+          - "8.1"
         mongodb-version:
           - "4.4"
         topology:

--- a/src/MongoDB/BulkWrite.c
+++ b/src/MongoDB/BulkWrite.c
@@ -16,7 +16,6 @@
 
 #include <php.h>
 #include <Zend/zend_interfaces.h>
-#include <ext/spl/spl_iterators.h>
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -26,6 +25,11 @@
 #include "phongo_compat.h"
 #include "php_phongo.h"
 #include "php_bson.h"
+
+#if PHP_VERSION_ID < 70200
+#include <ext/spl/spl_iterators.h>
+#define zend_ce_countable spl_ce_Countable
+#endif /* PHP_VERSION_ID < 70200 */
 
 #define PHONGO_BULKWRITE_BYPASS_UNSET -1
 
@@ -669,7 +673,7 @@ void php_phongo_bulkwrite_init_ce(INIT_FUNC_ARGS) /* {{{ */
 	php_phongo_handler_bulkwrite.free_obj       = php_phongo_bulkwrite_free_object;
 	php_phongo_handler_bulkwrite.offset         = XtOffsetOf(php_phongo_bulkwrite_t, std);
 
-	zend_class_implements(php_phongo_bulkwrite_ce, 1, spl_ce_Countable);
+	zend_class_implements(php_phongo_bulkwrite_ce, 1, zend_ce_countable);
 } /* }}} */
 
 /*


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1793

zend_ce_countable was introduced in PHP 7.2 (see: php/php-src@27e7aea4124ffdecb6d40a2f5723e413a7b40562) and spl_ce_Countable was removed in PHP 8.1 (see: php/php-src@4f4c031f62e28ed53869a57264535a8739a010e9).