### PR TITLE
PHPC-2008: Re-enable writeresult-getserver-002 for replicaset-auth

### DIFF
--- a/tests/replicaset/writeresult-getserver-002.phpt
+++ b/tests/replicaset/writeresult-getserver-002.phpt
@@ -2,7 +2,6 @@
 MongoDB\Driver\Server: Manager->getServer() returning correct server
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
-<?php skip_if_auth(); /* TODO: PHPC-2008 */ ?>
 <?php skip_if_not_replica_set(); ?>
 <?php skip_if_no_secondary(); ?>
 <?php skip_if_not_clean(); ?>


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-2008

MO should now grant the necessary roles as of 10gen/mongo-orchestration@4e1ab405fe880ab278617b980476c6e1dacdd5cf.