### PR TITLE
PHPC-2111: Update ZPP info to forbid explicit null for optional args

### DIFF
--- a/src/BSON/functions.c
+++ b/src/BSON/functions.c
@@ -60,7 +60,7 @@ PHP_FUNCTION(MongoDB_BSON_toPHP)
 	PHONGO_PARSE_PARAMETERS_START(1, 2)
 	Z_PARAM_STRING(data, data_len)
 	Z_PARAM_OPTIONAL
-	Z_PARAM_ARRAY_OR_NULL(typemap)
+	Z_PARAM_ARRAY(typemap)
 	PHONGO_PARSE_PARAMETERS_END();
 
 	if (!php_phongo_bson_typemap_to_state(typemap, &state.map)) {

--- a/src/MongoDB/BulkWrite.c
+++ b/src/MongoDB/BulkWrite.c
@@ -322,7 +322,7 @@ static PHP_METHOD(MongoDB_Driver_BulkWrite, __construct)
 
 	PHONGO_PARSE_PARAMETERS_START(0, 1)
 	Z_PARAM_OPTIONAL
-	Z_PARAM_ARRAY_OR_NULL(options)
+	Z_PARAM_ARRAY(options)
 	PHONGO_PARSE_PARAMETERS_END();
 
 	if (options && php_array_existsc(options, "ordered")) {
@@ -435,7 +435,7 @@ static PHP_METHOD(MongoDB_Driver_BulkWrite, update)
 	PHONGO_PARAM_ARRAY_OR_OBJECT(zquery)
 	PHONGO_PARAM_ARRAY_OR_OBJECT(zupdate)
 	Z_PARAM_OPTIONAL
-	Z_PARAM_ARRAY_OR_NULL(zoptions)
+	Z_PARAM_ARRAY(zoptions)
 	PHONGO_PARSE_PARAMETERS_END();
 
 	php_phongo_zval_to_bson(zquery, PHONGO_BSON_NONE, &bquery, NULL);
@@ -500,7 +500,7 @@ static PHP_METHOD(MongoDB_Driver_BulkWrite, delete)
 	PHONGO_PARSE_PARAMETERS_START(1, 2)
 	PHONGO_PARAM_ARRAY_OR_OBJECT(zquery)
 	Z_PARAM_OPTIONAL
-	Z_PARAM_ARRAY_OR_NULL(zoptions)
+	Z_PARAM_ARRAY(zoptions)
 	PHONGO_PARSE_PARAMETERS_END();
 
 	php_phongo_zval_to_bson(zquery, PHONGO_BSON_NONE, &bquery, NULL);

--- a/src/MongoDB/ClientEncryption.c
+++ b/src/MongoDB/ClientEncryption.c
@@ -65,7 +65,7 @@ static PHP_METHOD(MongoDB_Driver_ClientEncryption, createDataKey)
 	PHONGO_PARSE_PARAMETERS_START(1, 2)
 	Z_PARAM_STRING(kms_provider, kms_provider_len)
 	Z_PARAM_OPTIONAL
-	Z_PARAM_ARRAY_OR_NULL(options)
+	Z_PARAM_ARRAY(options)
 	PHONGO_PARSE_PARAMETERS_END();
 
 	phongo_clientencryption_create_datakey(intern, return_value, kms_provider, options);
@@ -84,7 +84,7 @@ static PHP_METHOD(MongoDB_Driver_ClientEncryption, encrypt)
 	PHONGO_PARSE_PARAMETERS_START(1, 2)
 	Z_PARAM_ZVAL(value)
 	Z_PARAM_OPTIONAL
-	Z_PARAM_ARRAY_OR_NULL(options)
+	Z_PARAM_ARRAY(options)
 	PHONGO_PARSE_PARAMETERS_END();
 
 	phongo_clientencryption_encrypt(intern, value, return_value, options);

--- a/src/MongoDB/Command.c
+++ b/src/MongoDB/Command.c
@@ -110,7 +110,7 @@ static PHP_METHOD(MongoDB_Driver_Command, __construct)
 	PHONGO_PARSE_PARAMETERS_START(1, 2)
 	PHONGO_PARAM_ARRAY_OR_OBJECT(document)
 	Z_PARAM_OPTIONAL
-	Z_PARAM_ARRAY_OR_NULL(options)
+	Z_PARAM_ARRAY(options)
 	PHONGO_PARSE_PARAMETERS_END();
 
 	php_phongo_command_init(intern, document, options);

--- a/src/MongoDB/Cursor.c
+++ b/src/MongoDB/Cursor.c
@@ -67,7 +67,7 @@ static PHP_METHOD(MongoDB_Driver_Cursor, setTypeMap)
 	intern = Z_CURSOR_OBJ_P(getThis());
 
 	PHONGO_PARSE_PARAMETERS_START(1, 1)
-	Z_PARAM_ARRAY_OR_NULL(typemap)
+	Z_PARAM_ARRAY(typemap)
 	PHONGO_PARSE_PARAMETERS_END();
 
 	if (!php_phongo_bson_typemap_to_state(typemap, &state.map)) {

--- a/src/MongoDB/Manager.c
+++ b/src/MongoDB/Manager.c
@@ -262,8 +262,8 @@ static PHP_METHOD(MongoDB_Driver_Manager, __construct)
 	PHONGO_PARSE_PARAMETERS_START(0, 3)
 	Z_PARAM_OPTIONAL
 	Z_PARAM_STRING_OR_NULL(uri_string, uri_string_len)
-	Z_PARAM_ARRAY_EX(options, 1, 1)
-	Z_PARAM_ARRAY_EX(driverOptions, 1, 1)
+	Z_PARAM_ARRAY_EX(options, 0, 1)
+	Z_PARAM_ARRAY_EX(driverOptions, 0, 1)
 	PHONGO_PARSE_PARAMETERS_END();
 
 	if (options) {
@@ -340,10 +340,10 @@ static PHP_METHOD(MongoDB_Driver_Manager, executeCommand)
 	uint32_t              server_id       = 0;
 
 	PHONGO_PARSE_PARAMETERS_START(2, 3)
-	Z_PARAM_STRING_OR_NULL(db, db_len)
+	Z_PARAM_STRING(db, db_len)
 	Z_PARAM_OBJECT_OF_CLASS(command, php_phongo_command_ce)
 	Z_PARAM_OPTIONAL
-	Z_PARAM_ZVAL_OR_NULL(options)
+	Z_PARAM_ZVAL(options)
 	PHONGO_PARSE_PARAMETERS_END();
 
 	intern = Z_MANAGER_OBJ_P(getThis());
@@ -392,10 +392,10 @@ static PHP_METHOD(MongoDB_Driver_Manager, executeReadCommand)
 	zval*                 zsession        = NULL;
 
 	PHONGO_PARSE_PARAMETERS_START(2, 3)
-	Z_PARAM_STRING_OR_NULL(db, db_len)
+	Z_PARAM_STRING(db, db_len)
 	Z_PARAM_OBJECT_OF_CLASS(command, php_phongo_command_ce)
 	Z_PARAM_OPTIONAL
-	Z_PARAM_ARRAY_OR_NULL(options)
+	Z_PARAM_ARRAY(options)
 	PHONGO_PARSE_PARAMETERS_END();
 
 	intern = Z_MANAGER_OBJ_P(getThis());
@@ -436,10 +436,10 @@ static PHP_METHOD(MongoDB_Driver_Manager, executeWriteCommand)
 	zval*                 zsession  = NULL;
 
 	PHONGO_PARSE_PARAMETERS_START(2, 3)
-	Z_PARAM_STRING_OR_NULL(db, db_len)
+	Z_PARAM_STRING(db, db_len)
 	Z_PARAM_OBJECT_OF_CLASS(command, php_phongo_command_ce)
 	Z_PARAM_OPTIONAL
-	Z_PARAM_ARRAY_OR_NULL(options)
+	Z_PARAM_ARRAY(options)
 	PHONGO_PARSE_PARAMETERS_END();
 
 	intern = Z_MANAGER_OBJ_P(getThis());
@@ -475,10 +475,10 @@ static PHP_METHOD(MongoDB_Driver_Manager, executeReadWriteCommand)
 	zval*                 zsession  = NULL;
 
 	PHONGO_PARSE_PARAMETERS_START(2, 3)
-	Z_PARAM_STRING_OR_NULL(db, db_len)
+	Z_PARAM_STRING(db, db_len)
 	Z_PARAM_OBJECT_OF_CLASS(command, php_phongo_command_ce)
 	Z_PARAM_OPTIONAL
-	Z_PARAM_ARRAY_OR_NULL(options)
+	Z_PARAM_ARRAY(options)
 	PHONGO_PARSE_PARAMETERS_END();
 
 	intern = Z_MANAGER_OBJ_P(getThis());
@@ -516,10 +516,10 @@ static PHP_METHOD(MongoDB_Driver_Manager, executeQuery)
 	zval*    zsession        = NULL;
 
 	PHONGO_PARSE_PARAMETERS_START(2, 3)
-	Z_PARAM_STRING_OR_NULL(namespace, namespace_len)
+	Z_PARAM_STRING(namespace, namespace_len)
 	Z_PARAM_OBJECT_OF_CLASS(query, php_phongo_query_ce)
 	Z_PARAM_OPTIONAL
-	Z_PARAM_ZVAL_OR_NULL(options)
+	Z_PARAM_ZVAL(options)
 	PHONGO_PARSE_PARAMETERS_END();
 
 	intern = Z_MANAGER_OBJ_P(getThis());
@@ -569,10 +569,10 @@ static PHP_METHOD(MongoDB_Driver_Manager, executeBulkWrite)
 	zval*                   zsession     = NULL;
 
 	PHONGO_PARSE_PARAMETERS_START(2, 3)
-	Z_PARAM_STRING_OR_NULL(namespace, namespace_len)
+	Z_PARAM_STRING(namespace, namespace_len)
 	Z_PARAM_OBJECT_OF_CLASS(zbulk, php_phongo_bulkwrite_ce)
 	Z_PARAM_OPTIONAL
-	Z_PARAM_ZVAL_OR_NULL(options)
+	Z_PARAM_ZVAL(options)
 	PHONGO_PARSE_PARAMETERS_END();
 
 	intern = Z_MANAGER_OBJ_P(getThis());
@@ -740,7 +740,7 @@ static PHP_METHOD(MongoDB_Driver_Manager, startSession)
 
 	PHONGO_PARSE_PARAMETERS_START(0, 1)
 	Z_PARAM_OPTIONAL
-	Z_PARAM_ARRAY_OR_NULL(options)
+	Z_PARAM_ARRAY(options)
 	PHONGO_PARSE_PARAMETERS_END();
 
 	if (options && php_array_existsc(options, "causalConsistency")) {

--- a/src/MongoDB/Manager.stub.php
+++ b/src/MongoDB/Manager.stub.php
@@ -9,31 +9,31 @@ namespace MongoDB\Driver;
 
 final class Manager
 {
-    final public function __construct(?string $uri = null, ?array $uriOptions = null, ?array $driverOptions = null) {}
+    final public function __construct(?string $uri = null, array $uriOptions = [], array $driverOptions = []) {}
 
     final public function addSubscriber(Monitoring\Subscriber $subscriber): void {}
 
     final public function createClientEncryption(array $options): ClientEncryption {}
 
 #if PHP_VERSION_ID >= 80000
-    final public function executeBulkWrite(string $namespace, BulkWrite $bulk, array|WriteConcern|null $options = null): WriteResult {}
+    final public function executeBulkWrite(string $namespace, BulkWrite $bulk, array|WriteConcern $options = []): WriteResult {}
 #else
-    /** @param array|WriteConcern|null $options */
-    final public function executeBulkWrite(string $namespace, BulkWrite $bulk, $options = null): WriteResult {}
+    /** @param array|WriteConcern $options */
+    final public function executeBulkWrite(string $namespace, BulkWrite $bulk, $options = []): WriteResult {}
 #endif
 
 #if PHP_VERSION_ID >= 80000
-    final public function executeCommand(string $db, Command $command, array|ReadPreference|null $options = null): Cursor {}
+    final public function executeCommand(string $db, Command $command, array|ReadPreference $options = []): Cursor {}
 #else
-    /** @param array|ReadPreference|null $options */
-    final public function executeCommand(string $db, Command $command, $options = null): Cursor {}
+    /** @param array|ReadPreference $options */
+    final public function executeCommand(string $db, Command $command, $options = []): Cursor {}
 #endif
 
 #if PHP_VERSION_ID >= 80000
-    final public function executeQuery(string $namespace, Query $query, array|ReadPreference|null $options = null): Cursor {}
+    final public function executeQuery(string $namespace, Query $query, array|ReadPreference $options = []): Cursor {}
 #else
-    /** @param array|ReadPreference|null $options */
-    final public function executeQuery(string $namespace, Query $query, $options = null): Cursor {}
+    /** @param array|ReadPreference $options */
+    final public function executeQuery(string $namespace, Query $query, $options = []): Cursor {}
 #endif
 
     final public function executeReadCommand(string $db, Command $command, array $options = []): Cursor {}

--- a/src/MongoDB/Manager_arginfo.h
+++ b/src/MongoDB/Manager_arginfo.h
@@ -1,10 +1,10 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 516a26c70864397ba986d9855f4f876fe84bceb9 */
+ * Stub hash: 83bce26a74730a7af6a0f04a84061ba6093737f0 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Manager___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, uri, IS_STRING, 1, "null")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, uriOptions, IS_ARRAY, 1, "null")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, driverOptions, IS_ARRAY, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, uriOptions, IS_ARRAY, 0, "[]")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, driverOptions, IS_ARRAY, 0, "[]")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Manager_addSubscriber, 0, 1, IS_VOID, 0)
@@ -19,7 +19,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Manager_executeBulkWrite, 0, 2, MongoDB\\Driver\\WriteResult, 0)
 	ZEND_ARG_TYPE_INFO(0, namespace, IS_STRING, 0)
 	ZEND_ARG_OBJ_INFO(0, bulk, MongoDB\\Driver\\BulkWrite, 0)
