### PR TITLE
PHPC-2118: Test load-balanced on debian11

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1251,8 +1251,7 @@ buildvariants:
 
 # Load balancer is available from MongoDB 5.0+
 - matrix_name: "test-loadBalanced"
-  # TODO: Add MongoDB 6.0 and use Debian 11 once BUILD-15237 is resolved
-  matrix_spec: { "os": "debian92", "mongodb-versions": "5.0", "php-edge-versions": "latest-stable" }
+  matrix_spec: { "os": "debian11", "mongodb-versions": ["5.0", "6.0"], "php-edge-versions": "latest-stable" }
   display_name: "Load balanced - ${mongodb-versions}"
   tasks:
     - name: "test-loadBalanced"


### PR DESCRIPTION
PHPC-2118

Corresponding patch build: https://spruce.mongodb.com/version/62f35f4c3627e01ee6a79032/tasks