### PR TITLE
PHPC-2028: Replace PHONGO_ALLOC_OBJECT_T with zend_object_alloc

### DIFF
--- a/phongo_compat.h
+++ b/phongo_compat.h
@@ -80,7 +80,11 @@
 #else
 #error Unsupported architecture (integers are neither 32-bit nor 64-bit)
 #endif
-#define PHONGO_ALLOC_OBJECT_T(_obj_t, _class_type) (_obj_t*) ecalloc(1, sizeof(_obj_t) + zend_object_properties_size(_class_type))
+
+#if PHP_VERSION_ID < 70300
+#define zend_object_alloc(obj_size, ce) ecalloc(1, obj_size + zend_object_properties_size(ce))
+#endif
+
 #define ADD_ASSOC_STRING(_zv, _key, _value) add_assoc_string_ex(_zv, ZEND_STRL(_key), (char*) (_value));
 #define ADD_ASSOC_STRINGL(_zv, _key, _value, _len) add_assoc_stringl_ex(_zv, ZEND_STRL(_key), (char*) (_value), _len);
 #define ADD_ASSOC_STRING_EX(_zv, _key, _key_len, _value, _value_len) add_assoc_stringl_ex(_zv, _key, _key_len, (char*) (_value), _value_len);

--- a/src/BSON/Binary.c
+++ b/src/BSON/Binary.c
@@ -383,9 +383,7 @@ static void php_phongo_binary_free_object(zend_object* object) /* {{{ */
 
 static zend_object* php_phongo_binary_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_binary_t* intern = NULL;
-
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_binary_t, class_type);
+	php_phongo_binary_t* intern = zend_object_alloc(sizeof(php_phongo_binary_t), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);

--- a/src/BSON/DBPointer.c
+++ b/src/BSON/DBPointer.c
@@ -288,9 +288,8 @@ static void php_phongo_dbpointer_free_object(zend_object* object) /* {{{ */
 
 zend_object* php_phongo_dbpointer_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_dbpointer_t* intern = NULL;
+	php_phongo_dbpointer_t* intern = zend_object_alloc(sizeof(php_phongo_dbpointer_t), class_type);
 
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_dbpointer_t, class_type);
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
 

--- a/src/BSON/Decimal128.c
+++ b/src/BSON/Decimal128.c
@@ -320,9 +320,7 @@ static void php_phongo_decimal128_free_object(zend_object* object) /* {{{ */
 
 static zend_object* php_phongo_decimal128_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_decimal128_t* intern = NULL;
-
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_decimal128_t, class_type);
+	php_phongo_decimal128_t* intern = zend_object_alloc(sizeof(php_phongo_decimal128_t), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);

--- a/src/BSON/Int64.c
+++ b/src/BSON/Int64.c
@@ -268,9 +268,8 @@ static void php_phongo_int64_free_object(zend_object* object) /* {{{ */
 
 zend_object* php_phongo_int64_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_int64_t* intern = NULL;
+	php_phongo_int64_t* intern = zend_object_alloc(sizeof(php_phongo_int64_t), class_type);
 
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_int64_t, class_type);
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
 

--- a/src/BSON/Javascript.c
+++ b/src/BSON/Javascript.c
@@ -441,9 +441,8 @@ static void php_phongo_javascript_free_object(zend_object* object) /* {{{ */
 
 zend_object* php_phongo_javascript_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_javascript_t* intern = NULL;
+	php_phongo_javascript_t* intern = zend_object_alloc(sizeof(php_phongo_javascript_t), class_type);
 
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_javascript_t, class_type);
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
 

--- a/src/BSON/MaxKey.c
+++ b/src/BSON/MaxKey.c
@@ -158,9 +158,8 @@ static void php_phongo_maxkey_free_object(zend_object* object) /* {{{ */
 
 static zend_object* php_phongo_maxkey_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_maxkey_t* intern = NULL;