-	ZEND_ARG_OBJ_TYPE_MASK(0, options, MongoDB\\Driver\\WriteConcern, MAY_BE_ARRAY|MAY_BE_NULL, "null")
+	ZEND_ARG_OBJ_TYPE_MASK(0, options, MongoDB\\Driver\\WriteConcern, MAY_BE_ARRAY, "[]")
 ZEND_END_ARG_INFO()
 #endif
 
@@ -27,7 +27,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Manager_executeBulkWrite, 0, 2, MongoDB\\Driver\\WriteResult, 0)
 	ZEND_ARG_TYPE_INFO(0, namespace, IS_STRING, 0)
 	ZEND_ARG_OBJ_INFO(0, bulk, MongoDB\\Driver\\BulkWrite, 0)
-	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, options, "null")
+	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, options, "[]")
 ZEND_END_ARG_INFO()
 #endif
 
@@ -35,7 +35,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Manager_executeCommand, 0, 2, MongoDB\\Driver\\Cursor, 0)
 	ZEND_ARG_TYPE_INFO(0, db, IS_STRING, 0)
 	ZEND_ARG_OBJ_INFO(0, command, MongoDB\\Driver\\Command, 0)
-	ZEND_ARG_OBJ_TYPE_MASK(0, options, MongoDB\\Driver\\ReadPreference, MAY_BE_ARRAY|MAY_BE_NULL, "null")
+	ZEND_ARG_OBJ_TYPE_MASK(0, options, MongoDB\\Driver\\ReadPreference, MAY_BE_ARRAY, "[]")
 ZEND_END_ARG_INFO()
 #endif
 
