### PR TITLE
PHPC-1945: Remove class_exists checks from SKIPIF blocks in Decimal128 tests

### DIFF
--- a/tests/bson/bson-decimal128-001.phpt
+++ b/tests/bson/bson-decimal128-001.phpt
@@ -1,7 +1,5 @@
 --TEST--
 MongoDB\BSON\Decimal128
---SKIPIF--
-<?php if (!class_exists('MongoDB\BSON\Decimal128')) { die('skip MongoDB\BSON\Decimal128 is not available'); } ?>
 --FILE--
 <?php
 

--- a/tests/bson/bson-decimal128-002.phpt
+++ b/tests/bson/bson-decimal128-002.phpt
@@ -1,7 +1,5 @@
 --TEST--
 MongoDB\BSON\Decimal128 NaN values
---SKIPIF--
-<?php if (!class_exists('MongoDB\BSON\Decimal128')) { die('skip MongoDB\BSON\Decimal128 is not available'); } ?>
 --FILE--
 <?php
 

--- a/tests/bson/bson-decimal128-003.phpt
+++ b/tests/bson/bson-decimal128-003.phpt
@@ -1,7 +1,5 @@
 --TEST--
 MongoDB\BSON\Decimal128 Infinity values
---SKIPIF--
-<?php if (!class_exists('MongoDB\BSON\Decimal128')) { die('skip MongoDB\BSON\Decimal128 is not available'); } ?>
 --FILE--
 <?php
 

--- a/tests/bson/bson-decimal128-004.phpt
+++ b/tests/bson/bson-decimal128-004.phpt
@@ -1,7 +1,5 @@
 --TEST--
 MongoDB\BSON\Decimal128 debug handler
---SKIPIF--
-<?php if (!class_exists('MongoDB\BSON\Decimal128')) { die('skip MongoDB\BSON\Decimal128 is not available'); } ?>
 --FILE--
 <?php
 

--- a/tests/bson/bson-decimal128-clone-001.phpt
+++ b/tests/bson/bson-decimal128-clone-001.phpt
@@ -3,7 +3,6 @@ MongoDB\BSON\Decimal128 can be cloned (PHP < 8.2)
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_php_version('>=', '8.2'); ?>
-<?php if (!class_exists('MongoDB\BSON\Decimal128')) { die('skip MongoDB\BSON\Decimal128 is not available'); } ?>
 --FILE--
 <?php
 

--- a/tests/bson/bson-decimal128-clone-002.phpt
+++ b/tests/bson/bson-decimal128-clone-002.phpt
@@ -3,7 +3,6 @@ MongoDB\BSON\Decimal128 can be cloned (PHP >= 8.2)
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_php_version('<', '8.2'); ?>
-<?php if (!class_exists('MongoDB\BSON\Decimal128')) { die('skip MongoDB\BSON\Decimal128 is not available'); } ?>
 --FILE--
 <?php
 

--- a/tests/bson/bson-decimal128-get_properties-001.phpt
+++ b/tests/bson/bson-decimal128-get_properties-001.phpt
@@ -1,7 +1,5 @@
 --TEST--
 MongoDB\BSON\Decimal128 get_properties handler (get_object_vars)
---SKIPIF--
-<?php if (!class_exists('MongoDB\BSON\Decimal128')) { die('skip MongoDB\BSON\Decimal128 is not available'); } ?>
 --FILE--
 <?php
 

--- a/tests/bson/bson-decimal128-get_properties-002.phpt
+++ b/tests/bson/bson-decimal128-get_properties-002.phpt
@@ -1,7 +1,5 @@
 --TEST--
 MongoDB\BSON\Decimal128 get_properties handler (foreach)
---SKIPIF--
-<?php if (!class_exists('MongoDB\BSON\Decimal128')) { die('skip MongoDB\BSON\Decimal128 is not available'); } ?>
 --FILE--
 <?php
 

--- a/tests/bson/bson-decimal128-jsonserialize-001.phpt
+++ b/tests/bson/bson-decimal128-jsonserialize-001.phpt
@@ -1,7 +1,5 @@
 --TEST--
 MongoDB\BSON\Decimal128::jsonSerialize() return value
---SKIPIF--
-<?php if (!class_exists('MongoDB\BSON\Decimal128')) { die('skip MongoDB\BSON\Decimal128 is not available'); } ?>
 --FILE--
 <?php
 

--- a/tests/bson/bson-decimal128-jsonserialize-002.phpt
+++ b/tests/bson/bson-decimal128-jsonserialize-002.phpt
@@ -1,7 +1,5 @@
 --TEST--
 MongoDB\BSON\Decimal128::jsonSerialize() with json_encode()
---SKIPIF--
-<?php if (!class_exists('MongoDB\BSON\Decimal128')) { die('skip MongoDB\BSON\Decimal128 is not available'); } ?>
 --FILE--
 <?php
 

--- a/tests/bson/bson-decimal128-set_state-001.phpt
+++ b/tests/bson/bson-decimal128-set_state-001.phpt
@@ -1,7 +1,5 @@
 --TEST--
 MongoDB\BSON\Decimal128::__set_state()
---SKIPIF--
-<?php if (!class_exists('MongoDB\BSON\Decimal128')) { die('skip MongoDB\BSON\Decimal128 is not available'); } ?>
 --FILE--
 <?php
 

--- a/tests/bson/bson-decimal128-set_state_error-001.phpt
+++ b/tests/bson/bson-decimal128-set_state_error-001.phpt
@@ -1,7 +1,5 @@
 --TEST--
 MongoDB\BSON\Decimal128::__set_state() requires "dec" string field
---SKIPIF--
-<?php if (!class_exists('MongoDB\BSON\Decimal128')) { die('skip MongoDB\BSON\Decimal128 is not available'); } ?>
 --FILE--
 <?php
 

--- a/tests/bson/bson-decimal128-set_state_error-002.phpt
+++ b/tests/bson/bson-decimal128-set_state_error-002.phpt
@@ -1,7 +1,5 @@
 --TEST--
 MongoDB\BSON\Decimal128::__set_state() requires valid decimal string
---SKIPIF--
-<?php if (!class_exists('MongoDB\BSON\Decimal128')) { die('skip MongoDB\BSON\Decimal128 is not available'); } ?>
 --FILE--
 <?php
 

--- a/tests/bson/bson-decimal128_error-001.phpt
+++ b/tests/bson/bson-decimal128_error-001.phpt
@@ -3,7 +3,6 @@ MongoDB\BSON\Decimal128 requires valid decimal string
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_php_version('>=', '7.99'); ?>
-<?php if (!class_exists('MongoDB\BSON\Decimal128')) { die('skip MongoDB\BSON\Decimal128 is not available'); } ?>
 --FILE--
 <?php
 


### PR DESCRIPTION
Since Decimal128 is always available in current versions of the extension, these SKIPIFs should be removed.

[PHPC-1945](https://jira.mongodb.org/browse/PHPC-1945)