+	php_phongo_maxkey_t* intern = zend_object_alloc(sizeof(php_phongo_maxkey_t), class_type);
 
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_maxkey_t, class_type);
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
 

--- a/src/BSON/MinKey.c
+++ b/src/BSON/MinKey.c
@@ -158,9 +158,7 @@ static void php_phongo_minkey_free_object(zend_object* object) /* {{{ */
 
 static zend_object* php_phongo_minkey_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_minkey_t* intern = NULL;
-
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_minkey_t, class_type);
+	php_phongo_minkey_t* intern = zend_object_alloc(sizeof(php_phongo_minkey_t), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);

--- a/src/BSON/ObjectId.c
+++ b/src/BSON/ObjectId.c
@@ -360,9 +360,7 @@ static void php_phongo_objectid_free_object(zend_object* object) /* {{{ */
 
 static zend_object* php_phongo_objectid_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_objectid_t* intern = NULL;
-
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_objectid_t, class_type);
+	php_phongo_objectid_t* intern = zend_object_alloc(sizeof(php_phongo_objectid_t), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);

--- a/src/BSON/Regex.c
+++ b/src/BSON/Regex.c
@@ -396,9 +396,7 @@ static void php_phongo_regex_free_object(zend_object* object) /* {{{ */
 
 static zend_object* php_phongo_regex_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_regex_t* intern = NULL;
-
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_regex_t, class_type);
+	php_phongo_regex_t* intern = zend_object_alloc(sizeof(php_phongo_regex_t), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);

--- a/src/BSON/Symbol.c
+++ b/src/BSON/Symbol.c
@@ -263,9 +263,8 @@ static void php_phongo_symbol_free_object(zend_object* object) /* {{{ */
 
 zend_object* php_phongo_symbol_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_symbol_t* intern = NULL;
+	php_phongo_symbol_t* intern = zend_object_alloc(sizeof(php_phongo_symbol_t), class_type);
 
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_symbol_t, class_type);
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
 

--- a/src/BSON/Timestamp.c
+++ b/src/BSON/Timestamp.c
@@ -437,9 +437,7 @@ static void php_phongo_timestamp_free_object(zend_object* object) /* {{{ */
 
 static zend_object* php_phongo_timestamp_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_timestamp_t* intern = NULL;
-
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_timestamp_t, class_type);
+	php_phongo_timestamp_t* intern = zend_object_alloc(sizeof(php_phongo_timestamp_t), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);

--- a/src/BSON/UTCDateTime.c
+++ b/src/BSON/UTCDateTime.c
@@ -437,9 +437,7 @@ static void php_phongo_utcdatetime_free_object(zend_object* object) /* {{{ */
 
 static zend_object* php_phongo_utcdatetime_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_utcdatetime_t* intern = NULL;
-
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_utcdatetime_t, class_type);
+	php_phongo_utcdatetime_t* intern = zend_object_alloc(sizeof(php_phongo_utcdatetime_t), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);

--- a/src/BSON/Undefined.c
+++ b/src/BSON/Undefined.c
@@ -158,9 +158,8 @@ static void php_phongo_undefined_free_object(zend_object* object) /* {{{ */
 
 static zend_object* php_phongo_undefined_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_undefined_t* intern = NULL;
+	php_phongo_undefined_t* intern = zend_object_alloc(sizeof(php_phongo_undefined_t), class_type);
 
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_undefined_t, class_type);
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
 

--- a/src/MongoDB/BulkWrite.c
+++ b/src/MongoDB/BulkWrite.c
@@ -592,9 +592,7 @@ static void php_phongo_bulkwrite_free_object(zend_object* object) /* {{{ */
 
 static zend_object* php_phongo_bulkwrite_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_bulkwrite_t* intern = NULL;
-
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_bulkwrite_t, class_type);
+	php_phongo_bulkwrite_t* intern = zend_object_alloc(sizeof(php_phongo_bulkwrite_t), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);