@@ -43,7 +43,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Manager_executeCommand, 0, 2, MongoDB\\Driver\\Cursor, 0)
 	ZEND_ARG_TYPE_INFO(0, db, IS_STRING, 0)
 	ZEND_ARG_OBJ_INFO(0, command, MongoDB\\Driver\\Command, 0)
-	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, options, "null")
+	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, options, "[]")
 ZEND_END_ARG_INFO()
 #endif
 
@@ -51,7 +51,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Manager_executeQuery, 0, 2, MongoDB\\Driver\\Cursor, 0)
 	ZEND_ARG_TYPE_INFO(0, namespace, IS_STRING, 0)
 	ZEND_ARG_OBJ_INFO(0, query, MongoDB\\Driver\\Query, 0)
-	ZEND_ARG_OBJ_TYPE_MASK(0, options, MongoDB\\Driver\\ReadPreference, MAY_BE_ARRAY|MAY_BE_NULL, "null")
+	ZEND_ARG_OBJ_TYPE_MASK(0, options, MongoDB\\Driver\\ReadPreference, MAY_BE_ARRAY, "[]")
 ZEND_END_ARG_INFO()
 #endif
 
@@ -59,7 +59,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Manager_executeQuery, 0, 2, MongoDB\\Driver\\Cursor, 0)
 	ZEND_ARG_TYPE_INFO(0, namespace, IS_STRING, 0)
 	ZEND_ARG_OBJ_INFO(0, query, MongoDB\\Driver\\Query, 0)
