### PR TITLE
PHPC-1792: Change all copyrights to be <year>-present

### DIFF
--- a/phongo_compat.c
+++ b/phongo_compat.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-Present MongoDB, Inc.
+ * Copyright 2015-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/phongo_compat.c
+++ b/phongo_compat.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 MongoDB, Inc.
+ * Copyright 2015-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/phongo_compat.h
+++ b/phongo_compat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-Present MongoDB, Inc.
+ * Copyright 2015-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/phongo_compat.h
+++ b/phongo_compat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 MongoDB, Inc.
+ * Copyright 2015-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/phongo_version.h
+++ b/phongo_version.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/phongo_version.h
+++ b/phongo_version.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2018 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/php_bson.h
+++ b/php_bson.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/php_bson.h
+++ b/php_bson.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/php_phongo.c
+++ b/php_phongo.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/php_phongo.c
+++ b/php_phongo.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/php_phongo.h
+++ b/php_phongo.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/php_phongo.h
+++ b/php_phongo.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/php_phongo_classes.h
+++ b/php_phongo_classes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/php_phongo_classes.h
+++ b/php_phongo_classes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/php_phongo_structs.h
+++ b/php_phongo_structs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-Present MongoDB, Inc.
+ * Copyright 2015-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/php_phongo_structs.h
+++ b/php_phongo_structs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 MongoDB, Inc.
+ * Copyright 2015-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/Binary.c
+++ b/src/BSON/Binary.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/Binary.c
+++ b/src/BSON/Binary.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/BinaryInterface.c
+++ b/src/BSON/BinaryInterface.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-Present MongoDB, Inc.
+ * Copyright 2017-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/BinaryInterface.c
+++ b/src/BSON/BinaryInterface.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MongoDB, Inc.
+ * Copyright 2017-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/DBPointer.c
+++ b/src/BSON/DBPointer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/DBPointer.c
+++ b/src/BSON/DBPointer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/Decimal128.c
+++ b/src/BSON/Decimal128.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-Present MongoDB, Inc.
+ * Copyright 2015-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/Decimal128.c
+++ b/src/BSON/Decimal128.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 MongoDB, Inc.
+ * Copyright 2015-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/Decimal128Interface.c
+++ b/src/BSON/Decimal128Interface.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-Present MongoDB, Inc.
+ * Copyright 2017-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/Decimal128Interface.c
+++ b/src/BSON/Decimal128Interface.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MongoDB, Inc.
+ * Copyright 2017-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/Int64.c
+++ b/src/BSON/Int64.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-present MongoDB, Inc.
+ * Copyright 2018-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/Int64.c
+++ b/src/BSON/Int64.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-Present MongoDB, Inc.
+ * Copyright 2018-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/Javascript.c
+++ b/src/BSON/Javascript.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/Javascript.c
+++ b/src/BSON/Javascript.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/JavascriptInterface.c
+++ b/src/BSON/JavascriptInterface.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-Present MongoDB, Inc.
+ * Copyright 2017-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/JavascriptInterface.c
+++ b/src/BSON/JavascriptInterface.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MongoDB, Inc.
+ * Copyright 2017-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/MaxKey.c
+++ b/src/BSON/MaxKey.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/MaxKey.c
+++ b/src/BSON/MaxKey.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/MaxKeyInterface.c
+++ b/src/BSON/MaxKeyInterface.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-Present MongoDB, Inc.
+ * Copyright 2017-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/MaxKeyInterface.c
+++ b/src/BSON/MaxKeyInterface.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MongoDB, Inc.
+ * Copyright 2017-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/MinKey.c
+++ b/src/BSON/MinKey.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/MinKey.c
+++ b/src/BSON/MinKey.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/MinKeyInterface.c
+++ b/src/BSON/MinKeyInterface.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-Present MongoDB, Inc.
+ * Copyright 2017-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/MinKeyInterface.c
+++ b/src/BSON/MinKeyInterface.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MongoDB, Inc.
+ * Copyright 2017-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/ObjectId.c
+++ b/src/BSON/ObjectId.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/ObjectId.c
+++ b/src/BSON/ObjectId.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/ObjectIdInterface.c
+++ b/src/BSON/ObjectIdInterface.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-Present MongoDB, Inc.
+ * Copyright 2017-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/ObjectIdInterface.c
+++ b/src/BSON/ObjectIdInterface.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MongoDB, Inc.
+ * Copyright 2017-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/Persistable.c
+++ b/src/BSON/Persistable.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/Persistable.c
+++ b/src/BSON/Persistable.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/Regex.c
+++ b/src/BSON/Regex.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/Regex.c
+++ b/src/BSON/Regex.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/RegexInterface.c
+++ b/src/BSON/RegexInterface.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-Present MongoDB, Inc.
+ * Copyright 2017-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/RegexInterface.c
+++ b/src/BSON/RegexInterface.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MongoDB, Inc.
+ * Copyright 2017-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/Serializable.c
+++ b/src/BSON/Serializable.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/Serializable.c
+++ b/src/BSON/Serializable.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/Symbol.c
+++ b/src/BSON/Symbol.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/Symbol.c
+++ b/src/BSON/Symbol.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/Timestamp.c
+++ b/src/BSON/Timestamp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/Timestamp.c
+++ b/src/BSON/Timestamp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/TimestampInterface.c
+++ b/src/BSON/TimestampInterface.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-Present MongoDB, Inc.
+ * Copyright 2017-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/TimestampInterface.c
+++ b/src/BSON/TimestampInterface.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MongoDB, Inc.
+ * Copyright 2017-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/Type.c
+++ b/src/BSON/Type.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/Type.c
+++ b/src/BSON/Type.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/UTCDateTime.c
+++ b/src/BSON/UTCDateTime.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/UTCDateTime.c
+++ b/src/BSON/UTCDateTime.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/UTCDateTimeInterface.c
+++ b/src/BSON/UTCDateTimeInterface.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-Present MongoDB, Inc.
+ * Copyright 2017-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/UTCDateTimeInterface.c
+++ b/src/BSON/UTCDateTimeInterface.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MongoDB, Inc.
+ * Copyright 2017-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/Undefined.c
+++ b/src/BSON/Undefined.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/Undefined.c
+++ b/src/BSON/Undefined.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/Unserializable.c
+++ b/src/BSON/Unserializable.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/Unserializable.c
+++ b/src/BSON/Unserializable.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/functions.c
+++ b/src/BSON/functions.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/functions.c
+++ b/src/BSON/functions.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/functions.h
+++ b/src/BSON/functions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/BSON/functions.h
+++ b/src/BSON/functions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/BulkWrite.c
+++ b/src/MongoDB/BulkWrite.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-Present MongoDB, Inc.
+ * Copyright 2015-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/BulkWrite.c
+++ b/src/MongoDB/BulkWrite.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 MongoDB, Inc.
+ * Copyright 2015-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/ClientEncryption.c
+++ b/src/MongoDB/ClientEncryption.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-Present MongoDB, Inc.
+ * Copyright 2019-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/ClientEncryption.c
+++ b/src/MongoDB/ClientEncryption.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MongoDB, Inc.
+ * Copyright 2019-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Command.c
+++ b/src/MongoDB/Command.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Command.c
+++ b/src/MongoDB/Command.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Cursor.c
+++ b/src/MongoDB/Cursor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Cursor.c
+++ b/src/MongoDB/Cursor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/CursorId.c
+++ b/src/MongoDB/CursorId.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/CursorId.c
+++ b/src/MongoDB/CursorId.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/CursorInterface.c
+++ b/src/MongoDB/CursorInterface.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-Present MongoDB, Inc.
+ * Copyright 2018-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/CursorInterface.c
+++ b/src/MongoDB/CursorInterface.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 MongoDB, Inc.
+ * Copyright 2018-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Exception/AuthenticationException.c
+++ b/src/MongoDB/Exception/AuthenticationException.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Exception/AuthenticationException.c
+++ b/src/MongoDB/Exception/AuthenticationException.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Exception/BulkWriteException.c
+++ b/src/MongoDB/Exception/BulkWriteException.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-Present MongoDB, Inc.
+ * Copyright 2015-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Exception/BulkWriteException.c
+++ b/src/MongoDB/Exception/BulkWriteException.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 MongoDB, Inc.
+ * Copyright 2015-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Exception/CommandException.c
+++ b/src/MongoDB/Exception/CommandException.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-Present MongoDB, Inc.
+ * Copyright 2018-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Exception/CommandException.c
+++ b/src/MongoDB/Exception/CommandException.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 MongoDB, Inc.
+ * Copyright 2018-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Exception/ConnectionException.c
+++ b/src/MongoDB/Exception/ConnectionException.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Exception/ConnectionException.c
+++ b/src/MongoDB/Exception/ConnectionException.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Exception/ConnectionTimeoutException.c
+++ b/src/MongoDB/Exception/ConnectionTimeoutException.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-Present MongoDB, Inc.
+ * Copyright 2015-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Exception/ConnectionTimeoutException.c
+++ b/src/MongoDB/Exception/ConnectionTimeoutException.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 MongoDB, Inc.
+ * Copyright 2015-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Exception/EncryptionException.c
+++ b/src/MongoDB/Exception/EncryptionException.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2020 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Exception/EncryptionException.c
+++ b/src/MongoDB/Exception/EncryptionException.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Exception/Exception.c
+++ b/src/MongoDB/Exception/Exception.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Exception/Exception.c
+++ b/src/MongoDB/Exception/Exception.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Exception/ExecutionTimeoutException.c
+++ b/src/MongoDB/Exception/ExecutionTimeoutException.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-Present MongoDB, Inc.
+ * Copyright 2015-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Exception/ExecutionTimeoutException.c
+++ b/src/MongoDB/Exception/ExecutionTimeoutException.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 MongoDB, Inc.
+ * Copyright 2015-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Exception/InvalidArgumentException.c
+++ b/src/MongoDB/Exception/InvalidArgumentException.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-Present MongoDB, Inc.
+ * Copyright 2015-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Exception/InvalidArgumentException.c
+++ b/src/MongoDB/Exception/InvalidArgumentException.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 MongoDB, Inc.
+ * Copyright 2015-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Exception/LogicException.c
+++ b/src/MongoDB/Exception/LogicException.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-Present MongoDB, Inc.
+ * Copyright 2015-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Exception/LogicException.c
+++ b/src/MongoDB/Exception/LogicException.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 MongoDB, Inc.
+ * Copyright 2015-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Exception/RuntimeException.c
+++ b/src/MongoDB/Exception/RuntimeException.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-Present MongoDB, Inc.
+ * Copyright 2015-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Exception/RuntimeException.c
+++ b/src/MongoDB/Exception/RuntimeException.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 MongoDB, Inc.
+ * Copyright 2015-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Exception/SSLConnectionException.c
+++ b/src/MongoDB/Exception/SSLConnectionException.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Exception/SSLConnectionException.c
+++ b/src/MongoDB/Exception/SSLConnectionException.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Exception/ServerException.c
+++ b/src/MongoDB/Exception/ServerException.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-Present MongoDB, Inc.
+ * Copyright 2018-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Exception/ServerException.c
+++ b/src/MongoDB/Exception/ServerException.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 MongoDB, Inc.
+ * Copyright 2018-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Exception/UnexpectedValueException.c
+++ b/src/MongoDB/Exception/UnexpectedValueException.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Exception/UnexpectedValueException.c
+++ b/src/MongoDB/Exception/UnexpectedValueException.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Exception/WriteException.c
+++ b/src/MongoDB/Exception/WriteException.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Exception/WriteException.c
+++ b/src/MongoDB/Exception/WriteException.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Manager.c
+++ b/src/MongoDB/Manager.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Manager.c
+++ b/src/MongoDB/Manager.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Monitoring/CommandFailedEvent.c
+++ b/src/MongoDB/Monitoring/CommandFailedEvent.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-Present MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Monitoring/CommandFailedEvent.c
+++ b/src/MongoDB/Monitoring/CommandFailedEvent.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 MongoDB, Inc.
+ * Copyright 2016-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Monitoring/CommandStartedEvent.c
+++ b/src/MongoDB/Monitoring/CommandStartedEvent.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-Present MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Monitoring/CommandStartedEvent.c
+++ b/src/MongoDB/Monitoring/CommandStartedEvent.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 MongoDB, Inc.
+ * Copyright 2016-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Monitoring/CommandSubscriber.c
+++ b/src/MongoDB/Monitoring/CommandSubscriber.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-Present MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Monitoring/CommandSubscriber.c
+++ b/src/MongoDB/Monitoring/CommandSubscriber.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 MongoDB, Inc.
+ * Copyright 2016-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Monitoring/CommandSucceededEvent.c
+++ b/src/MongoDB/Monitoring/CommandSucceededEvent.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-Present MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Monitoring/CommandSucceededEvent.c
+++ b/src/MongoDB/Monitoring/CommandSucceededEvent.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 MongoDB, Inc.
+ * Copyright 2016-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Monitoring/Subscriber.c
+++ b/src/MongoDB/Monitoring/Subscriber.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-Present MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Monitoring/Subscriber.c
+++ b/src/MongoDB/Monitoring/Subscriber.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 MongoDB, Inc.
+ * Copyright 2016-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Monitoring/functions.c
+++ b/src/MongoDB/Monitoring/functions.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-Present MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Monitoring/functions.c
+++ b/src/MongoDB/Monitoring/functions.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 MongoDB, Inc.
+ * Copyright 2016-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Monitoring/functions.h
+++ b/src/MongoDB/Monitoring/functions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-Present MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Monitoring/functions.h
+++ b/src/MongoDB/Monitoring/functions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 MongoDB, Inc.
+ * Copyright 2016-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Query.c
+++ b/src/MongoDB/Query.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Query.c
+++ b/src/MongoDB/Query.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/ReadConcern.c
+++ b/src/MongoDB/ReadConcern.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-Present MongoDB, Inc.
+ * Copyright 2015-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/ReadConcern.c
+++ b/src/MongoDB/ReadConcern.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 MongoDB, Inc.
+ * Copyright 2015-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/ReadPreference.c
+++ b/src/MongoDB/ReadPreference.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/ReadPreference.c
+++ b/src/MongoDB/ReadPreference.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Server.c
+++ b/src/MongoDB/Server.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Server.c
+++ b/src/MongoDB/Server.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/ServerApi.c
+++ b/src/MongoDB/ServerApi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-Present MongoDB, Inc.
+ * Copyright 2021-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/ServerApi.c
+++ b/src/MongoDB/ServerApi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-present MongoDB, Inc.
+ * Copyright 2021-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Session.c
+++ b/src/MongoDB/Session.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-Present MongoDB, Inc.
+ * Copyright 2017-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Session.c
+++ b/src/MongoDB/Session.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MongoDB, Inc.
+ * Copyright 2017-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Session.h
+++ b/src/MongoDB/Session.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-Present MongoDB, Inc.
+ * Copyright 2017-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/Session.h
+++ b/src/MongoDB/Session.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MongoDB, Inc.
+ * Copyright 2017-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/WriteConcern.c
+++ b/src/MongoDB/WriteConcern.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/WriteConcern.c
+++ b/src/MongoDB/WriteConcern.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/WriteConcernError.c
+++ b/src/MongoDB/WriteConcernError.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/WriteConcernError.c
+++ b/src/MongoDB/WriteConcernError.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/WriteError.c
+++ b/src/MongoDB/WriteError.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/WriteError.c
+++ b/src/MongoDB/WriteError.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/WriteResult.c
+++ b/src/MongoDB/WriteResult.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB/WriteResult.c
+++ b/src/MongoDB/WriteResult.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/bson-encode.c
+++ b/src/bson-encode.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/bson-encode.c
+++ b/src/bson-encode.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/bson.c
+++ b/src/bson.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-Present MongoDB, Inc.
+ * Copyright 2014-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/bson.c
+++ b/src/bson.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MongoDB, Inc.
+ * Copyright 2014-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/phongo_apm.c
+++ b/src/phongo_apm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-Present MongoDB, Inc.
+ * Copyright 2021-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/phongo_apm.c
+++ b/src/phongo_apm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-present MongoDB, Inc.
+ * Copyright 2021-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/phongo_apm.h
+++ b/src/phongo_apm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-Present MongoDB, Inc.
+ * Copyright 2021-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/phongo_apm.h
+++ b/src/phongo_apm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-present MongoDB, Inc.
+ * Copyright 2021-Present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/template.rc
+++ b/template.rc
@@ -38,7 +38,7 @@ BEGIN
             VALUE "FileDescription", FILE_DESCRIPTION
             VALUE "FileVersion", PHP_MONGODB_VERSION
             VALUE "InternalName", FILE_NAME