--- a/src/MongoDB/ClientEncryption.c
+++ b/src/MongoDB/ClientEncryption.c
@@ -140,9 +140,7 @@ static void php_phongo_clientencryption_free_object(zend_object* object) /* {{{ 
 
 static zend_object* php_phongo_clientencryption_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_clientencryption_t* intern = NULL;
-
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_clientencryption_t, class_type);
+	php_phongo_clientencryption_t* intern = zend_object_alloc(sizeof(php_phongo_clientencryption_t), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);

--- a/src/MongoDB/Command.c
+++ b/src/MongoDB/Command.c
@@ -152,9 +152,7 @@ static void php_phongo_command_free_object(zend_object* object) /* {{{ */
 
 static zend_object* php_phongo_command_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_command_t* intern = NULL;
-
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_command_t, class_type);
+	php_phongo_command_t* intern = zend_object_alloc(sizeof(php_phongo_command_t), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);

--- a/src/MongoDB/Cursor.c
+++ b/src/MongoDB/Cursor.c
@@ -447,9 +447,7 @@ static void php_phongo_cursor_free_object(zend_object* object) /* {{{ */
 
 static zend_object* php_phongo_cursor_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_cursor_t* intern = NULL;
-
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_cursor_t, class_type);
+	php_phongo_cursor_t* intern = zend_object_alloc(sizeof(php_phongo_cursor_t), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);

--- a/src/MongoDB/CursorId.c
+++ b/src/MongoDB/CursorId.c
@@ -279,9 +279,7 @@ static void php_phongo_cursorid_free_object(zend_object* object) /* {{{ */
 
 static zend_object* php_phongo_cursorid_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_cursorid_t* intern = NULL;
-
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_cursorid_t, class_type);
+	php_phongo_cursorid_t* intern = zend_object_alloc(sizeof(php_phongo_cursorid_t), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);

--- a/src/MongoDB/Manager.c
+++ b/src/MongoDB/Manager.c
@@ -954,9 +954,7 @@ static void php_phongo_manager_free_object(zend_object* object) /* {{{ */
 
 static zend_object* php_phongo_manager_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_manager_t* intern = NULL;
-
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_manager_t, class_type);
+	php_phongo_manager_t* intern = zend_object_alloc(sizeof(php_phongo_manager_t), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);

