### PR TITLE
PHPC-1685 Drop support for PHP 7.0

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1060,10 +1060,6 @@ axes:
         display_name: "PHP 7.1"
         variables:
           PHP_VERSION: "7.1"
-      - id: "7.0"
-        display_name: "PHP 7.0"
-        variables:
-          PHP_VERSION: "7.0"
 
   - id: os-php7
     display_name: OS
@@ -1120,9 +1116,9 @@ axes:
 buildvariants:
 
 - matrix_name: "tests-php7"
-  matrix_spec: {"os-php7": "*", "edge-versions": "latest-stable", "php-versions": ["7.0","7.1","7.2","7.3"] }
+  matrix_spec: {"os-php7": "*", "edge-versions": "latest-stable", "php-versions": ["7.1","7.2","7.3"] }
   exclude_spec:
-    - {"os-php7": "ubuntu1804-arm64-test", "edge-versions": "latest-stable", "php-versions": ["7.0","7.1","7.2"]}
+    - {"os-php7": "ubuntu1804-arm64-test", "edge-versions": "latest-stable", "php-versions": ["7.1","7.2"]}
   display_name: "All: ${edge-versions}/${php-versions} — ${os-php7}"
   tasks:
      - name: "test-standalone-ssl"

--- a/bin/package.xml.in
+++ b/bin/package.xml.in
@@ -58,7 +58,7 @@ necessary to build a fully-functional MongoDB driver.
  <dependencies>
   <required>
    <php>
-    <min>7.0.0</min>
+    <min>7.1.0</min>
     <max>8.99.99</max>
    </php>
    <pearinstaller>

--- a/config.m4
+++ b/config.m4
@@ -20,8 +20,8 @@ if test "$PHP_MONGODB" != "no"; then
   fi
 
   AC_MSG_RESULT($PHP_MONGODB_PHP_VERSION)
-  if test "$PHP_MONGODB_PHP_VERSION_ID" -lt "70000"; then
-    AC_MSG_ERROR([not supported. Need a PHP version >= 7.0.0 (found $PHP_MONGODB_PHP_VERSION)])
+  if test "$PHP_MONGODB_PHP_VERSION_ID" -lt "70100"; then
+    AC_MSG_ERROR([not supported. Need a PHP version >= 7.1.0 (found $PHP_MONGODB_PHP_VERSION)])
   fi
 
   PHP_ARG_ENABLE([mongodb-developer-flags],


### PR DESCRIPTION
PHPC-1685

While we're only removing the (now deprecated) `SetUpTearDownTrait` at this time, more significant changes will happen once we drop PHP 7.1, as this allows us to start introducing argument types.