### PR TITLE
PHPC-2042: Remove conditional win32/time.h include

### DIFF
--- a/src/BSON/UTCDateTime.c
+++ b/src/BSON/UTCDateTime.c
@@ -22,10 +22,6 @@
 #include <ext/standard/php_var.h>
 #include <Zend/zend_interfaces.h>
 
-#ifdef PHP_WIN32
-#include <win32/time.h>
-#endif
-
 #include "php_phongo.h"
 #include "phongo_error.h"
 #include "phongo_util.h"


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-2042

This dates back to 29a372916c5a5b7544006dd69a54fa3f373d56e6 but should no longer be necessary as of 6eaa91b87bbf5760a9bf6a6a13f911274da02253, which switched gettimeofday() to the libbson compat function.