### PR TITLE
PHPC-2004 and PHPC-2007: Specify __toString() return type and implement Stringable

### DIFF
--- a/src/BSON/Binary.c
+++ b/src/BSON/Binary.c
@@ -460,6 +460,10 @@ void php_phongo_binary_init_ce(INIT_FUNC_ARGS) /* {{{ */
 	zend_class_implements(php_phongo_binary_ce, 1, php_phongo_type_ce);
 	zend_class_implements(php_phongo_binary_ce, 1, zend_ce_serializable);
 
+#if PHP_VERSION_ID >= 80000
+	zend_class_implements(php_phongo_binary_ce, 1, zend_ce_stringable);
+#endif
+
 	memcpy(&php_phongo_handler_binary, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 	PHONGO_COMPAT_SET_COMPARE_OBJECTS_HANDLER(binary);
 	php_phongo_handler_binary.clone_obj      = php_phongo_binary_clone_object;

--- a/src/BSON/Binary.c
+++ b/src/BSON/Binary.c
@@ -329,6 +329,9 @@ ZEND_BEGIN_ARG_INFO_EX(ai_Binary___set_state, 0, 0, 1)
 	ZEND_ARG_ARRAY_INFO(0, properties, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(ai_Binary___toString, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(ai_Binary___unserialize, 0, 0, 1)
 	ZEND_ARG_ARRAY_INFO(0, data, 0)
 ZEND_END_ARG_INFO()
@@ -347,7 +350,7 @@ static zend_function_entry php_phongo_binary_me[] = {
 	PHP_ME(Binary, __construct, ai_Binary___construct, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(Binary, __serialize, ai_Binary_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(Binary, __set_state, ai_Binary___set_state, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
-	PHP_ME(Binary, __toString, ai_Binary_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
+	PHP_ME(Binary, __toString, ai_Binary___toString, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(Binary, __unserialize, ai_Binary___unserialize, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(Binary, jsonSerialize, ai_Binary_jsonSerialize, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(Binary, serialize, ai_Binary_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)

--- a/src/BSON/BinaryInterface.c
+++ b/src/BSON/BinaryInterface.c
@@ -26,17 +26,20 @@
 zend_class_entry* php_phongo_binary_interface_ce;
 
 /* {{{ MongoDB\BSON\BinaryInterface function entries */
+/* clang-format off */
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(ai_BinaryInterface___toString, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(ai_BinaryInterface_void, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
 static zend_function_entry php_phongo_binary_interface_me[] = {
-	/* clang-format off */
 	ZEND_ABSTRACT_ME(BinaryInterface, getData, ai_BinaryInterface_void)
 	ZEND_ABSTRACT_ME(BinaryInterface, getType, ai_BinaryInterface_void)
-	ZEND_ABSTRACT_ME(BinaryInterface, __toString, ai_BinaryInterface_void)
+	ZEND_ABSTRACT_ME(BinaryInterface, __toString, ai_BinaryInterface___toString)
 	PHP_FE_END
-	/* clang-format on */
 };
+/* clang-format on */
 /* }}} */
 
 void php_phongo_binary_interface_init_ce(INIT_FUNC_ARGS) /* {{{ */

--- a/src/BSON/DBPointer.c
+++ b/src/BSON/DBPointer.c
@@ -360,6 +360,10 @@ void php_phongo_dbpointer_init_ce(INIT_FUNC_ARGS) /* {{{ */
 	zend_class_implements(php_phongo_dbpointer_ce, 1, php_phongo_type_ce);
 	zend_class_implements(php_phongo_dbpointer_ce, 1, zend_ce_serializable);
 
+#if PHP_VERSION_ID >= 80000
+	zend_class_implements(php_phongo_dbpointer_ce, 1, zend_ce_stringable);
+#endif
+
 	memcpy(&php_phongo_handler_dbpointer, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 	PHONGO_COMPAT_SET_COMPARE_OBJECTS_HANDLER(dbpointer);
 	php_phongo_handler_dbpointer.clone_obj      = php_phongo_dbpointer_clone_object;

--- a/src/BSON/DBPointer.c
+++ b/src/BSON/DBPointer.c
@@ -236,6 +236,9 @@ static PHP_METHOD(DBPointer, __unserialize)
 
 /* {{{ MongoDB\BSON\DBPointer function entries */
 /* clang-format off */
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(ai_DBPointer___toString, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(ai_DBPointer___unserialize, 0, 0, 1)
 	ZEND_ARG_ARRAY_INFO(0, data, 0)
 ZEND_END_ARG_INFO()
@@ -253,7 +256,7 @@ ZEND_END_ARG_INFO()
 static zend_function_entry php_phongo_dbpointer_me[] = {
 	/* __set_state intentionally missing */
 	PHP_ME(DBPointer, __serialize, ai_DBPointer_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
-	PHP_ME(DBPointer, __toString, ai_DBPointer_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
+	PHP_ME(DBPointer, __toString, ai_DBPointer___toString, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(DBPointer, __unserialize, ai_DBPointer___unserialize, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(DBPointer, jsonSerialize, ai_DBPointer_jsonSerialize, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(DBPointer, serialize, ai_DBPointer_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)

--- a/src/BSON/Decimal128.c
+++ b/src/BSON/Decimal128.c
@@ -377,6 +377,10 @@ void php_phongo_decimal128_init_ce(INIT_FUNC_ARGS) /* {{{ */
 	zend_class_implements(php_phongo_decimal128_ce, 1, php_phongo_type_ce);
 	zend_class_implements(php_phongo_decimal128_ce, 1, zend_ce_serializable);
 
+#if PHP_VERSION_ID >= 80000
+	zend_class_implements(php_phongo_decimal128_ce, 1, zend_ce_stringable);
+#endif
+
 	memcpy(&php_phongo_handler_decimal128, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 	php_phongo_handler_decimal128.clone_obj      = php_phongo_decimal128_clone_object;
 	php_phongo_handler_decimal128.get_debug_info = php_phongo_decimal128_get_debug_info;

--- a/src/BSON/Decimal128.c
+++ b/src/BSON/Decimal128.c
@@ -272,6 +272,9 @@ ZEND_BEGIN_ARG_INFO_EX(ai_Decimal128___set_state, 0, 0, 1)
 	ZEND_ARG_ARRAY_INFO(0, properties, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(ai_Decimal128___toString, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(ai_Decimal128___unserialize, 0, 0, 1)
 	ZEND_ARG_ARRAY_INFO(0, data, 0)
 ZEND_END_ARG_INFO()
@@ -290,7 +293,7 @@ static zend_function_entry php_phongo_decimal128_me[] = {
 	PHP_ME(Decimal128, __construct, ai_Decimal128___construct, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(Decimal128, __serialize, ai_Decimal128_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(Decimal128, __set_state, ai_Decimal128___set_state, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
-	PHP_ME(Decimal128, __toString, ai_Decimal128_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
+	PHP_ME(Decimal128, __toString, ai_Decimal128___toString, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(Decimal128, __unserialize, ai_Decimal128___unserialize, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(Decimal128, jsonSerialize, ai_Decimal128_jsonSerialize, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(Decimal128, serialize, ai_Decimal128_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)

--- a/src/BSON/Decimal128Interface.c
+++ b/src/BSON/Decimal128Interface.c
@@ -26,15 +26,15 @@
 zend_class_entry* php_phongo_decimal128_interface_ce;
 
 /* {{{ MongoDB\BSON\Decimal128Interface function entries */
-ZEND_BEGIN_ARG_INFO_EX(ai_Decimal128Interface_void, 0, 0, 0)
+/* clang-format off */
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(ai_Decimal128Interface___toString, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 static zend_function_entry php_phongo_decimal128_interface_me[] = {
-	/* clang-format off */
-	ZEND_ABSTRACT_ME(Decimal128Interface, __toString, ai_Decimal128Interface_void)
+	ZEND_ABSTRACT_ME(Decimal128Interface, __toString, ai_Decimal128Interface___toString)
 	PHP_FE_END
-	/* clang-format on */
 };
+/* clang-format on */
 /* }}} */
 
 void php_phongo_decimal128_interface_init_ce(INIT_FUNC_ARGS) /* {{{ */

--- a/src/BSON/Int64.c
+++ b/src/BSON/Int64.c
@@ -220,6 +220,9 @@ static PHP_METHOD(Int64, __unserialize)
 
 /* {{{ MongoDB\BSON\Int64 function entries */
 /* clang-format off */
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(ai_Int64___toString, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(ai_Int64___unserialize, 0, 0, 1)
 	ZEND_ARG_ARRAY_INFO(0, data, 0)
 ZEND_END_ARG_INFO()
@@ -237,7 +240,7 @@ ZEND_END_ARG_INFO()
 static zend_function_entry php_phongo_int64_me[] = {
 	/* __set_state intentionally missing */
 	PHP_ME(Int64, __serialize, ai_Int64_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
-	PHP_ME(Int64, __toString, ai_Int64_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
+	PHP_ME(Int64, __toString, ai_Int64___toString, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(Int64, __unserialize, ai_Int64___unserialize, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(Int64, jsonSerialize, ai_Int64_jsonSerialize, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(Int64, serialize, ai_Int64_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)

--- a/src/BSON/Int64.c
+++ b/src/BSON/Int64.c
@@ -337,6 +337,10 @@ void php_phongo_int64_init_ce(INIT_FUNC_ARGS) /* {{{ */
 	zend_class_implements(php_phongo_int64_ce, 1, php_phongo_type_ce);
 	zend_class_implements(php_phongo_int64_ce, 1, zend_ce_serializable);
 
+#if PHP_VERSION_ID >= 80000
+	zend_class_implements(php_phongo_int64_ce, 1, zend_ce_stringable);
+#endif
+
 	memcpy(&php_phongo_handler_int64, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 	PHONGO_COMPAT_SET_COMPARE_OBJECTS_HANDLER(int64);
 	php_phongo_handler_int64.clone_obj      = php_phongo_int64_clone_object;

--- a/src/BSON/Javascript.c
+++ b/src/BSON/Javascript.c
@@ -383,6 +383,9 @@ ZEND_BEGIN_ARG_INFO_EX(ai_Javascript___set_state, 0, 0, 1)
 	ZEND_ARG_ARRAY_INFO(0, properties, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(ai_Javascript___toString, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(ai_Javascript___unserialize, 0, 0, 1)
 	ZEND_ARG_ARRAY_INFO(0, data, 0)
 ZEND_END_ARG_INFO()
@@ -401,7 +404,7 @@ static zend_function_entry php_phongo_javascript_me[] = {
 	PHP_ME(Javascript, __construct, ai_Javascript___construct, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(Javascript, __serialize, ai_Javascript_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(Javascript, __set_state, ai_Javascript___set_state, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
-	PHP_ME(Javascript, __toString, ai_Javascript_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
+	PHP_ME(Javascript, __toString, ai_Javascript___toString, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(Javascript, __unserialize, ai_Javascript___unserialize, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(Javascript, jsonSerialize, ai_Javascript_jsonSerialize, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(Javascript, serialize, ai_Javascript_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)

--- a/src/BSON/Javascript.c
+++ b/src/BSON/Javascript.c
@@ -509,6 +509,10 @@ void php_phongo_javascript_init_ce(INIT_FUNC_ARGS) /* {{{ */
 	zend_class_implements(php_phongo_javascript_ce, 1, php_phongo_type_ce);
 	zend_class_implements(php_phongo_javascript_ce, 1, zend_ce_serializable);
 
+#if PHP_VERSION_ID >= 80000
+	zend_class_implements(php_phongo_javascript_ce, 1, zend_ce_stringable);
+#endif
+
 	memcpy(&php_phongo_handler_javascript, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 	PHONGO_COMPAT_SET_COMPARE_OBJECTS_HANDLER(javascript);
 	php_phongo_handler_javascript.clone_obj      = php_phongo_javascript_clone_object;

--- a/src/BSON/JavascriptInterface.c
+++ b/src/BSON/JavascriptInterface.c
@@ -26,17 +26,20 @@
 zend_class_entry* php_phongo_javascript_interface_ce;
 
 /* {{{ MongoDB\BSON\JavascriptInterface function entries */
+/* clang-format off */
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(ai_JavascriptInterface___toString, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(ai_JavascriptInterface_void, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
 static zend_function_entry php_phongo_javascript_interface_me[] = {
-	/* clang-format off */
 	ZEND_ABSTRACT_ME(JavascriptInterface, getCode, ai_JavascriptInterface_void)
 	ZEND_ABSTRACT_ME(JavascriptInterface, getScope, ai_JavascriptInterface_void)
-	ZEND_ABSTRACT_ME(JavascriptInterface, __toString, ai_JavascriptInterface_void)
+	ZEND_ABSTRACT_ME(JavascriptInterface, __toString, ai_JavascriptInterface___toString)
 	PHP_FE_END
-	/* clang-format on */
 };
+/* clang-format on */
 /* }}} */
 
 void php_phongo_javascript_interface_init_ce(INIT_FUNC_ARGS) /* {{{ */

--- a/src/BSON/ObjectId.c
+++ b/src/BSON/ObjectId.c
@@ -430,6 +430,10 @@ void php_phongo_objectid_init_ce(INIT_FUNC_ARGS) /* {{{ */
 	zend_class_implements(php_phongo_objectid_ce, 1, php_phongo_type_ce);
 	zend_class_implements(php_phongo_objectid_ce, 1, zend_ce_serializable);
 
+#if PHP_VERSION_ID >= 80000
+	zend_class_implements(php_phongo_objectid_ce, 1, zend_ce_stringable);
+#endif
+
 	memcpy(&php_phongo_handler_objectid, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 	PHONGO_COMPAT_SET_COMPARE_OBJECTS_HANDLER(objectid);
 	php_phongo_handler_objectid.clone_obj      = php_phongo_objectid_clone_object;

--- a/src/BSON/ObjectId.c
+++ b/src/BSON/ObjectId.c
@@ -311,6 +311,9 @@ ZEND_BEGIN_ARG_INFO_EX(ai_ObjectId___set_state, 0, 0, 1)
 	ZEND_ARG_ARRAY_INFO(0, properties, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(ai_ObjectId___toString, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(ai_ObjectId___unserialize, 0, 0, 1)
 	ZEND_ARG_ARRAY_INFO(0, data, 0)
 ZEND_END_ARG_INFO()
@@ -330,7 +333,7 @@ static zend_function_entry php_phongo_objectid_me[] = {
 	PHP_ME(ObjectId, getTimestamp, ai_ObjectId_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(ObjectId, __serialize, ai_ObjectId_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(ObjectId, __set_state, ai_ObjectId___set_state, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
-	PHP_ME(ObjectId, __toString, ai_ObjectId_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
+	PHP_ME(ObjectId, __toString, ai_ObjectId___toString, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(ObjectId, __unserialize, ai_ObjectId___unserialize, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(ObjectId, jsonSerialize, ai_ObjectId_jsonSerialize, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(ObjectId, serialize, ai_ObjectId_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)

--- a/src/BSON/ObjectIdInterface.c
+++ b/src/BSON/ObjectIdInterface.c
@@ -26,16 +26,19 @@
 zend_class_entry* php_phongo_objectid_interface_ce;
 
 /* {{{ MongoDB\BSON\ObjectIdInterface function entries */
+/* clang-format off */
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(ai_ObjectIdInterface___toString, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(ai_ObjectIdInterface_void, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
 static zend_function_entry php_phongo_objectid_interface_me[] = {
-	/* clang-format off */
 	ZEND_ABSTRACT_ME(ObjectIdInterface, getTimestamp, ai_ObjectIdInterface_void)
-	ZEND_ABSTRACT_ME(ObjectIdInterface, __toString, ai_ObjectIdInterface_void)
+	ZEND_ABSTRACT_ME(ObjectIdInterface, __toString, ai_ObjectIdInterface___toString)
 	PHP_FE_END
-	/* clang-format on */
 };
+/* clang-format on */
 /* }}} */
 
 void php_phongo_objectid_interface_init_ce(INIT_FUNC_ARGS) /* {{{ */

--- a/src/BSON/Regex.c
+++ b/src/BSON/Regex.c
@@ -338,6 +338,9 @@ ZEND_BEGIN_ARG_INFO_EX(ai_Regex___set_state, 0, 0, 1)
 	ZEND_ARG_ARRAY_INFO(0, properties, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(ai_Regex___toString, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(ai_Regex___unserialize, 0, 0, 1)
 	ZEND_ARG_ARRAY_INFO(0, data, 0)
 ZEND_END_ARG_INFO()
@@ -356,7 +359,7 @@ static zend_function_entry php_phongo_regex_me[] = {
 	PHP_ME(Regex, __construct, ai_Regex___construct, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(Regex, __serialize, ai_Regex_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(Regex, __set_state, ai_Regex___set_state, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
-	PHP_ME(Regex, __toString, ai_Regex_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
+	PHP_ME(Regex, __toString, ai_Regex___toString, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(Regex, __unserialize, ai_Regex___unserialize, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(Regex, jsonSerialize, ai_Regex_jsonSerialize, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(Regex, serialize, ai_Regex_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)

--- a/src/BSON/Regex.c
+++ b/src/BSON/Regex.c
@@ -471,6 +471,10 @@ void php_phongo_regex_init_ce(INIT_FUNC_ARGS) /* {{{ */
 	zend_class_implements(php_phongo_regex_ce, 1, zend_ce_serializable);
 	zend_class_implements(php_phongo_regex_ce, 1, php_phongo_json_serializable_ce);
 
+#if PHP_VERSION_ID >= 80000
+	zend_class_implements(php_phongo_regex_ce, 1, zend_ce_stringable);
+#endif
+
 	memcpy(&php_phongo_handler_regex, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 	PHONGO_COMPAT_SET_COMPARE_OBJECTS_HANDLER(regex);
 	php_phongo_handler_regex.clone_obj      = php_phongo_regex_clone_object;

--- a/src/BSON/RegexInterface.c
+++ b/src/BSON/RegexInterface.c
@@ -26,17 +26,20 @@
 zend_class_entry* php_phongo_regex_interface_ce;
 
 /* {{{ MongoDB\BSON\RegexInterface function entries */
+/* clang-format off */
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(ai_RegexInterface___toString, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(ai_RegexInterface_void, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
 static zend_function_entry php_phongo_regex_interface_me[] = {
-	/* clang-format off */
 	ZEND_ABSTRACT_ME(RegexInterface, getFlags, ai_RegexInterface_void)
 	ZEND_ABSTRACT_ME(RegexInterface, getPattern, ai_RegexInterface_void)
-	ZEND_ABSTRACT_ME(RegexInterface, __toString, ai_RegexInterface_void)
+	ZEND_ABSTRACT_ME(RegexInterface, __toString, ai_RegexInterface___toString)
 	PHP_FE_END
-	/* clang-format on */
 };
+/* clang-format on */
 /* }}} */
 
 void php_phongo_regex_interface_init_ce(INIT_FUNC_ARGS) /* {{{ */

--- a/src/BSON/Symbol.c
+++ b/src/BSON/Symbol.c
@@ -328,6 +328,10 @@ void php_phongo_symbol_init_ce(INIT_FUNC_ARGS) /* {{{ */
 	zend_class_implements(php_phongo_symbol_ce, 1, php_phongo_type_ce);
 	zend_class_implements(php_phongo_symbol_ce, 1, zend_ce_serializable);
 
+#if PHP_VERSION_ID >= 80000
+	zend_class_implements(php_phongo_symbol_ce, 1, zend_ce_stringable);
+#endif
+
 	memcpy(&php_phongo_handler_symbol, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 	PHONGO_COMPAT_SET_COMPARE_OBJECTS_HANDLER(symbol);
 	php_phongo_handler_symbol.clone_obj      = php_phongo_symbol_clone_object;

--- a/src/BSON/Symbol.c
+++ b/src/BSON/Symbol.c
@@ -211,6 +211,9 @@ static PHP_METHOD(Symbol, __unserialize)
 
 /* {{{ MongoDB\BSON\Symbol function entries */
 /* clang-format off */
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(ai_Symbol___toString, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(ai_Symbol___unserialize, 0, 0, 1)
 	ZEND_ARG_ARRAY_INFO(0, data, 0)
 ZEND_END_ARG_INFO()
@@ -228,7 +231,7 @@ ZEND_END_ARG_INFO()
 static zend_function_entry php_phongo_symbol_me[] = {
 	/* __set_state intentionally missing */
 	PHP_ME(Symbol, __serialize, ai_Symbol_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
-	PHP_ME(Symbol, __toString, ai_Symbol_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
+	PHP_ME(Symbol, __toString, ai_Symbol___toString, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(Symbol, __unserialize, ai_Symbol___unserialize, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(Symbol, jsonSerialize, ai_Symbol_jsonSerialize, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(Symbol, serialize, ai_Symbol_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)

--- a/src/BSON/Timestamp.c
+++ b/src/BSON/Timestamp.c
@@ -513,6 +513,10 @@ void php_phongo_timestamp_init_ce(INIT_FUNC_ARGS) /* {{{ */
 	zend_class_implements(php_phongo_timestamp_ce, 1, php_phongo_type_ce);
 	zend_class_implements(php_phongo_timestamp_ce, 1, zend_ce_serializable);
 
+#if PHP_VERSION_ID >= 80000
+	zend_class_implements(php_phongo_timestamp_ce, 1, zend_ce_stringable);
+#endif
+
 	memcpy(&php_phongo_handler_timestamp, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 	PHONGO_COMPAT_SET_COMPARE_OBJECTS_HANDLER(timestamp);
 	php_phongo_handler_timestamp.clone_obj      = php_phongo_timestamp_clone_object;

--- a/src/BSON/Timestamp.c
+++ b/src/BSON/Timestamp.c
@@ -387,6 +387,9 @@ ZEND_BEGIN_ARG_INFO_EX(ai_Timestamp___set_state, 0, 0, 1)
 	ZEND_ARG_ARRAY_INFO(0, properties, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(ai_Timestamp___toString, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(ai_Timestamp___unserialize, 0, 0, 1)
 	ZEND_ARG_ARRAY_INFO(0, data, 0)
 ZEND_END_ARG_INFO()
@@ -405,7 +408,7 @@ static zend_function_entry php_phongo_timestamp_me[] = {
 	PHP_ME(Timestamp, __construct, ai_Timestamp___construct, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(Timestamp, __serialize, ai_Timestamp_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(Timestamp, __set_state, ai_Timestamp___set_state, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
-	PHP_ME(Timestamp, __toString, ai_Timestamp_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
+	PHP_ME(Timestamp, __toString, ai_Timestamp___toString, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(Timestamp, __unserialize, ai_Timestamp___unserialize, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(Timestamp, jsonSerialize, ai_Timestamp_jsonSerialize, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(Timestamp, serialize, ai_Timestamp_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)

--- a/src/BSON/TimestampInterface.c
+++ b/src/BSON/TimestampInterface.c
@@ -26,17 +26,20 @@
 zend_class_entry* php_phongo_timestamp_interface_ce;
 
 /* {{{ MongoDB\BSON\TimestampInterface function entries */
+/* clang-format off */
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(ai_TimestampInterface___toString, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(ai_TimestampInterface_void, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
 static zend_function_entry php_phongo_timestamp_interface_me[] = {
-	/* clang-format off */
 	ZEND_ABSTRACT_ME(TimestampInterface, getIncrement, ai_TimestampInterface_void)
 	ZEND_ABSTRACT_ME(TimestampInterface, getTimestamp, ai_TimestampInterface_void)
-	ZEND_ABSTRACT_ME(TimestampInterface, __toString, ai_TimestampInterface_void)
+	ZEND_ABSTRACT_ME(TimestampInterface, __toString, ai_TimestampInterface___toString)
 	PHP_FE_END
-	/* clang-format on */
 };
+/* clang-format on */
 /* }}} */
 
 void php_phongo_timestamp_interface_init_ce(INIT_FUNC_ARGS) /* {{{ */

--- a/src/BSON/UTCDateTime.c
+++ b/src/BSON/UTCDateTime.c
@@ -388,6 +388,9 @@ ZEND_BEGIN_ARG_INFO_EX(ai_UTCDateTime___set_state, 0, 0, 1)
 	ZEND_ARG_ARRAY_INFO(0, properties, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(ai_UTCDateTime___toString, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(ai_UTCDateTime___unserialize, 0, 0, 1)
 	ZEND_ARG_ARRAY_INFO(0, data, 0)
 ZEND_END_ARG_INFO()
@@ -406,7 +409,7 @@ static zend_function_entry php_phongo_utcdatetime_me[] = {
 	PHP_ME(UTCDateTime, __construct, ai_UTCDateTime___construct, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(UTCDateTime, __serialize, ai_UTCDateTime_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(UTCDateTime, __set_state, ai_UTCDateTime___set_state, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
-	PHP_ME(UTCDateTime, __toString, ai_UTCDateTime_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
+	PHP_ME(UTCDateTime, __toString, ai_UTCDateTime___toString, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(UTCDateTime, __unserialize, ai_UTCDateTime___unserialize, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(UTCDateTime, jsonSerialize, ai_UTCDateTime_jsonSerialize, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(UTCDateTime, serialize, ai_UTCDateTime_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)

--- a/src/BSON/UTCDateTime.c
+++ b/src/BSON/UTCDateTime.c
@@ -508,6 +508,10 @@ void php_phongo_utcdatetime_init_ce(INIT_FUNC_ARGS) /* {{{ */
 	zend_class_implements(php_phongo_utcdatetime_ce, 1, php_phongo_type_ce);
 	zend_class_implements(php_phongo_utcdatetime_ce, 1, zend_ce_serializable);
 
+#if PHP_VERSION_ID >= 80000
+	zend_class_implements(php_phongo_utcdatetime_ce, 1, zend_ce_stringable);
+#endif
+
 	memcpy(&php_phongo_handler_utcdatetime, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 	PHONGO_COMPAT_SET_COMPARE_OBJECTS_HANDLER(utcdatetime);
 	php_phongo_handler_utcdatetime.clone_obj      = php_phongo_utcdatetime_clone_object;

--- a/src/BSON/UTCDateTime.c
+++ b/src/BSON/UTCDateTime.c
@@ -99,7 +99,7 @@ static bool php_phongo_utcdatetime_init_from_date(php_phongo_utcdatetime_t* inte
 	int64_t sec, usec;
 
 	/* The following assignments use the same logic as date_format() in php_date.c */
-	sec = datetime_obj->time->sse;
+	sec  = datetime_obj->time->sse;
 	usec = (int64_t) floor(datetime_obj->time->us);
 
 	intern->milliseconds = (sec * 1000) + (usec / 1000);

--- a/src/BSON/UTCDateTimeInterface.c
+++ b/src/BSON/UTCDateTimeInterface.c
@@ -26,16 +26,19 @@
 zend_class_entry* php_phongo_utcdatetime_interface_ce;
 
 /* {{{ MongoDB\BSON\UTCDateTimeInterface function entries */
+/* clang-format off */
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(ai_UTCDateTimeInterface___toString, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(ai_UTCDateTimeInterface_void, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
 static zend_function_entry php_phongo_utcdatetime_interface_me[] = {
-	/* clang-format off */
 	ZEND_ABSTRACT_ME(UTCDateTimeInterface, toDateTime, ai_UTCDateTimeInterface_void)
-	ZEND_ABSTRACT_ME(UTCDateTimeInterface, __toString, ai_UTCDateTimeInterface_void)
+	ZEND_ABSTRACT_ME(UTCDateTimeInterface, __toString, ai_UTCDateTimeInterface___toString)
 	PHP_FE_END
-	/* clang-format on */
 };
+/* clang-format on */
 /* }}} */
 
 void php_phongo_utcdatetime_interface_init_ce(INIT_FUNC_ARGS) /* {{{ */

--- a/src/BSON/Undefined.c
+++ b/src/BSON/Undefined.c
@@ -115,6 +115,9 @@ static PHP_METHOD(Undefined, __unserialize)
 
 /* {{{ MongoDB\BSON\Undefined function entries */
 /* clang-format off */
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(ai_Undefined___toString, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(ai_Undefined___unserialize, 0, 0, 1)
 	ZEND_ARG_ARRAY_INFO(0, data, 0)
 ZEND_END_ARG_INFO()
@@ -132,7 +135,7 @@ ZEND_END_ARG_INFO()
 static zend_function_entry php_phongo_undefined_me[] = {
 	/* __set_state intentionally missing */
 	PHP_ME(Undefined, __serialize, ai_Undefined_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
-	PHP_ME(Undefined, __toString, ai_Undefined_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
+	PHP_ME(Undefined, __toString, ai_Undefined___toString, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(Undefined, __unserialize, ai_Undefined___unserialize, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(Undefined, jsonSerialize, ai_Undefined_jsonSerialize, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(Undefined, serialize, ai_Undefined_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)

--- a/src/BSON/Undefined.c
+++ b/src/BSON/Undefined.c
@@ -183,6 +183,10 @@ void php_phongo_undefined_init_ce(INIT_FUNC_ARGS) /* {{{ */
 	zend_class_implements(php_phongo_undefined_ce, 1, php_phongo_type_ce);
 	zend_class_implements(php_phongo_undefined_ce, 1, zend_ce_serializable);
 
+#if PHP_VERSION_ID >= 80000
+	zend_class_implements(php_phongo_undefined_ce, 1, zend_ce_stringable);
+#endif
+
 	memcpy(&php_phongo_handler_undefined, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 	/* Re-assign default handler previously removed in php_phongo.c */
 	php_phongo_handler_undefined.clone_obj = zend_objects_clone_obj;

--- a/src/MongoDB/CursorId.c
+++ b/src/MongoDB/CursorId.c
@@ -230,8 +230,12 @@ static PHP_METHOD(CursorId, __unserialize)
 } /* }}} */
 
 /* {{{ MongoDB\Driver\CursorId function entries */
+/* clang-format off */
 ZEND_BEGIN_ARG_INFO_EX(ai_CursorId___set_state, 0, 0, 1)
 	ZEND_ARG_ARRAY_INFO(0, properties, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(ai_CursorId___toString, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_CursorId___unserialize, 0, 0, 1)
@@ -246,17 +250,16 @@ ZEND_BEGIN_ARG_INFO_EX(ai_CursorId_void, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
 static zend_function_entry php_phongo_cursorid_me[] = {
-	/* clang-format off */
 	PHP_ME(CursorId, __serialize, ai_CursorId_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(CursorId, __set_state, ai_CursorId___set_state, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
-	PHP_ME(CursorId, __toString, ai_CursorId_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
+	PHP_ME(CursorId, __toString, ai_CursorId___toString, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(CursorId, __unserialize, ai_CursorId___unserialize, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(CursorId, serialize, ai_CursorId_void, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	PHP_ME(CursorId, unserialize, ai_CursorId_unserialize, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	ZEND_NAMED_ME(__construct, PHP_FN(MongoDB_disabled___construct), ai_CursorId_void, ZEND_ACC_PRIVATE | ZEND_ACC_FINAL)
 	PHP_FE_END
-	/* clang-format on */
 };
+/* clang-format on */
 /* }}} */
 
 /* {{{ MongoDB\Driver\CursorId object handlers */

--- a/src/MongoDB/CursorId.c
+++ b/src/MongoDB/CursorId.c
@@ -314,6 +314,10 @@ void php_phongo_cursorid_init_ce(INIT_FUNC_ARGS) /* {{{ */
 
 	zend_class_implements(php_phongo_cursorid_ce, 1, zend_ce_serializable);
 
+#if PHP_VERSION_ID >= 80000
+	zend_class_implements(php_phongo_cursorid_ce, 1, zend_ce_stringable);
+#endif
+
 	memcpy(&php_phongo_handler_cursorid, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 	php_phongo_handler_cursorid.get_debug_info = php_phongo_cursorid_get_debug_info;
 	php_phongo_handler_cursorid.get_properties = php_phongo_cursorid_get_properties;

--- a/tests/session/session-advanceOperationTime-003.phpt
+++ b/tests/session/session-advanceOperationTime-003.phpt
@@ -21,7 +21,7 @@ class MyTimestamp implements MongoDB\BSON\TimestampInterface
         return 1234;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return sprintf('[%d:%d]', $this->getIncrement(), $this->getTimestamp());
     }

--- a/tests/session/session-advanceOperationTime_error-001.phpt
+++ b/tests/session/session-advanceOperationTime_error-001.phpt
@@ -38,7 +38,7 @@ class MyTimestamp implements MongoDB\BSON\TimestampInterface
         return 1234;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return sprintf('[%d:%d]', $this->getIncrement(), $this->getTimestamp());
     }


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-2004
https://jira.mongodb.org/browse/PHPC-2007

See https://externals.io/message/116308#116318 for context. There is a subtle BC break here, as userland classes implementing our BSON interfaces will now need to explicitly specify a string return type on PHP versions before 8.1 (where it's added automatically). AFAICT, the only way to avoid the BC break entirely would be to continue to omit return type info and let PHP 8.1+ add the return type info and Stringable implementation automatically; however, that's not a permanent solution as PHP 8.2 will start raising warnings for the automatic behavior (https://github.com/php/php-src/commit/86379b6710f972e0d4a11c89ce28d5768d9824d3).

For that reason, I'm inclined to explicitly add return type info and Stringable implementations (for PHP 8+) and force users to confront the BC break now. This is also unlikely to affect many users, since the BSON interfaces are not widely used ([PHPC-640](https://jira.mongodb.org/browse/PHPC-640) is one such example).

