### PR TITLE
PHPC-2015: Clean up stub files for BSON classes

### DIFF
--- a/src/BSON/Binary.stub.php
+++ b/src/BSON/Binary.stub.php
@@ -5,88 +5,87 @@
   * @generate-function-entries static
   */
 
-namespace MongoDB\BSON
+namespace MongoDB\BSON;
+
+final class Binary implements BinaryInterface, \JsonSerializable, Type, \Serializable
 {
-    final class Binary implements BinaryInterface, \JsonSerializable, Type, \Serializable
-    {
-        /**
-          * @var int
-          * @cvalue BSON_SUBTYPE_BINARY
-          */
-        public const TYPE_GENERIC = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue BSON_SUBTYPE_BINARY
+     */
+    public const TYPE_GENERIC = UNKNOWN;
 
-        /**
-          * @var int
-          * @cvalue BSON_SUBTYPE_FUNCTION
-          */
-        public const TYPE_FUNCTION = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue BSON_SUBTYPE_FUNCTION
+     */
+    public const TYPE_FUNCTION = UNKNOWN;
 
-        /**
-          * @var int
-          * @cvalue BSON_SUBTYPE_BINARY_DEPRECATED
-          */
-        public const TYPE_OLD_BINARY = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue BSON_SUBTYPE_BINARY_DEPRECATED
+     */
+    public const TYPE_OLD_BINARY = UNKNOWN;
 
-        /**
-          * @var int
-          * @cvalue BSON_SUBTYPE_UUID_DEPRECATED
-          */
-        public const TYPE_OLD_UUID = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue BSON_SUBTYPE_UUID_DEPRECATED
+     */
+    public const TYPE_OLD_UUID = UNKNOWN;
 
-        /**
-          * @var int
-          * @cvalue BSON_SUBTYPE_UUID
-          */
-        public const TYPE_UUID = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue BSON_SUBTYPE_UUID
+     */
+    public const TYPE_UUID = UNKNOWN;
 
-        /**
-          * @var int
-          * @cvalue BSON_SUBTYPE_MD5
-          */
-        public const TYPE_MD5 = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue BSON_SUBTYPE_MD5
+     */
+    public const TYPE_MD5 = UNKNOWN;
 
-        /**
-          * @var int
-          * @cvalue BSON_SUBTYPE_ENCRYPTED
-          */
-        public const TYPE_ENCRYPTED = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue BSON_SUBTYPE_ENCRYPTED
+     */
+    public const TYPE_ENCRYPTED = UNKNOWN;
 
-        /**
-          * @var int
-          * @cvalue BSON_SUBTYPE_COLUMN
-          */
-        public const TYPE_COLUMN = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue BSON_SUBTYPE_COLUMN
+     */
+    public const TYPE_COLUMN = UNKNOWN;
 
-        /**
-          * @var int
-          * @cvalue BSON_SUBTYPE_USER
-          */
-        public const TYPE_USER_DEFINED = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue BSON_SUBTYPE_USER
+     */
+    public const TYPE_USER_DEFINED = UNKNOWN;
 
-        public final function __construct(string $data, int $type) {}
+    public final function __construct(string $data, int $type) {}
 
-        final public function getData(): string {}
+    final public function getData(): string {}
 
-        final public function getType(): int {}
+    final public function getType(): int {}
 
-        public static function __set_state(array $properties): Binary {}
+    public static function __set_state(array $properties): Binary {}
 
-        final public function __toString(): string {}
+    final public function __toString(): string {}
 
-        final public function serialize(): string {}
+    final public function serialize(): string {}
 
-        /** @param string $serialized */
-        final public function unserialize($serialized): void {}
+    /** @param string $serialized */
+    final public function unserialize($serialized): void {}
 
-        final public function __unserialize(array $data): void {}
+    final public function __unserialize(array $data): void {}
 
-        final public function __serialize(): array {}
+    final public function __serialize(): array {}
 
 #if PHP_VERSION_ID >= 80000
-        final public function jsonSerialize(): mixed {}
+    final public function jsonSerialize(): mixed {}
 #else
-        /** @return mixed */
-        final public function jsonSerialize() {}
+    /** @return mixed */
+    final public function jsonSerialize() {}
 #endif
-    }
 }

--- a/src/BSON/BinaryInterface.stub.php
+++ b/src/BSON/BinaryInterface.stub.php
@@ -5,16 +5,15 @@
   * @generate-function-entries
   */
 
-namespace MongoDB\BSON
+namespace MongoDB\BSON;
+
+interface BinaryInterface
 {
-    interface BinaryInterface
-    {
-        /** @tentative-return-type */
-        public function getData(): string;
+    /** @tentative-return-type */
+    public function getData(): string;
 
-        /** @tentative-return-type */
-        public function getType(): int;
+    /** @tentative-return-type */
+    public function getType(): int;
 
-        public function __toString(): string;
-    }
+    public function __toString(): string;
 }