-	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, options, "null")
+	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, options, "[]")
 ZEND_END_ARG_INFO()
 #endif
 

--- a/src/MongoDB/Query.c
+++ b/src/MongoDB/Query.c
@@ -403,7 +403,7 @@ static PHP_METHOD(MongoDB_Driver_Query, __construct)
 	PHONGO_PARSE_PARAMETERS_START(1, 2)
 	PHONGO_PARAM_ARRAY_OR_OBJECT(filter)
 	Z_PARAM_OPTIONAL
-	Z_PARAM_ARRAY_OR_NULL(options)
+	Z_PARAM_ARRAY(options)
 	PHONGO_PARSE_PARAMETERS_END();
 
 	php_phongo_query_init(intern, filter, options);

--- a/src/MongoDB/ReadPreference.c
+++ b/src/MongoDB/ReadPreference.c
@@ -192,7 +192,7 @@ static PHP_METHOD(MongoDB_Driver_ReadPreference, __construct)
 	Z_PARAM_ZVAL(mode)
 	Z_PARAM_OPTIONAL
 	Z_PARAM_ARRAY_EX(tagSets, 1, 1)
-	Z_PARAM_ARRAY_OR_NULL(options)
+	Z_PARAM_ARRAY(options)
 	PHONGO_PARSE_PARAMETERS_END();
 
 	if (Z_TYPE_P(mode) == IS_LONG) {

--- a/src/MongoDB/ReadPreference.stub.php
+++ b/src/MongoDB/ReadPreference.stub.php
@@ -82,10 +82,10 @@ final class ReadPreference implements \MongoDB\BSON\Serializable, \Serializable
     public const SMALLEST_MAX_STALENESS_SECONDS = UNKNOWN;
 
 #if PHP_VERSION_ID >= 80000
-    final public function __construct(string|int $mode, ?array $tagSets = null, ?array $options = null) {}
+    final public function __construct(string|int $mode, ?array $tagSets = [], array $options = []) {}
 #else
     /** @param string|int $mode */
-    final public function __construct($mode, ?array $tagSets = null, ?array $options = null) {}
+    final public function __construct($mode, ?array $tagSets = [], array $options = []) {}
 #endif
 
     final public function getHedge(): ?object {}

--- a/src/MongoDB/ReadPreference_arginfo.h
+++ b/src/MongoDB/ReadPreference_arginfo.h
@@ -1,19 +1,19 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: ed8a570b0c805aec5562830088257ff92068a721 */
+ * Stub hash: 220449250c143480bc7278468a26a45f1733fb35 */
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_ReadPreference___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_MASK(0, mode, MAY_BE_STRING|MAY_BE_LONG, NULL)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, tagSets, IS_ARRAY, 1, "null")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, tagSets, IS_ARRAY, 1, "[]")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 0, "[]")
 ZEND_END_ARG_INFO()
 #endif
 
 #if !(PHP_VERSION_ID >= 80000)
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_ReadPreference___construct, 0, 0, 1)
 	ZEND_ARG_INFO(0, mode)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, tagSets, IS_ARRAY, 1, "null")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, tagSets, IS_ARRAY, 1, "[]")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 0, "[]")
 ZEND_END_ARG_INFO()
 #endif
 