--- a/src/MongoDB/Monitoring/CommandFailedEvent.c
+++ b/src/MongoDB/Monitoring/CommandFailedEvent.c
@@ -241,9 +241,7 @@ static void php_phongo_commandfailedevent_free_object(zend_object* object) /* {{
 
 static zend_object* php_phongo_commandfailedevent_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_commandfailedevent_t* intern = NULL;
-
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_commandfailedevent_t, class_type);
+	php_phongo_commandfailedevent_t* intern = zend_object_alloc(sizeof(php_phongo_commandfailedevent_t), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);

--- a/src/MongoDB/Monitoring/CommandStartedEvent.c
+++ b/src/MongoDB/Monitoring/CommandStartedEvent.c
@@ -221,9 +221,7 @@ static void php_phongo_commandstartedevent_free_object(zend_object* object) /* {
 
 static zend_object* php_phongo_commandstartedevent_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_commandstartedevent_t* intern = NULL;
-
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_commandstartedevent_t, class_type);
+	php_phongo_commandstartedevent_t* intern = zend_object_alloc(sizeof(php_phongo_commandstartedevent_t), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);

--- a/src/MongoDB/Monitoring/CommandSucceededEvent.c
+++ b/src/MongoDB/Monitoring/CommandSucceededEvent.c
@@ -217,9 +217,7 @@ static void php_phongo_commandsucceededevent_free_object(zend_object* object) /*
 
 static zend_object* php_phongo_commandsucceededevent_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_commandsucceededevent_t* intern = NULL;
-
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_commandsucceededevent_t, class_type);
+	php_phongo_commandsucceededevent_t* intern = zend_object_alloc(sizeof(php_phongo_commandsucceededevent_t), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);

--- a/src/MongoDB/Monitoring/ServerChangedEvent.c
+++ b/src/MongoDB/Monitoring/ServerChangedEvent.c
@@ -119,9 +119,7 @@ static void php_phongo_serverchangedevent_free_object(zend_object* object) /* {{
 
 static zend_object* php_phongo_serverchangedevent_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_serverchangedevent_t* intern = NULL;
-
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_serverchangedevent_t, class_type);
+	php_phongo_serverchangedevent_t* intern = zend_object_alloc(sizeof(php_phongo_serverchangedevent_t), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);

--- a/src/MongoDB/Monitoring/ServerClosedEvent.c
+++ b/src/MongoDB/Monitoring/ServerClosedEvent.c
@@ -87,9 +87,7 @@ static void php_phongo_serverclosedevent_free_object(zend_object* object) /* {{{
 
 static zend_object* php_phongo_serverclosedevent_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_serverclosedevent_t* intern = NULL;
-
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_serverclosedevent_t, class_type);
+	php_phongo_serverclosedevent_t* intern = zend_object_alloc(sizeof(php_phongo_serverclosedevent_t), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);

--- a/src/MongoDB/Monitoring/ServerHeartbeatFailedEvent.c
+++ b/src/MongoDB/Monitoring/ServerHeartbeatFailedEvent.c
@@ -115,9 +115,7 @@ static void php_phongo_serverheartbeatfailedevent_free_object(zend_object* objec
 
 static zend_object* php_phongo_serverheartbeatfailedevent_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_serverheartbeatfailedevent_t* intern = NULL;
-
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_serverheartbeatfailedevent_t, class_type);
+	php_phongo_serverheartbeatfailedevent_t* intern = zend_object_alloc(sizeof(php_phongo_serverheartbeatfailedevent_t), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);

--- a/src/MongoDB/Monitoring/ServerHeartbeatStartedEvent.c
+++ b/src/MongoDB/Monitoring/ServerHeartbeatStartedEvent.c
@@ -87,9 +87,7 @@ static void php_phongo_serverheartbeatstartedevent_free_object(zend_object* obje
 
 static zend_object* php_phongo_serverheartbeatstartedevent_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_serverheartbeatstartedevent_t* intern = NULL;
-
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_serverheartbeatstartedevent_t, class_type);
+	php_phongo_serverheartbeatstartedevent_t* intern = zend_object_alloc(sizeof(php_phongo_serverheartbeatstartedevent_t), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);

--- a/src/MongoDB/Monitoring/ServerHeartbeatSucceededEvent.c
+++ b/src/MongoDB/Monitoring/ServerHeartbeatSucceededEvent.c
@@ -123,9 +123,7 @@ static void php_phongo_serverheartbeatsucceededevent_free_object(zend_object* ob
 
 static zend_object* php_phongo_serverheartbeatsucceededevent_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_serverheartbeatsucceededevent_t* intern = NULL;
-
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_serverheartbeatsucceededevent_t, class_type);
+	php_phongo_serverheartbeatsucceededevent_t* intern = zend_object_alloc(sizeof(php_phongo_serverheartbeatsucceededevent_t), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);

--- a/src/MongoDB/Monitoring/ServerOpeningEvent.c
+++ b/src/MongoDB/Monitoring/ServerOpeningEvent.c
@@ -87,9 +87,7 @@ static void php_phongo_serveropeningevent_free_object(zend_object* object) /* {{
 
 static zend_object* php_phongo_serveropeningevent_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_serveropeningevent_t* intern = NULL;
-
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_serveropeningevent_t, class_type);
+	php_phongo_serveropeningevent_t* intern = zend_object_alloc(sizeof(php_phongo_serveropeningevent_t), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);

--- a/src/MongoDB/Monitoring/TopologyChangedEvent.c
+++ b/src/MongoDB/Monitoring/TopologyChangedEvent.c
@@ -95,9 +95,7 @@ static void php_phongo_topologychangedevent_free_object(zend_object* object) /* 
 
 static zend_object* php_phongo_topologychangedevent_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_topologychangedevent_t* intern = NULL;
-
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_topologychangedevent_t, class_type);
+	php_phongo_topologychangedevent_t* intern = zend_object_alloc(sizeof(php_phongo_topologychangedevent_t), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);

--- a/src/MongoDB/Monitoring/TopologyClosedEvent.c
+++ b/src/MongoDB/Monitoring/TopologyClosedEvent.c
@@ -63,9 +63,7 @@ static void php_phongo_topologyclosedevent_free_object(zend_object* object) /* {
 
 static zend_object* php_phongo_topologyclosedevent_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_topologyclosedevent_t* intern = NULL;
-
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_topologyclosedevent_t, class_type);
+	php_phongo_topologyclosedevent_t* intern = zend_object_alloc(sizeof(php_phongo_topologyclosedevent_t), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);

--- a/src/MongoDB/Monitoring/TopologyOpeningEvent.c
+++ b/src/MongoDB/Monitoring/TopologyOpeningEvent.c
@@ -63,9 +63,7 @@ static void php_phongo_topologyopeningevent_free_object(zend_object* object) /* 
 
 static zend_object* php_phongo_topologyopeningevent_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_topologyopeningevent_t* intern = NULL;
-
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_topologyopeningevent_t, class_type);
+	php_phongo_topologyopeningevent_t* intern = zend_object_alloc(sizeof(php_phongo_topologyopeningevent_t), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);

--- a/src/MongoDB/Query.c
+++ b/src/MongoDB/Query.c
@@ -411,9 +411,7 @@ static void php_phongo_query_free_object(zend_object* object) /* {{{ */
 
 static zend_object* php_phongo_query_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_query_t* intern = NULL;