--- a/src/BSON/BinaryInterface_arginfo.h
+++ b/src/BSON/BinaryInterface_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 883b69330ddc0ad0a51793235e39d904e8665bec */
+ * Stub hash: 07bf399f3506a13fc4026d90cb58226598905092 */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_BinaryInterface_getData, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()

--- a/src/BSON/Binary_arginfo.h
+++ b/src/BSON/Binary_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 068e51189d6dcd1e5ff0a50d0f0195b0a93f36da */
+ * Stub hash: bd94329bd8849c9bcb93b41699a19589f1fb905b */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_Binary___construct, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)

--- a/src/BSON/DBPointer.stub.php
+++ b/src/BSON/DBPointer.stub.php
@@ -5,28 +5,26 @@
   * @generate-function-entries static
   */
 
-namespace MongoDB\BSON
+namespace MongoDB\BSON;
+final class DBPointer implements \JsonSerializable, Type, \Serializable
 {
-    final class DBPointer implements \JsonSerializable, Type, \Serializable
-    {
-        final private function __construct() {}
+    final private function __construct() {}
 
-        final public function __toString(): string {}
+    final public function __toString(): string {}
 
-        final public function serialize(): string {}
+    final public function serialize(): string {}
 
-        /** @param string $serialized */
-        final public function unserialize($serialized): void {}
+    /** @param string $serialized */
+    final public function unserialize($serialized): void {}
 
-        final public function __unserialize(array $data): void {}
+    final public function __unserialize(array $data): void {}
 
-        final public function __serialize(): array {}
+    final public function __serialize(): array {}
 
 #if PHP_VERSION_ID >= 80000
-        final public function jsonSerialize(): mixed {}
+    final public function jsonSerialize(): mixed {}
 #else
-        /** @return mixed */
-        final public function jsonSerialize() {}
+    /** @return mixed */
+    final public function jsonSerialize() {}
 #endif
-    }
 }

--- a/src/BSON/DBPointer_arginfo.h
+++ b/src/BSON/DBPointer_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 9f87f398d061bfa61312f34693a7e1a47a6803d5 */
+ * Stub hash: 93eae6546a9e300831dedd1a1912685657e8bc00 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_DBPointer___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()

--- a/src/BSON/Decimal128.stub.php
+++ b/src/BSON/Decimal128.stub.php
@@ -5,30 +5,29 @@
   * @generate-function-entries static
   */
 
-namespace MongoDB\BSON
+namespace MongoDB\BSON;
+
+final class Decimal128 implements Decimal128Interface, \JsonSerializable, Type, \Serializable
 {
-    final class Decimal128 implements Decimal128Interface, \JsonSerializable, Type, \Serializable
-    {
-        final public function __construct(string $value = '') {}
+    final public function __construct(string $value = '') {}
 
-        final public function __toString(): string {}
+    final public function __toString(): string {}
 
-        public static function __set_state(array $properties): Decimal128 {}
+    public static function __set_state(array $properties): Decimal128 {}
 
-        final public function serialize(): string {}
+    final public function serialize(): string {}
 
-        /** @param string $serialized */
-        final public function unserialize($serialized): void {}
+    /** @param string $serialized */
+    final public function unserialize($serialized): void {}
 
-        final public function __unserialize(array $data): void {}
+    final public function __unserialize(array $data): void {}
 
-        final public function __serialize(): array {}
+    final public function __serialize(): array {}
 
 #if PHP_VERSION_ID >= 80000
-        final public function jsonSerialize(): mixed {}
+    final public function jsonSerialize(): mixed {}
 #else
-        /** @return mixed */
-        final public function jsonSerialize() {}
+    /** @return mixed */
+    final public function jsonSerialize() {}
 #endif
-    }
 }

--- a/src/BSON/Decimal128Interface.stub.php
+++ b/src/BSON/Decimal128Interface.stub.php
@@ -5,11 +5,10 @@
   * @generate-function-entries
   */
 
-namespace MongoDB\BSON
+namespace MongoDB\BSON;
+
+interface Decimal128Interface
 {
-    interface Decimal128Interface
-    {
-        /** @tentative-return-type */
-        public function __toString(): string;
-    }
+    /** @tentative-return-type */
+    public function __toString(): string;
 }

--- a/src/BSON/Decimal128Interface_arginfo.h
+++ b/src/BSON/Decimal128Interface_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 5fd2c3e0222d95ee31abc731b49882fe3daaab98 */
+ * Stub hash: 8e3bdf5ec19b8267107a1f66c2c31739d935a611 */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Decimal128Interface___toString, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()

--- a/src/BSON/Decimal128_arginfo.h
+++ b/src/BSON/Decimal128_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: db92ad0b12a6766c9d1fd5591e296f1686b4f613 */
+ * Stub hash: 9481dbe518648d2d64cce460c6c5d73ce9df5c6c */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_Decimal128___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, value, IS_STRING, 0, "\'\'")

