### PR TITLE
PHPC-1848: Add 5.0 to the server testing matrix

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -996,6 +996,10 @@ axes:
         display_name: "MongoDB latest"
         variables:
            VERSION: "latest"
+      - id: "5.0"
+        display_name: "MongoDB 5.0"
+        variables:
+           VERSION: "5.0"
       - id: "4.4"
         display_name: "MongoDB 4.4"
         variables:
@@ -1104,9 +1108,9 @@ axes:
 buildvariants:
 
 - matrix_name: "tests-php7"
-  matrix_spec: {"os-php7": "*", "versions": "4.2", "php-versions": ["7.0","7.1","7.2","7.3"] }
+  matrix_spec: {"os-php7": "*", "versions": "4.4", "php-versions": ["7.0","7.1","7.2","7.3"] }
   exclude_spec:
-    - {"os-php7": "ubuntu1804-arm64-test", "versions": "4.2", "php-versions": ["7.0","7.1","7.2"]}
+    - {"os-php7": "ubuntu1804-arm64-test", "versions": "4.4", "php-versions": ["7.0","7.1","7.2"]}
   display_name: "All: ${versions}/${php-versions} — ${os-php7}"
   tasks:
      - name: "test-standalone-ssl"
@@ -1136,10 +1140,10 @@ buildvariants:
      - name: "test-replicaset-auth"
 
 
-- matrix_name: "mongo-40-php7"
-  matrix_spec: {"os-php7": "*", "versions": ["4.0", "4.2", "4.4", "latest"], "php-versions": "7.3" }
+- matrix_name: "mongo-php7"
+  matrix_spec: {"os-php7": "*", "versions": ["4.0", "4.2", "4.4", "5.0", "latest"], "php-versions": "7.3" }
   exclude_spec:
-    - {"os-php7": "rhel74-zseries", "versions": ["4.0", "4.2", "4.4", "latest"], "php-versions": "7.3"}
+    - {"os-php7": "rhel74-zseries", "versions": ["4.0", "4.2", "4.4", "5.0", "latest"], "php-versions": "7.3"}
     - {"os-php7": "ubuntu1804-arm64-test", "versions": "4.0", "php-versions": "7.3"}
   display_name: "${versions}/${php-versions} — ${os-php7}"
   tasks:
@@ -1150,8 +1154,8 @@ buildvariants:
      - name: "test-replicaset-auth"
      - name: "test-sharded"
 
-- matrix_name: "mongo-40-php7-nossl"
-  matrix_spec: {"os-php7": "rhel74-zseries", "versions": ["4.2", "4.4", "latest"], "php-versions": "7.3"}
+- matrix_name: "mongo-php7-nossl"
+  matrix_spec: {"os-php7": "rhel74-zseries", "versions": ["4.2", "4.4", "5.0", "latest"], "php-versions": "7.3"}
   display_name: "${versions}/${php-versions} — ${os-php7}"
   tasks:
      - name: "test-standalone"
@@ -1173,7 +1177,7 @@ buildvariants:
      - name: "test-standalone"
 
 - matrix_name: "libmongoc-versions-php7"
-  matrix_spec: {"os-php7": "debian92-test", "versions": "4.2", "php-versions": "7.2", "libmongoc-version": "*"}
+  matrix_spec: {"os-php7": "debian92-test", "versions": "4.4", "php-versions": "7.2", "libmongoc-version": "*"}
   display_name: "${versions}/${php-versions}/${os-php7} — libmongoc ${libmongoc-version}"
   tasks:
      - name: "test-standalone"
@@ -1187,13 +1191,13 @@ buildvariants:
     - name: "test-atlas"
 
 - matrix_name: "test-ocsp"
-  matrix_spec: { "os-php7": "debian92-test", "versions": ["4.4", "latest"], "php-versions": "7.3" }
+  matrix_spec: { "os-php7": "debian92-test", "versions": ["4.4", "5.0", "latest"], "php-versions": "7.3" }
   display_name: "OCSP tests - ${versions}"
   tasks:
     - name: ".ocsp"
 
 - matrix_name: "test-requireApiVersion"
-  matrix_spec: { "os-php7": "debian92-test", "php-versions": "7.3", "versions": "latest" }
+  matrix_spec: { "os-php7": "debian92-test", "versions": ["5.0", "latest"], "php-versions": "7.3" }
   display_name: "Versioned API - ${versions}"
   tasks:
     - name: "test-requireApiVersion"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1029,6 +1029,18 @@ axes:
         variables:
            VERSION: "3.0"
 