-            VALUE "LegalCopyright", "Copyright © 2014-present MongoDB, Inc."
+            VALUE "LegalCopyright", "Copyright 2014-Present MongoDB, Inc."
             VALUE "OriginalFilename", FILE_NAME
             VALUE "ProductName", "MongoDB Driver for PHP"
             VALUE "ProductVersion", PHP_MONGODB_VERSION

--- a/template.rc
+++ b/template.rc
@@ -38,7 +38,7 @@ BEGIN
             VALUE "FileDescription", FILE_DESCRIPTION
             VALUE "FileVersion", PHP_MONGODB_VERSION
             VALUE "InternalName", FILE_NAME
-            VALUE "LegalCopyright", "Copyright 2014-Present MongoDB, Inc."
+            VALUE "LegalCopyright", "Copyright 2014-present MongoDB, Inc."
             VALUE "OriginalFilename", FILE_NAME
             VALUE "ProductName", "MongoDB Driver for PHP"
             VALUE "ProductVersion", PHP_MONGODB_VERSION


### PR DESCRIPTION
Some of these were in the form of `Copyright <year> MongoDB, Inc.` as opposed to `Copyright <year>=<year> MongoDB, Inc.` - I changed those as well assuming we would want equivalence across files, but please lmk if that was an incorrect assumption!

I also opted for "Present" instead of "present" (template updated accordingly) - please lmk if you aren't a fan of that! 