--- a/src/BSON/Int64.stub.php
+++ b/src/BSON/Int64.stub.php
@@ -5,28 +5,27 @@
   * @generate-function-entries static
   */
 
-namespace MongoDB\BSON
+namespace MongoDB\BSON;
+
+final class Int64 implements \JsonSerializable, Type, \Serializable
 {
-    final class Int64 implements \JsonSerializable, Type, \Serializable
-    {
-        private final function __construct() {}
+    private final function __construct() {}
 
-        final public function __toString(): string {}
+    final public function __toString(): string {}
 
-        final public function serialize(): string {}
+    final public function serialize(): string {}
 
-        /** @param string $serialized */
-        final public function unserialize($serialized): void {}
+    /** @param string $serialized */
+    final public function unserialize($serialized): void {}
 
-        final public function __unserialize(array $data): void {}
+    final public function __unserialize(array $data): void {}
 
-        final public function __serialize(): array {}
+    final public function __serialize(): array {}
 
 #if PHP_VERSION_ID >= 80000
-        final public function jsonSerialize(): mixed {}
+    final public function jsonSerialize(): mixed {}
 #else
-        /** @return mixed */
-        final public function jsonSerialize() {}
+    /** @return mixed */
+    final public function jsonSerialize() {}
 #endif
-    }
 }

--- a/src/BSON/Int64_arginfo.h
+++ b/src/BSON/Int64_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: c6215d669e84919bca49dc8a770c29037cb390d5 */
+ * Stub hash: b82e697d10a284a301c3110f0e947ee45bdc555c */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_Int64___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()

--- a/src/BSON/Javascript.stub.php
+++ b/src/BSON/Javascript.stub.php
@@ -5,39 +5,38 @@
   * @generate-function-entries static
   */
 
-namespace MongoDB\BSON
+namespace MongoDB\BSON;
+
+final class Javascript implements JavascriptInterface, \JsonSerializable, Type, \Serializable
 {
-    final class Javascript implements JavascriptInterface, \JsonSerializable, Type, \Serializable
-    {
 #if PHP_VERSION_ID >= 80000
-        final public function __construct(string $code, array|object|null $scope = null) {}
+    final public function __construct(string $code, array|object|null $scope = null) {}
 #else
-        /** @param array|object|null $scope */
-        final public function __construct(string $code, $scope = null) {}
+    /** @param array|object|null $scope */
+    final public function __construct(string $code, $scope = null) {}
 #endif
 
-        public static function __set_state(array $properties): Javascript {}
+    public static function __set_state(array $properties): Javascript {}
 
-        final public function getCode(): string {}
+    final public function getCode(): string {}
 
-        final public function getScope(): ?object {}
+    final public function getScope(): ?object {}
 
-        final public function __toString(): string {}
+    final public function __toString(): string {}
 
-        final public function serialize(): string {}
+    final public function serialize(): string {}
 
-        /** @param string $serialized */
-        final public function unserialize($serialized): void {}
+    /** @param string $serialized */
+    final public function unserialize($serialized): void {}
 
-        final public function __unserialize(array $data): void {}
+    final public function __unserialize(array $data): void {}
 
-        final public function __serialize(): array {}
+    final public function __serialize(): array {}
 
 #if PHP_VERSION_ID >= 80000
-        final public function jsonSerialize(): mixed {}
+    final public function jsonSerialize(): mixed {}
 #else
-        /** @return mixed */
-        final public function jsonSerialize() {}
+    /** @return mixed */
+    final public function jsonSerialize() {}
 #endif
-    }
 }

--- a/src/BSON/JavascriptInterface.stub.php
+++ b/src/BSON/JavascriptInterface.stub.php
@@ -5,17 +5,16 @@
   * @generate-function-entries
   */
 
-namespace MongoDB\BSON
+namespace MongoDB\BSON;
+
+interface JavascriptInterface
 {
-    interface JavascriptInterface
-    {
-        /** @tentative-return-type */
-        public function getCode(): string;
+    /** @tentative-return-type */
+    public function getCode(): string;
 
-        /** @tentative-return-type */
-        public function getScope(): ?object;
+    /** @tentative-return-type */
+    public function getScope(): ?object;
 
-        /** @tentative-return-type */
-        public function __toString(): string;
-    }
+    /** @tentative-return-type */
+    public function __toString(): string;
 }

--- a/src/BSON/JavascriptInterface_arginfo.h
+++ b/src/BSON/JavascriptInterface_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 766b1ffbfc5227e9b0144556f3ce8517be834b55 */
+ * Stub hash: e1aced8ac16b4214e8c1aeb4c02916f82f5ddba4 */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_JavascriptInterface_getCode, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()

--- a/src/BSON/Javascript_arginfo.h
+++ b/src/BSON/Javascript_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a9028fe55d0bc6cdbfeec5007ce13cbc1887435a */
+ * Stub hash: d6c761a209314b8b183a5ef806ff077f0936aff4 */
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_Javascript___construct, 0, 0, 1)