+  - id: edge-versions
+    display_name: MongoDB Version
+    values:
+      - id: "latest-stable"
+        display_name: "MongoDB 4.4"
+        variables:
+          VERSION: "4.4"
+      - id: "oldest-supported"
+        display_name: "MongoDB 3.0"
+        variables:
+          VERSION: "3.0"
+
   - id: php-versions
     display_name: PHP Version
     values:
@@ -1108,10 +1120,10 @@ axes:
 buildvariants:
 
 - matrix_name: "tests-php7"
-  matrix_spec: {"os-php7": "*", "versions": "4.4", "php-versions": ["7.0","7.1","7.2","7.3"] }
+  matrix_spec: {"os-php7": "*", "edge-versions": "latest-stable", "php-versions": ["7.0","7.1","7.2","7.3"] }
   exclude_spec:
-    - {"os-php7": "ubuntu1804-arm64-test", "versions": "4.4", "php-versions": ["7.0","7.1","7.2"]}
-  display_name: "All: ${versions}/${php-versions} — ${os-php7}"
+    - {"os-php7": "ubuntu1804-arm64-test", "edge-versions": "latest-stable", "php-versions": ["7.0","7.1","7.2"]}
+  display_name: "All: ${edge-versions}/${php-versions} — ${os-php7}"
   tasks:
      - name: "test-standalone-ssl"
      - name: "test-replicaset-auth"
@@ -1177,8 +1189,8 @@ buildvariants:
      - name: "test-standalone"
 
 - matrix_name: "libmongoc-versions-php7"
-  matrix_spec: {"os-php7": "debian92-test", "versions": "4.4", "php-versions": "7.2", "libmongoc-version": "*"}
-  display_name: "${versions}/${php-versions}/${os-php7} — libmongoc ${libmongoc-version}"
+  matrix_spec: {"os-php7": "debian92-test", "edge-versions": "latest-stable", "php-versions": "7.2", "libmongoc-version": "*"}
+  display_name: "${edge-versions}/${php-versions}/${os-php7} — libmongoc ${libmongoc-version}"
   tasks:
      - name: "test-standalone"
      - name: "test-replicaset"

--- a/tests/manager/manager-executeBulkWrite_error-004.phpt
+++ b/tests/manager/manager-executeBulkWrite_error-004.phpt
@@ -15,7 +15,7 @@ $bulk->insert(array('_id' => 1, 'x' => 1));
 $manager->executeBulkWrite(NS, $bulk);
 
 $bulk = new MongoDB\Driver\BulkWrite();
-$bulk->delete(['$foo' => 1], ['limit' => 1]);
+$bulk->delete(['field' => ['$unsupportedOperator' => true]], ['limit' => 1]);
 
 try {
     $manager->executeBulkWrite(NS, $bulk);
@@ -34,7 +34,7 @@ var_dump(iterator_to_array($cursor));
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-BulkWriteException: unknown top level operator: $foo
+BulkWriteException: unknown operator: $unsupportedOperator
 
 ===> WriteResult
 server: %s:%d
@@ -45,7 +45,7 @@ upsertedCount: 0
 deletedCount: 0
 object(MongoDB\Driver\WriteError)#%d (%d) {
   ["message"]=>
-  string(32) "unknown top level operator: $foo"
+  string(38) "unknown operator: $unsupportedOperator"
   ["code"]=>
   int(2)
   ["index"]=>
@@ -53,7 +53,7 @@ object(MongoDB\Driver\WriteError)#%d (%d) {
   ["info"]=>
   NULL
 }
-writeError[0].message: unknown top level operator: $foo
+writeError[0].message: unknown operator: $unsupportedOperator
 writeError[0].code: 2
 
 ===> Collection

--- a/tests/manager/manager-executeQuery_error-003.phpt
+++ b/tests/manager/manager-executeQuery_error-003.phpt
@@ -9,7 +9,7 @@ MongoDB\Driver\Manager::executeQuery() exposes error document via CommandExcepti
 require_once __DIR__ . "/../utils/basic.inc";
 
 $manager = create_test_manager();
-$query = new MongoDB\Driver\Query(['$foo' => 1]);
+$query = new MongoDB\Driver\Query(['field' => ['$unsupportedOperator' => true]]);
 
 try {
     $manager->executeQuery(NS, $query);
@@ -24,7 +24,7 @@ try {
 ===DONE===
 <?php exit(0); ?>
 --EXPECT--
-MongoDB\Driver\Exception\CommandException(2): unknown top level operator: $foo
+MongoDB\Driver\Exception\CommandException(2): unknown operator: $unsupportedOperator
 bool(true)
 bool(true)
 ===DONE===


### PR DESCRIPTION
PHPC-1848

This also updates the config file to use a `latest-stable` alias to avoid having to update multiple build variants when it changes.