--- a/src/MongoDB/Server.c
+++ b/src/MongoDB/Server.c
@@ -53,7 +53,7 @@ static PHP_METHOD(MongoDB_Driver_Server, executeCommand)
 	Z_PARAM_STRING(db, db_len)
 	Z_PARAM_OBJECT_OF_CLASS(command, php_phongo_command_ce)
 	Z_PARAM_OPTIONAL
-	Z_PARAM_ZVAL_OR_NULL(options)
+	Z_PARAM_ZVAL(options)
 	PHONGO_PARSE_PARAMETERS_END();
 
 	options = php_phongo_prep_legacy_option(options, "readPreference", &free_options);
@@ -86,7 +86,7 @@ static PHP_METHOD(MongoDB_Driver_Server, executeReadCommand)
 	Z_PARAM_STRING(db, db_len)
 	Z_PARAM_OBJECT_OF_CLASS(command, php_phongo_command_ce)
 	Z_PARAM_OPTIONAL
-	Z_PARAM_ARRAY_OR_NULL(options)
+	Z_PARAM_ARRAY(options)
 	PHONGO_PARSE_PARAMETERS_END();
 
 	/* If the Server was created in a different process, reset the client so
@@ -113,7 +113,7 @@ static PHP_METHOD(MongoDB_Driver_Server, executeWriteCommand)
 	Z_PARAM_STRING(db, db_len)
 	Z_PARAM_OBJECT_OF_CLASS(command, php_phongo_command_ce)
 	Z_PARAM_OPTIONAL
-	Z_PARAM_ARRAY_OR_NULL(options)
+	Z_PARAM_ARRAY(options)
 	PHONGO_PARSE_PARAMETERS_END();
 
 	/* If the Server was created in a different process, reset the client so
@@ -140,7 +140,7 @@ static PHP_METHOD(MongoDB_Driver_Server, executeReadWriteCommand)
 	Z_PARAM_STRING(db, db_len)
 	Z_PARAM_OBJECT_OF_CLASS(command, php_phongo_command_ce)
 	Z_PARAM_OPTIONAL
-	Z_PARAM_ARRAY_OR_NULL(options)
+	Z_PARAM_ARRAY(options)
 	PHONGO_PARSE_PARAMETERS_END();
 
 	/* If the Server was created in a different process, reset the client so
@@ -168,7 +168,7 @@ static PHP_METHOD(MongoDB_Driver_Server, executeQuery)
 	Z_PARAM_STRING(namespace, namespace_len)
 	Z_PARAM_OBJECT_OF_CLASS(query, php_phongo_query_ce)
 	Z_PARAM_OPTIONAL
-	Z_PARAM_ZVAL_OR_NULL(options)
+	Z_PARAM_ZVAL(options)
 	PHONGO_PARSE_PARAMETERS_END();
 
 	options = php_phongo_prep_legacy_option(options, "readPreference", &free_options);
@@ -204,7 +204,7 @@ static PHP_METHOD(MongoDB_Driver_Server, executeBulkWrite)
 	Z_PARAM_STRING(namespace, namespace_len)
 	Z_PARAM_OBJECT_OF_CLASS(zbulk, php_phongo_bulkwrite_ce)
 	Z_PARAM_OPTIONAL
-	Z_PARAM_ZVAL_OR_NULL(options)
+	Z_PARAM_ZVAL(options)
 	PHONGO_PARSE_PARAMETERS_END();
 
 	bulk = Z_BULKWRITE_OBJ_P(zbulk);

--- a/src/MongoDB/Server.stub.php
+++ b/src/MongoDB/Server.stub.php
@@ -72,24 +72,24 @@ final class Server
     final private function __construct() {}
 
 #if PHP_VERSION_ID >= 80000
-    final public function executeBulkWrite(string $namespace, BulkWrite $bulkWrite, array|WriteConcern|null $options = null): WriteResult {}
+    final public function executeBulkWrite(string $namespace, BulkWrite $bulkWrite, array|WriteConcern $options = []): WriteResult {}
 #else
-    /** @param array|WriteConcern|null $options */
-    final public function executeBulkWrite(string $namespace, BulkWrite $bulkWrite, $options = null): WriteResult {}
+    /** @param array|WriteConcern $options */
+    final public function executeBulkWrite(string $namespace, BulkWrite $bulkWrite, $options = []): WriteResult {}
 #endif
 
 #if PHP_VERSION_ID >= 80000
