### PR TITLE
PHPC-2004: Use tentative return types for BSON interface toString methods

### DIFF
--- a/src/BSON/BinaryInterface.c
+++ b/src/BSON/BinaryInterface.c
@@ -27,7 +27,7 @@ zend_class_entry* php_phongo_binary_interface_ce;
 
 /* {{{ MongoDB\BSON\BinaryInterface function entries */
 /* clang-format off */
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(ai_BinaryInterface___toString, 0, 0, IS_STRING, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_BinaryInterface___toString, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_BinaryInterface_void, 0, 0, 0)

--- a/src/BSON/Decimal128Interface.c
+++ b/src/BSON/Decimal128Interface.c
@@ -27,7 +27,7 @@ zend_class_entry* php_phongo_decimal128_interface_ce;
 
 /* {{{ MongoDB\BSON\Decimal128Interface function entries */
 /* clang-format off */
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(ai_Decimal128Interface___toString, 0, 0, IS_STRING, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_Decimal128Interface___toString, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 static zend_function_entry php_phongo_decimal128_interface_me[] = {

--- a/src/BSON/JavascriptInterface.c
+++ b/src/BSON/JavascriptInterface.c
@@ -27,7 +27,7 @@ zend_class_entry* php_phongo_javascript_interface_ce;
 
 /* {{{ MongoDB\BSON\JavascriptInterface function entries */
 /* clang-format off */
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(ai_JavascriptInterface___toString, 0, 0, IS_STRING, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_JavascriptInterface___toString, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_JavascriptInterface_void, 0, 0, 0)

--- a/src/BSON/ObjectIdInterface.c
+++ b/src/BSON/ObjectIdInterface.c
@@ -27,7 +27,7 @@ zend_class_entry* php_phongo_objectid_interface_ce;
 
 /* {{{ MongoDB\BSON\ObjectIdInterface function entries */
 /* clang-format off */
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(ai_ObjectIdInterface___toString, 0, 0, IS_STRING, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_ObjectIdInterface___toString, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_ObjectIdInterface_void, 0, 0, 0)

--- a/src/BSON/RegexInterface.c
+++ b/src/BSON/RegexInterface.c
@@ -27,7 +27,7 @@ zend_class_entry* php_phongo_regex_interface_ce;
 
 /* {{{ MongoDB\BSON\RegexInterface function entries */
 /* clang-format off */
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(ai_RegexInterface___toString, 0, 0, IS_STRING, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_RegexInterface___toString, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_RegexInterface_void, 0, 0, 0)

--- a/src/BSON/TimestampInterface.c
+++ b/src/BSON/TimestampInterface.c
@@ -27,7 +27,7 @@ zend_class_entry* php_phongo_timestamp_interface_ce;
 
 /* {{{ MongoDB\BSON\TimestampInterface function entries */
 /* clang-format off */
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(ai_TimestampInterface___toString, 0, 0, IS_STRING, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_TimestampInterface___toString, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_TimestampInterface_void, 0, 0, 0)

--- a/src/BSON/UTCDateTimeInterface.c
+++ b/src/BSON/UTCDateTimeInterface.c
@@ -27,7 +27,7 @@ zend_class_entry* php_phongo_utcdatetime_interface_ce;
 
 /* {{{ MongoDB\BSON\UTCDateTimeInterface function entries */
 /* clang-format off */
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(ai_UTCDateTimeInterface___toString, 0, 0, IS_STRING, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_UTCDateTimeInterface___toString, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_UTCDateTimeInterface_void, 0, 0, 0)

--- a/tests/session/session-advanceOperationTime-003.phpt
+++ b/tests/session/session-advanceOperationTime-003.phpt
@@ -21,7 +21,7 @@ class MyTimestamp implements MongoDB\BSON\TimestampInterface
         return 1234;
     }
 
-    public function __toString(): string
+    public function __toString()
     {
         return sprintf('[%d:%d]', $this->getIncrement(), $this->getTimestamp());
     }

--- a/tests/session/session-advanceOperationTime_error-001.phpt
+++ b/tests/session/session-advanceOperationTime_error-001.phpt
@@ -38,7 +38,7 @@ class MyTimestamp implements MongoDB\BSON\TimestampInterface
         return 1234;
     }
 
-    public function __toString(): string
+    public function __toString()
     {
         return sprintf('[%d:%d]', $this->getIncrement(), $this->getTimestamp());
     }


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-2004

This should avoid the BC break introduced in 6c82ec8b52fad33c3e9444ae8bd2c27a729c4688. PHP 8.1 will automatically add return type info for Stringable, which means the ReturnTypeWillChange attribute should not be necessary on userland classes.