--- a/src/BSON/MaxKey.stub.php
+++ b/src/BSON/MaxKey.stub.php
@@ -5,26 +5,25 @@
   * @generate-function-entries static
   */
 
-namespace MongoDB\BSON
+namespace MongoDB\BSON;
+
+final class MaxKey implements MaxKeyInterface, \JsonSerializable, Type, \Serializable
 {
-    final class MaxKey implements MaxKeyInterface, \JsonSerializable, Type, \Serializable
-    {
-        public static function __set_state(array $properties): MaxKey {}
+    public static function __set_state(array $properties): MaxKey {}
 
-        final public function serialize(): string {}
+    final public function serialize(): string {}
 
-        /** @param string $serialized */
-        final public function unserialize($serialized): void {}
+    /** @param string $serialized */
+    final public function unserialize($serialized): void {}
 
-        final public function __unserialize(array $data): void {}
+    final public function __unserialize(array $data): void {}
 
-        final public function __serialize(): array {}
+    final public function __serialize(): array {}
 
 #if PHP_VERSION_ID >= 80000
-        final public function jsonSerialize(): mixed {}
+    final public function jsonSerialize(): mixed {}
 #else
-        /** @return mixed */
-        final public function jsonSerialize() {}
+    /** @return mixed */
+    final public function jsonSerialize() {}
 #endif
-    }
 }

--- a/src/BSON/MaxKeyInterface.stub.php
+++ b/src/BSON/MaxKeyInterface.stub.php
@@ -5,9 +5,8 @@
   * @generate-function-entries
   */
 
-namespace MongoDB\BSON
+namespace MongoDB\BSON;
+
+interface MaxKeyInterface
 {
-    interface MaxKeyInterface
-    {
-    }
 }

--- a/src/BSON/MaxKeyInterface_arginfo.h
+++ b/src/BSON/MaxKeyInterface_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 78f16e761ce9b1f94820c84e9fc6da1d09b99caf */
+ * Stub hash: 5daff813c44bcd25309b064a26d58ea3e2e101bf */
 
 
 

--- a/src/BSON/MaxKey_arginfo.h
+++ b/src/BSON/MaxKey_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a68f1540c10abe02af741956e530794ee69aa027 */
+ * Stub hash: d51b2b42e3bcce4fc655379f5b97ca8aec7a7b06 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_BSON_MaxKey___set_state, 0, 1, MongoDB\\BSON\\MaxKey, 0)
 	ZEND_ARG_TYPE_INFO(0, properties, IS_ARRAY, 0)

--- a/src/BSON/MinKey.stub.php
+++ b/src/BSON/MinKey.stub.php
@@ -5,26 +5,25 @@
   * @generate-function-entries static
   */
 
-namespace MongoDB\BSON
+namespace MongoDB\BSON;
+
+final class MinKey implements MinKeyInterface, \JsonSerializable, Type, \Serializable
 {
-    final class MinKey implements MinKeyInterface, \JsonSerializable, Type, \Serializable
-    {
-        public static function __set_state(array $properties): MinKey {}
+    public static function __set_state(array $properties): MinKey {}
 
-        final public function serialize(): string {}
+    final public function serialize(): string {}
 
-        /** @param string $serialized */
-        final public function unserialize($serialized): void {}
+    /** @param string $serialized */
+    final public function unserialize($serialized): void {}
 
-        final public function __unserialize(array $data): void {}
+    final public function __unserialize(array $data): void {}
 
-        final public function __serialize(): array {}
+    final public function __serialize(): array {}
 
 #if PHP_VERSION_ID >= 80000
-        final public function jsonSerialize(): mixed {}
+    final public function jsonSerialize(): mixed {}
 #else
-        /** @return mixed */
-        final public function jsonSerialize() {}
+    /** @return mixed */
+    final public function jsonSerialize() {}
 #endif
-    }
 }

--- a/src/BSON/MinKeyInterface.stub.php
+++ b/src/BSON/MinKeyInterface.stub.php
@@ -5,9 +5,8 @@
   * @generate-function-entries
   */
 
-namespace MongoDB\BSON
+namespace MongoDB\BSON;
+
+interface MinKeyInterface
 {
-    interface MinKeyInterface
-    {
-    }
 }

--- a/src/BSON/MinKeyInterface_arginfo.h
+++ b/src/BSON/MinKeyInterface_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 04d8a6bf2ecc07aa9bf2a8acce13ca644a0512c6 */
+ * Stub hash: d89b62cfa857d8c0d930cb3a85e1e9a4b459e4b0 */
 
 
 

--- a/src/BSON/MinKey_arginfo.h
+++ b/src/BSON/MinKey_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8f749d167d9e76d878732d4df179c930fc3b70e6 */
+ * Stub hash: bceebd5cd96405600260a3b38bb7f4afb55cf998 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_BSON_MinKey___set_state, 0, 1, MongoDB\\BSON\\MinKey, 0)
 	ZEND_ARG_TYPE_INFO(0, properties, IS_ARRAY, 0)

