### PR TITLE
Fix message for catching wrong exception in raises()

### DIFF
--- a/tests/utils/tools.php
+++ b/tests/utils/tools.php
@@ -607,7 +607,7 @@ function raises($function, $type, $infunction = null) {
             }
             printf("OK: Got %s\n", severityToString($e->getSeverity()));
         } else {
-            printf("ALMOST: Got %s - expected %s\n", get_class($e), $exceptionname);
+            printf("ALMOST: Got %s - expected %s\n", get_class($e), ErrorException::class);
         }
         restore_error_handler();
         return $e->getMessage();


### PR DESCRIPTION
The original implementation of raises() in c6a793d466ef1dda46ce33bbd5e2d77e914249bb apparently referenced an undeclared $exceptionname variable several times. That was later addressed 804f383aea602c2bf3698169d893fc3cd2f10782 but that commit neglected to fix this reference.

This change avoids a possible message where the actual exception is printed twice:

```
ALMOST: Got Exception - expected Exception
```

Given the [error handler](https://www.php.net/set_error_handler) implementation here, we should always except an [ErrorException](https://www.php.net/manual/en/class.errorexception.php).