### PR TITLE
Bump PHP versions tested by AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,20 +15,24 @@ environment:
   CONFIGURE_OPTS: --enable-mongodb --with-mongodb-sasl=yes --with-mongodb-client-side-encryption=yes
 
   matrix:
-    - PHP_VER: 8.0.0rc2
+    - PHP_VER: 8.0.7
       TS: 1
       CRT: vs16
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-    - PHP_VER: 7.4.4
+    - PHP_VER: 8.0.7
+      TS: 0
+      CRT: vs16
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+    - PHP_VER: 7.4.20
       TS: 1
       CRT: vc15
-    - PHP_VER: 7.4.4
+    - PHP_VER: 7.4.20
       TS: 0
       CRT: vc15
-    - PHP_VER: 7.3.16
+    - PHP_VER: 7.3.28
       TS: 1
       CRT: vc15
-    - PHP_VER: 7.3.16
+    - PHP_VER: 7.3.28
       TS: 0
       CRT: vc15
     - PHP_VER: 7.2.29


### PR DESCRIPTION
Note: I expect these to fail for reasons explained in https://github.com/mongodb/mongo-php-driver/pull/1229#issuecomment-866419799.