--- a/src/BSON/ObjectId.stub.php
+++ b/src/BSON/ObjectId.stub.php
@@ -5,32 +5,31 @@
   * @generate-function-entries static
   */
 
-namespace MongoDB\BSON
+namespace MongoDB\BSON;
+
+final class ObjectId implements ObjectIdInterface, \JsonSerializable, Type, \Serializable
 {
-    final class ObjectId implements ObjectIdInterface, \JsonSerializable, Type, \Serializable
-    {
-        public final function __construct(?string $id = null) {}
+    public final function __construct(?string $id = null) {}
 
-        public final function getTimestamp(): int {}
+    public final function getTimestamp(): int {}
 
-        public final function __toString(): string {}
+    public final function __toString(): string {}
 
-        public static function __set_state(array $properties): ObjectId {}
+    public static function __set_state(array $properties): ObjectId {}
 
-        final public function serialize(): string {}
+    final public function serialize(): string {}
 
-        /** @param string $serialized */
-        final public function unserialize($serialized): void {}
+    /** @param string $serialized */
+    final public function unserialize($serialized): void {}
 
-        final public function __unserialize(array $data): void {}
+    final public function __unserialize(array $data): void {}
 
-        final public function __serialize(): array {}
+    final public function __serialize(): array {}
 
 #if PHP_VERSION_ID >= 80000
-        final public function jsonSerialize(): mixed {}
+    final public function jsonSerialize(): mixed {}
 #else
-        /** @return mixed */
-        final public function jsonSerialize() {}
+    /** @return mixed */
+    final public function jsonSerialize() {}
 #endif
-    }
 }

--- a/src/BSON/ObjectIdInterface.stub.php
+++ b/src/BSON/ObjectIdInterface.stub.php
@@ -5,14 +5,13 @@
   * @generate-function-entries
   */
 
-namespace MongoDB\BSON
-{
-    interface ObjectIdInterface
-    {
-        /** @tentative-return-type */
-        public function getTimestamp(): int;
+namespace MongoDB\BSON;
 
-        /** @tentative-return-type */
-        public function __toString(): string;
-    }
+interface ObjectIdInterface
+{
+    /** @tentative-return-type */
+    public function getTimestamp(): int;
+
+    /** @tentative-return-type */
+    public function __toString(): string;
 }

--- a/src/BSON/ObjectIdInterface_arginfo.h
+++ b/src/BSON/ObjectIdInterface_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 03dae1ab4d3cdb2773bb2b520d8d1cd2c2942451 */
+ * Stub hash: 462040ee782f5bbafdfd32a24b43b26ff3c305bb */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_ObjectIdInterface_getTimestamp, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()

--- a/src/BSON/ObjectId_arginfo.h
+++ b/src/BSON/ObjectId_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 9a0fe843331b06e904cd938cf1240bd527fd93a0 */
+ * Stub hash: 1da0211fe28a1ce4bd6dfae362b693cf91b3f859 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_ObjectId___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, id, IS_STRING, 1, "null")

--- a/src/BSON/Persistable.stub.php
+++ b/src/BSON/Persistable.stub.php
@@ -5,9 +5,8 @@
   * @generate-function-entries
   */
 
-namespace MongoDB\BSON
+namespace MongoDB\BSON;
+
+interface Persistable extends Serializable, Unserializable
 {
-    interface Persistable extends Serializable, Unserializable
-    {
-    }
 }

--- a/src/BSON/Persistable_arginfo.h
+++ b/src/BSON/Persistable_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: d76c482a30a2793675623bffa883f822a8b1a4eb */
+ * Stub hash: daf8e224ad79ad7e551fd104cb52d31022f5d0b4 */
 
 
 

--- a/src/BSON/Regex.stub.php
+++ b/src/BSON/Regex.stub.php
@@ -5,34 +5,33 @@
   * @generate-function-entries static
   */
 
-namespace MongoDB\BSON
+namespace MongoDB\BSON;
+
+final class Regex implements RegexInterface, \JsonSerializable, Type, \Serializable
 {
-    final class Regex implements RegexInterface, \JsonSerializable, Type, \Serializable
-    {
-        public final function __construct(string $pattern, string $flags = '') {}
+    public final function __construct(string $pattern, string $flags = '') {}
 
-        public final function getPattern(): string {}
+    public final function getPattern(): string {}
 
-        public final function getFlags(): string {}
+    public final function getFlags(): string {}
 
-        public final function __toString(): string {}
+    public final function __toString(): string {}
 
-        public static function __set_state(array $properties): Regex {}
+    public static function __set_state(array $properties): Regex {}
 
-        final public function serialize(): string {}
+    final public function serialize(): string {}
 
-        /** @param string $serialized */
-        final public function unserialize($serialized): void {}
+    /** @param string $serialized */
+    final public function unserialize($serialized): void {}
 
-        final public function __unserialize(array $data): void {}
+    final public function __unserialize(array $data): void {}
 
-        final public function __serialize(): array {}
+    final public function __serialize(): array {}
 
 #if PHP_VERSION_ID >= 80000
-        final public function jsonSerialize(): mixed {}
+    final public function jsonSerialize(): mixed {}
 #else
-        /** @return mixed */
-        final public function jsonSerialize() {}
+    /** @return mixed */
+    final public function jsonSerialize() {}
 #endif
-    }
 }