-    final public function executeCommand(string $db, Command $command, array|ReadPreference|null $options = null): Cursor {}
+    final public function executeCommand(string $db, Command $command, array|ReadPreference $options = []): Cursor {}
 #else
-    /** @param array|ReadPreference|null $options */
-    final public function executeCommand(string $db, Command $command, $options = null): Cursor {}
+    /** @param array|ReadPreference $options */
+    final public function executeCommand(string $db, Command $command, $options = []): Cursor {}
 #endif
 
 #if PHP_VERSION_ID >= 80000
-    final public function executeQuery(string $namespace, Query $query, array|ReadPreference|null $options = null): Cursor {}
+    final public function executeQuery(string $namespace, Query $query, array|ReadPreference $options = []): Cursor {}
 #else
-    /** @param array|ReadPreference|null $options */
-    final public function executeQuery(string $namespace, Query $query, $options = null): Cursor {}
+    /** @param array|ReadPreference $options */
+    final public function executeQuery(string $namespace, Query $query, $options = []): Cursor {}
 #endif
 
     final public function executeReadCommand(string $db, Command $command, array $options = []): Cursor {}

--- a/src/MongoDB/Server_arginfo.h
+++ b/src/MongoDB/Server_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8c4e8b2bd6a1a5b0047a69ea3cd79399aa474a05 */
+ * Stub hash: daf818269c1954ae112bfa5144e01d187c8bd09b */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Server___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -8,7 +8,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Server_executeBulkWrite, 0, 2, MongoDB\\Driver\\WriteResult, 0)
 	ZEND_ARG_TYPE_INFO(0, namespace, IS_STRING, 0)
 	ZEND_ARG_OBJ_INFO(0, bulkWrite, MongoDB\\Driver\\BulkWrite, 0)
