### PR TITLE
PHPC-1870: Include config.h after php.h to avoid redef of WORDS_BIGENDIAN

### DIFF
--- a/src/phongo_apm.c
+++ b/src/phongo_apm.c
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #include "bson/bson.h"
 #include "mongoc/mongoc.h"
 
@@ -25,6 +21,10 @@
 #include <Zend/zend_exceptions.h>
 #include <Zend/zend_interfaces.h>
 #include <Zend/zend_operators.h>
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
 
 #include "phongo_compat.h"
 #include "php_phongo.h"


### PR DESCRIPTION
This should fix zSeries build failures introduced by 324182a8e6c840297dad02a9bb6a37919f0d2b53 (#1213)

Patch build with zSeries hosts: https://spruce.mongodb.com/version/60d641ced1fe074ffa5b2877/tasks