--- a/src/BSON/RegexInterface.stub.php
+++ b/src/BSON/RegexInterface.stub.php
@@ -5,17 +5,16 @@
   * @generate-function-entries
   */
 
-namespace MongoDB\BSON
+namespace MongoDB\BSON;
+
+interface RegexInterface
 {
-    interface RegexInterface
-    {
-        /** @tentative-return-type */
-        public function getPattern(): string;
+    /** @tentative-return-type */
+    public function getPattern(): string;
 
-        /** @tentative-return-type */
-        public function getFlags(): string;
+    /** @tentative-return-type */
+    public function getFlags(): string;
 
-        /** @tentative-return-type */
-        public function __toString(): string;
-    }
+    /** @tentative-return-type */
+    public function __toString(): string;
 }

--- a/src/BSON/RegexInterface_arginfo.h
+++ b/src/BSON/RegexInterface_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 0b3af1ec11dcb8e97fb9342bbf64564139fc4218 */
+ * Stub hash: 38b21216ed0d4a03e8661e2605190045595126a9 */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_RegexInterface_getPattern, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()

--- a/src/BSON/Regex_arginfo.h
+++ b/src/BSON/Regex_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: f6764f122c47c9071ba8fce92e46ba862f695a4e */
+ * Stub hash: 56e7e6b3257040bbacee67d3f6239eede3a5ab00 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_Regex___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, pattern, IS_STRING, 0)

--- a/src/BSON/Serializable.stub.php
+++ b/src/BSON/Serializable.stub.php
@@ -5,16 +5,15 @@
   * @generate-function-entries
   */
 
-namespace MongoDB\BSON
+namespace MongoDB\BSON;
+
+interface Serializable extends Type
 {
-    interface Serializable extends Type
-    {
 #if PHP_VERSION_ID >= 80000
-        /** @tentative-return-type */
-        public function bsonSerialize(): array|object;
+    /** @tentative-return-type */
+    public function bsonSerialize(): array|object;
 #else
-        /** @return array|object */
-        public function bsonSerialize();
+    /** @return array|object */
+    public function bsonSerialize();
 #endif
-    }
 }

--- a/src/BSON/Serializable_arginfo.h
+++ b/src/BSON/Serializable_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 22bef071736dda02427583bb0f259a8a3f2ccffe */
+ * Stub hash: 197f9b0284b024f5a88c425e5e55758da0b77cfd */
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_MASK_EX(arginfo_class_MongoDB_BSON_Serializable_bsonSerialize, 0, 0, MAY_BE_ARRAY|MAY_BE_OBJECT)

--- a/src/BSON/Symbol.stub.php
+++ b/src/BSON/Symbol.stub.php
@@ -5,28 +5,27 @@
   * @generate-function-entries static
   */
 
-namespace MongoDB\BSON
+namespace MongoDB\BSON;
+
+final class Symbol implements \JsonSerializable, Type, \Serializable
 {
-    final class Symbol implements \JsonSerializable, Type, \Serializable
-    {
-        final private function __construct() {}
+    final private function __construct() {}
 
-        final public function __toString(): string {}
+    final public function __toString(): string {}
 
-        final public function serialize(): string {}
+    final public function serialize(): string {}
 
-        /** @param string $serialized */
-        final public function unserialize($serialized): void {}
+    /** @param string $serialized */
+    final public function unserialize($serialized): void {}
 
-        final public function __unserialize(array $data): void {}
+    final public function __unserialize(array $data): void {}
 
-        final public function __serialize(): array {}
+    final public function __serialize(): array {}
 
 #if PHP_VERSION_ID >= 80000
-        final public function jsonSerialize(): mixed {}
+    final public function jsonSerialize(): mixed {}
 #else
-        /** @return mixed */
-        final public function jsonSerialize() {}
+    /** @return mixed */
+    final public function jsonSerialize() {}
 #endif
-    }
 }

--- a/src/BSON/Symbol_arginfo.h
+++ b/src/BSON/Symbol_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 2e833687b33ec7a6e25da5be58d2a483b63bac18 */
+ * Stub hash: 6ad6b28aaf0404d5917a9c31c2fd725ec104a7df */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_Symbol___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()

--- a/src/BSON/Timestamp.stub.php
+++ b/src/BSON/Timestamp.stub.php
@@ -5,42 +5,41 @@
   * @generate-function-entries static
   */
 