-
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_query_t, class_type);
+	php_phongo_query_t* intern = zend_object_alloc(sizeof(php_phongo_query_t), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);

--- a/src/MongoDB/ReadConcern.c
+++ b/src/MongoDB/ReadConcern.c
@@ -353,9 +353,7 @@ static void php_phongo_readconcern_free_object(zend_object* object) /* {{{ */
 
 static zend_object* php_phongo_readconcern_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_readconcern_t* intern = NULL;
-
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_readconcern_t, class_type);
+	php_phongo_readconcern_t* intern = zend_object_alloc(sizeof(php_phongo_readconcern_t), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);

--- a/src/MongoDB/ReadPreference.c
+++ b/src/MongoDB/ReadPreference.c
@@ -761,9 +761,7 @@ static void php_phongo_readpreference_free_object(zend_object* object) /* {{{ */
 
 static zend_object* php_phongo_readpreference_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_readpreference_t* intern = NULL;
-
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_readpreference_t, class_type);
+	php_phongo_readpreference_t* intern = zend_object_alloc(sizeof(php_phongo_readpreference_t), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);

--- a/src/MongoDB/Server.c
+++ b/src/MongoDB/Server.c
@@ -681,9 +681,7 @@ static void php_phongo_server_free_object(zend_object* object) /* {{{ */
 
 static zend_object* php_phongo_server_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_server_t* intern = NULL;
-
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_server_t, class_type);
+	php_phongo_server_t* intern = zend_object_alloc(sizeof(php_phongo_server_t), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);

--- a/src/MongoDB/ServerApi.c
+++ b/src/MongoDB/ServerApi.c
@@ -349,9 +349,7 @@ static void php_phongo_serverapi_free_object(zend_object* object) /* {{{ */
 
 static zend_object* php_phongo_serverapi_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_serverapi_t* intern = NULL;
-
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_serverapi_t, class_type);
+	php_phongo_serverapi_t* intern = zend_object_alloc(sizeof(php_phongo_serverapi_t), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);

