### PR TITLE
PHPC-1474 and PHPC-1879: Expose transaction information in debug info for session and fix Session::getTransactionOptions() leak

### DIFF
--- a/tests/session/session-debug-001.phpt
+++ b/tests/session/session-debug-001.phpt
@@ -37,5 +37,11 @@ object(MongoDB\Driver\Session)#%d (%d) {
   NULL
   ["server"]=>
   NULL
+  ["inTransaction"]=>
+  bool(false)
+  ["transactionState"]=>
+  string(4) "none"
+  ["transactionOptions"]=>
+  NULL
 }
 ===DONE===

--- a/tests/session/session-debug-002.phpt
+++ b/tests/session/session-debug-002.phpt
@@ -55,5 +55,11 @@ object(MongoDB\Driver\Session)#%d (%d) {
   }
   ["server"]=>
   NULL
+  ["inTransaction"]=>
+  bool(false)
+  ["transactionState"]=>
+  string(4) "none"
+  ["transactionOptions"]=>
+  NULL
 }
 ===DONE===

--- a/tests/session/session-debug-003.phpt
+++ b/tests/session/session-debug-003.phpt
@@ -37,5 +37,11 @@ object(MongoDB\Driver\Session)#%d (%d) {
   NULL
   ["server"]=>
   NULL
+  ["inTransaction"]=>
+  bool(false)
+  ["transactionState"]=>
+  string(4) "none"
+  ["transactionOptions"]=>
+  NULL
 }
 ===DONE===

--- a/tests/session/session-debug-004.phpt
+++ b/tests/session/session-debug-004.phpt
@@ -34,5 +34,11 @@ object(MongoDB\Driver\Session)#%d (%d) {
   NULL
   ["server"]=>
   NULL
+  ["inTransaction"]=>
+  NULL
+  ["transactionState"]=>
+  NULL
+  ["transactionOptions"]=>
+  NULL
 }
 ===DONE===

--- a/tests/session/session-debug-005.phpt
+++ b/tests/session/session-debug-005.phpt
@@ -2,6 +2,7 @@
 MongoDB\Driver\Session debug output (during a pinned transaction)
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_not_libmongoc_crypto(); ?>
 <?php skip_if_not_mongos_with_replica_set(); ?>
 <?php skip_if_server_version('<', '4.1.6'); ?>
 <?php skip_if_not_clean(); ?>
@@ -62,6 +63,18 @@ object(MongoDB\Driver\Session)#%d (%d) {
   ["server"]=>
   object(MongoDB\Driver\Server)#%d (%d) {
     %a
+  }
+  ["inTransaction"]=>
+  bool(true)
+  ["transactionState"]=>
+  string(11) "in_progress"
+  ["transactionOptions"]=>
+  array(1) {
+    ["readPreference"]=>
+    object(MongoDB\Driver\ReadPreference)#%d (%d) {
+      ["mode"]=>
+      string(7) "primary"
+    }
   }
 }
 ===DONE===

--- a/tests/session/session-debug-006.phpt
+++ b/tests/session/session-debug-006.phpt
@@ -1,0 +1,73 @@
+--TEST--
+MongoDB\Driver\Session debug output (with transaction options)
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_not_libmongoc_crypto(); ?>
+<?php skip_if_no_transactions(); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = create_test_manager();
+$session = $manager->startSession();
+
+$options = [
+    'maxCommitTimeMS' => 1,
+    'readConcern' => new \MongoDB\Driver\ReadConcern('majority'),
+    'readPreference' => new \MongoDB\Driver\ReadPreference('primaryPreferred'),
+    'writeConcern' => new \MongoDB\Driver\WriteConcern('majority'),
+];
+
+$session->startTransaction($options);
+
+var_dump($session);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+object(MongoDB\Driver\Session)#%d (%d) {
+  ["logicalSessionId"]=>
+  array(1) {
+    ["id"]=>
+    object(MongoDB\BSON\Binary)#%d (%d) {
+      ["data"]=>
+      string(16) "%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c"
+      ["type"]=>
+      int(4)
+    }
+  }
+  ["clusterTime"]=>
+  NULL
+  ["causalConsistency"]=>
+  bool(true)
+  ["operationTime"]=>
+  NULL
+  ["server"]=>
+  NULL
+  ["inTransaction"]=>
+  bool(true)
+  ["transactionState"]=>
+  string(8) "starting"
+  ["transactionOptions"]=>
+  array(4) {
+    ["maxCommitTimeMS"]=>
+    int(1)
+    ["readConcern"]=>
+    object(MongoDB\Driver\ReadConcern)#%d (%d) {
+      ["level"]=>
+      string(8) "majority"
+    }
+    ["readPreference"]=>
+    object(MongoDB\Driver\ReadPreference)#%d (%d) {
+      ["mode"]=>
+      string(16) "primaryPreferred"
+    }
+    ["writeConcern"]=>
+    object(MongoDB\Driver\WriteConcern)#%d (%d) {
+      ["w"]=>
+      string(8) "majority"
+    }
+  }
+}
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1474
https://jira.mongodb.org/browse/PHPC-1879