-namespace MongoDB\BSON
+namespace MongoDB\BSON;
+
+final class Timestamp implements TimestampInterface, \JsonSerializable, Type, \Serializable
 {
-    final class Timestamp implements TimestampInterface, \JsonSerializable, Type, \Serializable
-    {
 #if PHP_VERSION_ID >= 80000
-        public final function __construct(int|string $increment, int|string $timestamp) {}
+    public final function __construct(int|string $increment, int|string $timestamp) {}
 #else
-        /**
-         * @param int|string $increment
-         * @param int|string $timestamp
-         */
-        public final function __construct($increment, $timestamp) {}
+    /**
+     * @param int|string $increment
+     * @param int|string $timestamp
+     */
+    public final function __construct($increment, $timestamp) {}
 #endif
 
-        public final function getTimestamp(): int {}
+    public final function getTimestamp(): int {}
 
-        public final function getIncrement(): int {}
+    public final function getIncrement(): int {}
 
-        public final function __toString(): string {}
+    public final function __toString(): string {}
 
-        public static function __set_state(array $properties): Timestamp {}
+    public static function __set_state(array $properties): Timestamp {}
 
-        final public function serialize(): string {}
+    final public function serialize(): string {}
 
-        /** @param string $serialized */
-        final public function unserialize($serialized): void {}
+    /** @param string $serialized */
+    final public function unserialize($serialized): void {}
 
-        final public function __unserialize(array $data): void {}
+    final public function __unserialize(array $data): void {}
 
-        final public function __serialize(): array {}
+    final public function __serialize(): array {}
 
 #if PHP_VERSION_ID >= 80000
-        final public function jsonSerialize(): mixed {}
+    final public function jsonSerialize(): mixed {}
 #else
-        /** @return mixed */
-        final public function jsonSerialize() {}
+    /** @return mixed */
+    final public function jsonSerialize() {}
 #endif
-    }
 }

--- a/src/BSON/TimestampInterface.stub.php
+++ b/src/BSON/TimestampInterface.stub.php
@@ -5,17 +5,16 @@
   * @generate-function-entries
   */
 
-namespace MongoDB\BSON
+namespace MongoDB\BSON;
+
+interface TimestampInterface
 {
-    interface TimestampInterface
-    {
-        /** @tentative-return-type */
-        public function getTimestamp(): int;
+    /** @tentative-return-type */
+    public function getTimestamp(): int;
 
-        /** @tentative-return-type */
-        public function getIncrement(): int;
+    /** @tentative-return-type */
+    public function getIncrement(): int;
 
-        /** @tentative-return-type */
-        public function __toString(): string;
-    }
+    /** @tentative-return-type */
+    public function __toString(): string;
 }

--- a/src/BSON/TimestampInterface_arginfo.h
+++ b/src/BSON/TimestampInterface_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 2b2c314ea62f4a89c03650bdef3a5a5e7c6d73db */
+ * Stub hash: 1beaafbca42dcc3b28e14228d59122ccd4b0933b */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_TimestampInterface_getTimestamp, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()

--- a/src/BSON/Timestamp_arginfo.h
+++ b/src/BSON/Timestamp_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3937f3fb9265b88474d71408bf3dc5323054a743 */
+ * Stub hash: 39cc2f31b3d2677c3f5d660502b7510b4e3335fa */
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_Timestamp___construct, 0, 0, 2)

--- a/src/BSON/Type.stub.php
+++ b/src/BSON/Type.stub.php
@@ -5,9 +5,8 @@
   * @generate-function-entries
   */
 
-namespace MongoDB\BSON
+namespace MongoDB\BSON;
+
+interface Type
 {
-    interface Type
-    {
-    }
 }

--- a/src/BSON/Type_arginfo.h
+++ b/src/BSON/Type_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 1cb5ddac5ec782a6ca7cd4c017a6b47084706a46 */
+ * Stub hash: d8ae2370dec489ad1f7433fb3ccf6debf10f2f71 */
 
 
 

--- a/src/BSON/UTCDateTime.stub.php
+++ b/src/BSON/UTCDateTime.stub.php
@@ -5,37 +5,36 @@
   * @generate-function-entries static
   */
 
-namespace MongoDB\BSON
+namespace MongoDB\BSON;
+
+final class UTCDateTime implements UTCDateTimeInterface, \JsonSerializable, Type, \Serializable
 {
-    final class UTCDateTime implements UTCDateTimeInterface, \JsonSerializable, Type, \Serializable
-    {
 #if PHP_VERSION_ID >= 80000
-        public final function __construct(int|string|float|\DateTimeInterface|null $milliseconds = null) {}
+    public final function __construct(int|string|float|\DateTimeInterface|null $milliseconds = null) {}
 #else
-        /** @param int|string|float|\DateTimeInterface|null $milliseconds */
-        public final function __construct($milliseconds = null) {}
+    /** @param int|string|float|\DateTimeInterface|null $milliseconds */
+    public final function __construct($milliseconds = null) {}
 #endif
 
-        public final function toDateTime(): \DateTime {}
+    public final function toDateTime(): \DateTime {}
 
-        public final function __toString(): string {}
+    public final function __toString(): string {}
 
-        public static function __set_state(array $properties): UTCDateTime {}
+    public static function __set_state(array $properties): UTCDateTime {}
 
-        final public function serialize(): string {}
+    final public function serialize(): string {}
 
-        /** @param string $serialized */
-        final public function unserialize($serialized): void {}
+    /** @param string $serialized */
+    final public function unserialize($serialized): void {}
 
-        final public function __unserialize(array $data): void {}
+    final public function __unserialize(array $data): void {}
 
-        final public function __serialize(): array {}
+    final public function __serialize(): array {}
 
 #if PHP_VERSION_ID >= 80000
-        final public function jsonSerialize(): mixed {}
+    final public function jsonSerialize(): mixed {}
 #else
-        /** @return mixed */
-        final public function jsonSerialize() {}
+    /** @return mixed */
+    final public function jsonSerialize() {}
 #endif
-    }
 }