-	ZEND_ARG_OBJ_TYPE_MASK(0, options, MongoDB\\Driver\\WriteConcern, MAY_BE_ARRAY|MAY_BE_NULL, "null")
+	ZEND_ARG_OBJ_TYPE_MASK(0, options, MongoDB\\Driver\\WriteConcern, MAY_BE_ARRAY, "[]")
 ZEND_END_ARG_INFO()
 #endif
 
@@ -16,7 +16,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Server_executeBulkWrite, 0, 2, MongoDB\\Driver\\WriteResult, 0)
 	ZEND_ARG_TYPE_INFO(0, namespace, IS_STRING, 0)
 	ZEND_ARG_OBJ_INFO(0, bulkWrite, MongoDB\\Driver\\BulkWrite, 0)
-	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, options, "null")
+	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, options, "[]")
 ZEND_END_ARG_INFO()
 #endif
 
@@ -24,7 +24,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Server_executeCommand, 0, 2, MongoDB\\Driver\\Cursor, 0)
 	ZEND_ARG_TYPE_INFO(0, db, IS_STRING, 0)
 	ZEND_ARG_OBJ_INFO(0, command, MongoDB\\Driver\\Command, 0)
-	ZEND_ARG_OBJ_TYPE_MASK(0, options, MongoDB\\Driver\\ReadPreference, MAY_BE_ARRAY|MAY_BE_NULL, "null")
+	ZEND_ARG_OBJ_TYPE_MASK(0, options, MongoDB\\Driver\\ReadPreference, MAY_BE_ARRAY, "[]")
 ZEND_END_ARG_INFO()
 #endif
 
