### PR TITLE
PHPC-2047: Update load balancer testing config

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -360,7 +360,7 @@ functions:
       params:
         script: |
           ${PREPARE_SHELL}
-          MONGODB_VERSION=${VERSION} TOPOLOGY=${TOPOLOGY} AUTH=${AUTH} SSL=${SSL} STORAGE_ENGINE=${STORAGE_ENGINE} REQUIRE_API_VERSION=${REQUIRE_API_VERSION} ORCHESTRATION_FILE=${ORCHESTRATION_FILE} sh ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
+          MONGODB_VERSION=${VERSION} TOPOLOGY=${TOPOLOGY} AUTH=${AUTH} SSL=${SSL} STORAGE_ENGINE=${STORAGE_ENGINE} LOAD_BALANCER=${LOAD_BALANCER} REQUIRE_API_VERSION=${REQUIRE_API_VERSION} ORCHESTRATION_FILE=${ORCHESTRATION_FILE} sh ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
     # run-orchestration generates expansion file with the MONGODB_URI for the cluster
     - command: expansions.update
       params:
@@ -611,12 +611,11 @@ tasks:
         - func: "bootstrap mongo-orchestration"
           vars:
             TOPOLOGY: "sharded_cluster"
+            LOAD_BALANCER: "true"
             SSL: "yes"
         - func: "start load balancer"
         - func: "run tests"
           vars:
-            # Testing with HAProxy requires service ID mocking
-            MOCK_SERVICE_ID: 1
             # Note: loadBalanced=true should already be appended to SINGLE_MONGOS_LB_URI
             MONGODB_URI: "${SINGLE_MONGOS_LB_URI}"
             SSL: "yes"
@@ -1285,7 +1284,8 @@ buildvariants:
     - name: "test-requireApiVersion"
 
 - matrix_name: "test-loadBalanced"
-  matrix_spec: { "os": "debian92", "versions": ["5.0", "latest"], "php-edge-versions": "latest-stable" }
+  # TODO: Add "5.2" server version alongside "latest" following its GA release
+  matrix_spec: { "os": "debian92", "versions": "latest", "php-edge-versions": "latest-stable" }
   display_name: "Load balanced - ${versions}"
   tasks:
     - name: "test-loadBalanced"

--- a/tests/connect/bug0720.phpt
+++ b/tests/connect/bug0720.phpt
@@ -5,6 +5,7 @@ PHPC-720: Do not persist SSL streams to avoid SSL reinitialization errors
 <?php skip_if_not_libmongoc_ssl(); ?>
 <?php skip_if_not_ssl(); ?>
 <?php skip_if_no_ssl_dir(); ?>
+<?php skip_if_not_live(); ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";

--- a/tests/connect/standalone-ssl-no_verify-001.phpt
+++ b/tests/connect/standalone-ssl-no_verify-001.phpt
@@ -4,6 +4,7 @@ Connect to MongoDB with SSL and no host/cert verification (driver options)
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_not_libmongoc_ssl(); ?>
 <?php skip_if_not_ssl(); ?>
+<?php skip_if_not_live(); ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";

--- a/tests/connect/standalone-ssl-no_verify-002.phpt
+++ b/tests/connect/standalone-ssl-no_verify-002.phpt
@@ -4,6 +4,7 @@ Connect to MongoDB with SSL and no host/cert verification (context options)
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_not_libmongoc_ssl(); ?>
 <?php skip_if_not_ssl(); ?>
+<?php skip_if_not_live(); ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";

--- a/tests/connect/standalone-ssl-no_verify-003.phpt
+++ b/tests/connect/standalone-ssl-no_verify-003.phpt
@@ -4,6 +4,7 @@ Connect to MongoDB with SSL and no host/cert verification (URI options)
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_not_libmongoc_ssl(); ?>
 <?php skip_if_not_ssl(); ?>
+<?php skip_if_not_live(); ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";

--- a/tests/connect/standalone-ssl-verify_cert-001.phpt
+++ b/tests/connect/standalone-ssl-verify_cert-001.phpt
@@ -5,6 +5,7 @@ Connect to MongoDB with SSL and cert verification (driver options)
 <?php skip_if_not_libmongoc_ssl(); ?>
 <?php skip_if_not_ssl(); ?>
 <?php skip_if_no_ssl_dir(); ?>
+<?php skip_if_not_live(); ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";

--- a/tests/connect/standalone-ssl-verify_cert-002.phpt
+++ b/tests/connect/standalone-ssl-verify_cert-002.phpt
@@ -5,6 +5,7 @@ Connect to MongoDB with SSL and cert verification (context options)
 <?php skip_if_not_libmongoc_ssl(); ?>
 <?php skip_if_not_ssl(); ?>
 <?php skip_if_no_ssl_dir(); ?>
+<?php skip_if_not_live(); ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";

--- a/tests/connect/standalone-ssl-verify_cert-003.phpt
+++ b/tests/connect/standalone-ssl-verify_cert-003.phpt
@@ -5,6 +5,7 @@ Connect to MongoDB with SSL and cert verification (URI options)
 <?php skip_if_not_libmongoc_ssl(); ?>
 <?php skip_if_not_ssl(); ?>
 <?php skip_if_no_ssl_dir(); ?>
+<?php skip_if_not_live(); ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";

--- a/tests/manager/bug0572.phpt
+++ b/tests/manager/bug0572.phpt
@@ -4,6 +4,7 @@ PHPC-572: Ensure stream context does not go out of scope before socket init
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_not_libmongoc_ssl(); ?>
 <?php skip_if_not_ssl(); ?>
+<?php skip_if_not_live(); ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";

--- a/tests/manager/manager-set-uri-options-002.phpt
+++ b/tests/manager/manager-set-uri-options-002.phpt
@@ -4,6 +4,7 @@ MongoDB\Driver\Manager: Connecting to MongoDB using "ssl" from $options
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_not_libmongoc_ssl(); ?>
 <?php skip_if_not_ssl(); ?>
+<?php skip_if_not_live(); ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-2047

Upstream changes in drivers-evergreen-tools now require passing LOAD_BALANCER to run-orchestration.sh. Additionally, service ID mocking is no longer required as of server version 5.1.