--- a/src/MongoDB/ServerDescription.c
+++ b/src/MongoDB/ServerDescription.c
@@ -189,9 +189,7 @@ static void php_phongo_serverdescription_free_object(zend_object* object) /* {{{
 
 static zend_object* php_phongo_serverdescription_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_serverdescription_t* intern = NULL;
-
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_serverdescription_t, class_type);
+	php_phongo_serverdescription_t* intern = zend_object_alloc(sizeof(php_phongo_serverdescription_t), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);

--- a/src/MongoDB/Session.c
+++ b/src/MongoDB/Session.c
@@ -688,9 +688,7 @@ static void php_phongo_session_free_object(zend_object* object) /* {{{ */
 
 static zend_object* php_phongo_session_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_session_t* intern = NULL;
-
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_session_t, class_type);
+	php_phongo_session_t* intern = zend_object_alloc(sizeof(php_phongo_session_t), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);

--- a/src/MongoDB/TopologyDescription.c
+++ b/src/MongoDB/TopologyDescription.c
@@ -147,9 +147,7 @@ static void php_phongo_topologydescription_free_object(zend_object* object) /* {
 
 static zend_object* php_phongo_topologydescription_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_topologydescription_t* intern = NULL;
-
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_topologydescription_t, class_type);
+	php_phongo_topologydescription_t* intern = zend_object_alloc(sizeof(php_phongo_topologydescription_t), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);

--- a/src/MongoDB/WriteConcern.c
+++ b/src/MongoDB/WriteConcern.c
@@ -570,9 +570,7 @@ static void php_phongo_writeconcern_free_object(zend_object* object) /* {{{ */
 
 static zend_object* php_phongo_writeconcern_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_writeconcern_t* intern = NULL;
-
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_writeconcern_t, class_type);
+	php_phongo_writeconcern_t* intern = zend_object_alloc(sizeof(php_phongo_writeconcern_t), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);

--- a/src/MongoDB/WriteConcernError.c
+++ b/src/MongoDB/WriteConcernError.c
@@ -121,9 +121,7 @@ static void php_phongo_writeconcernerror_free_object(zend_object* object) /* {{{
 
 static zend_object* php_phongo_writeconcernerror_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_writeconcernerror_t* intern = NULL;
-
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_writeconcernerror_t, class_type);
+	php_phongo_writeconcernerror_t* intern = zend_object_alloc(sizeof(php_phongo_writeconcernerror_t), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);

--- a/src/MongoDB/WriteError.c
+++ b/src/MongoDB/WriteError.c
@@ -142,9 +142,7 @@ static void php_phongo_writeerror_free_object(zend_object* object) /* {{{ */
 
 static zend_object* php_phongo_writeerror_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_writeerror_t* intern = NULL;
-
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_writeerror_t, class_type);
+	php_phongo_writeerror_t* intern = zend_object_alloc(sizeof(php_phongo_writeerror_t), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);

--- a/src/MongoDB/WriteResult.c
+++ b/src/MongoDB/WriteResult.c
@@ -376,9 +376,7 @@ static void php_phongo_writeresult_free_object(zend_object* object) /* {{{ */
 
 static zend_object* php_phongo_writeresult_create_object(zend_class_entry* class_type) /* {{{ */
 {
-	php_phongo_writeresult_t* intern = NULL;
-
-	intern = PHONGO_ALLOC_OBJECT_T(php_phongo_writeresult_t, class_type);
+	php_phongo_writeresult_t* intern = zend_object_alloc(sizeof(php_phongo_writeresult_t), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-2028

zend_object_alloc was introduced in php/php-src@b72b1a4e4d4a94a16b953bf8d826885efb56eeca for PHP 7.3+. For PHP 7.2, we define a macro providing the original behavior of PHONGO_ALLOC_OBJECT_T (slower dynamic memset).