@@ -32,7 +32,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Server_executeCommand, 0, 2, MongoDB\\Driver\\Cursor, 0)
 	ZEND_ARG_TYPE_INFO(0, db, IS_STRING, 0)
 	ZEND_ARG_OBJ_INFO(0, command, MongoDB\\Driver\\Command, 0)
-	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, options, "null")
+	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, options, "[]")
 ZEND_END_ARG_INFO()
 #endif
 
@@ -40,7 +40,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Server_executeQuery, 0, 2, MongoDB\\Driver\\Cursor, 0)
 	ZEND_ARG_TYPE_INFO(0, namespace, IS_STRING, 0)
 	ZEND_ARG_OBJ_INFO(0, query, MongoDB\\Driver\\Query, 0)
-	ZEND_ARG_OBJ_TYPE_MASK(0, options, MongoDB\\Driver\\ReadPreference, MAY_BE_ARRAY|MAY_BE_NULL, "null")
+	ZEND_ARG_OBJ_TYPE_MASK(0, options, MongoDB\\Driver\\ReadPreference, MAY_BE_ARRAY, "[]")
 ZEND_END_ARG_INFO()
 #endif
 
@@ -48,7 +48,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Server_executeQuery, 0, 2, MongoDB\\Driver\\Cursor, 0)
 	ZEND_ARG_TYPE_INFO(0, namespace, IS_STRING, 0)
 	ZEND_ARG_OBJ_INFO(0, query, MongoDB\\Driver\\Query, 0)
-	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, options, "null")
+	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, options, "[]")
 ZEND_END_ARG_INFO()
 #endif
 

--- a/src/MongoDB/Session.c
+++ b/src/MongoDB/Session.c
@@ -456,7 +456,7 @@ static PHP_METHOD(MongoDB_Driver_Session, startTransaction)
 
 	PHONGO_PARSE_PARAMETERS_START(0, 1)
 	Z_PARAM_OPTIONAL
-	Z_PARAM_ARRAY_OR_NULL(options)
+	Z_PARAM_ARRAY(options)
 	PHONGO_PARSE_PARAMETERS_END();
 
 	if (options) {

--- a/src/MongoDB/Session.stub.php
+++ b/src/MongoDB/Session.stub.php
@@ -72,7 +72,7 @@ final class Session
 
     final public function isInTransaction(): bool {}
 
-    final public function startTransaction(?array $options = []): void {}
+    final public function startTransaction(array $options = []): void {}
 
     final public function __wakeup(): void {}
 }

--- a/src/MongoDB/Session_arginfo.h
+++ b/src/MongoDB/Session_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: fbf742d6b12a1bf6e04201a81b08e3b26b8e261c */
+ * Stub hash: 89590ea11ca0d5a4f60fe36bb53813cdcbe418d7 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Session___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -51,7 +51,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_MongoDB_Driver_Session_isInTransaction arginfo_class_MongoDB_Driver_Session_isDirty
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Session_startTransaction, 0, 0, IS_VOID, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "[]")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 0, "[]")
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_MongoDB_Driver_Session___wakeup arginfo_class_MongoDB_Driver_Session_abortTransaction


### PR DESCRIPTION
PHPC-2111, also PHPC-2015

While working on the documentation, I noticed that a number of optional arguments were changed to also allow explicit `null` values. This PR undoes this, cleaning up the methods in the process. In some cases this also led to changes in the stub files, but in many cases the stub file already didn't declare the argument nullable, so allowing `null` while parsing parameters was definitely wrong.