--- a/src/BSON/UTCDateTimeInterface.stub.php
+++ b/src/BSON/UTCDateTimeInterface.stub.php
@@ -5,14 +5,13 @@
   * @generate-function-entries
   */
 
-namespace MongoDB\BSON
-{
-    interface UTCDateTimeInterface
-    {
-        /** @tentative-return-type */
-        public function toDateTime(): \DateTime;
+namespace MongoDB\BSON;
 
-        /** @tentative-return-type */
-        public function __toString(): string;
-    }
+interface UTCDateTimeInterface
+{
+    /** @tentative-return-type */
+    public function toDateTime(): \DateTime;
+
+    /** @tentative-return-type */
+    public function __toString(): string;
 }

--- a/src/BSON/UTCDateTimeInterface_arginfo.h
+++ b/src/BSON/UTCDateTimeInterface_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: c249307889b5e9cd4cab6449b9c8101fe6a7fc29 */
+ * Stub hash: c7562146623b30619f3fd3199e9318338451b5e4 */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_BSON_UTCDateTimeInterface_toDateTime, 0, 0, DateTime, 0)
 ZEND_END_ARG_INFO()

--- a/src/BSON/UTCDateTime_arginfo.h
+++ b/src/BSON/UTCDateTime_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 840ad5e10557cbc8d74bcd4c398581f69fd0b484 */
+ * Stub hash: 72a80de7cb8b38bd23411e39bf03444bba60d232 */
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_UTCDateTime___construct, 0, 0, 0)

--- a/src/BSON/Undefined.stub.php
+++ b/src/BSON/Undefined.stub.php
@@ -5,28 +5,27 @@
   * @generate-function-entries static
   */
 
-namespace MongoDB\BSON
+namespace MongoDB\BSON;
+
+final class Undefined implements \JsonSerializable, Type, \Serializable
 {
-    final class Undefined implements \JsonSerializable, Type, \Serializable
-    {
-        final private function __construct() {}
+    final private function __construct() {}
 
-        final public function __toString(): string {}
+    final public function __toString(): string {}
 
-        final public function serialize(): string {}
+    final public function serialize(): string {}
 
-        /** @param string $serialized */
-        final public function unserialize($serialized): void {}
+    /** @param string $serialized */
+    final public function unserialize($serialized): void {}
 
-        final public function __unserialize(array $data): void {}
+    final public function __unserialize(array $data): void {}
 
-        final public function __serialize(): array {}
+    final public function __serialize(): array {}
 
 #if PHP_VERSION_ID >= 80000
-        final public function jsonSerialize(): mixed {}
+    final public function jsonSerialize(): mixed {}
 #else
-        /** @return mixed */
-        final public function jsonSerialize() {}
+    /** @return mixed */
+    final public function jsonSerialize() {}
 #endif
-    }
 }

--- a/src/BSON/Undefined_arginfo.h
+++ b/src/BSON/Undefined_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 25ffea1990a4c900470860c9fe80eccbbc05df39 */
+ * Stub hash: 8219b902218d6d47481e7954b948b0e7ba7895ff */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_Undefined___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()

--- a/src/BSON/Unserializable.stub.php
+++ b/src/BSON/Unserializable.stub.php
@@ -5,11 +5,10 @@
   * @generate-function-entries
   */
 
-namespace MongoDB\BSON
+namespace MongoDB\BSON;
+
+interface Unserializable
 {
-    interface Unserializable
-    {
-        /** @tentative-return-type */
-        public function bsonUnserialize(array $data): void;
-    }
+    /** @tentative-return-type */
+    public function bsonUnserialize(array $data): void;
 }

--- a/src/BSON/Unserializable_arginfo.h
+++ b/src/BSON/Unserializable_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 30ba8f312b25c0ca61a8d13896d5d2282092da49 */
+ * Stub hash: d9d116df34766b1aa4ca0229c484d677b5a0991d */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Unserializable_bsonUnserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)


### PR DESCRIPTION
PHPC-2015

Follow-up to #1337, where I cleaned up formatting in all stub files but missed those in src/BSON. This commit rectifies this.