### PR TITLE
PHPC-1875: Skip snapshot error test on sharded clusters

### DIFF
--- a/tests/session/session-004.phpt
+++ b/tests/session/session-004.phpt
@@ -7,6 +7,7 @@ PHPC-1875: Disable writes on snapshot sessions
 <?php skip_if_not_libmongoc_crypto(); ?>
 <?php skip_if_not_live(); ?>
 <?php skip_if_server_version('<', '5.0'); ?>
+<?php skip_if_not_replica_set(); /* TODO: SERVER-58176 */ ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1875

skip_if_not_replica_set will be more portable once we start testing on load balancers, which will back sharded clusters.