### PR TITLE
PHPC-2124: Ensure that null is still accepted for optional parameters

### DIFF
--- a/src/BSON/Decimal128.stub.php
+++ b/src/BSON/Decimal128.stub.php
@@ -9,7 +9,7 @@ namespace MongoDB\BSON;
 
 final class Decimal128 implements Decimal128Interface, \JsonSerializable, Type, \Serializable
 {
-    final public function __construct(string $value = '') {}
+    final public function __construct(string $value) {}
 
     final public function __toString(): string {}
 

--- a/src/BSON/Decimal128_arginfo.h
+++ b/src/BSON/Decimal128_arginfo.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 9481dbe518648d2d64cce460c6c5d73ce9df5c6c */
+ * Stub hash: be5acdbf8df3109c3c50f10bbd1ab8b4e96875e6 */
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_Decimal128___construct, 0, 0, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, value, IS_STRING, 0, "\'\'")
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_Decimal128___construct, 0, 0, 1)
+	ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Decimal128___toString, 0, 0, IS_STRING, 0)

--- a/src/MongoDB/BulkWrite.stub.php
+++ b/src/MongoDB/BulkWrite.stub.php
@@ -9,15 +9,15 @@ namespace MongoDB\Driver;
 
 final class BulkWrite implements \Countable
 {
-    public final function __construct(array $options = []) {}
+    public final function __construct(?array $options = null) {}
 
     public function count(): int {}
 
 #if PHP_VERSION_ID >= 80000
-    public function delete(array|object $filter, array $deleteOptions = []): void {}
+    public function delete(array|object $filter, ?array $deleteOptions = null): void {}
 #else
     /** @param array|object $filter */
-    public function delete($filter, array $deleteOptions = []): void {}
+    public function delete($filter, ?array $deleteOptions = null): void {}
 #endif
 
 #if PHP_VERSION_ID >= 80000
@@ -31,13 +31,13 @@ final class BulkWrite implements \Countable
 #endif
 
 #if PHP_VERSION_ID >= 80000
-    public function update(array|object $filter, array|object $newObj, array $updateOptions = []): void {}
+    public function update(array|object $filter, array|object $newObj, ?array $updateOptions = null): void {}
 #else
     /**
      * @param array|object $filter
      * @param array|object $newObj
      */
-    public function update($filter, $newObj, array $updateOptions = []): void {}
+    public function update($filter, $newObj, ?array $updateOptions = null): void {}
 #endif
 
     final public function __wakeup(): void {}

--- a/src/MongoDB/BulkWrite_arginfo.h
+++ b/src/MongoDB/BulkWrite_arginfo.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3325b767b4321a1837fa7a8aef924a39e6e6816d */
+ * Stub hash: 179d375c7c122723254e7b19dd97f8ef33caf38c */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_BulkWrite___construct, 0, 0, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 0, "[]")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_BulkWrite_count, 0, 0, IS_LONG, 0)
@@ -11,14 +11,14 @@ ZEND_END_ARG_INFO()
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_BulkWrite_delete, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_MASK(0, filter, MAY_BE_ARRAY|MAY_BE_OBJECT, NULL)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, deleteOptions, IS_ARRAY, 0, "[]")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, deleteOptions, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 #endif
 
 #if !(PHP_VERSION_ID >= 80000)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_BulkWrite_delete, 0, 1, IS_VOID, 0)
 	ZEND_ARG_INFO(0, filter)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, deleteOptions, IS_ARRAY, 0, "[]")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, deleteOptions, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 #endif
 
@@ -38,7 +38,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_BulkWrite_update, 0, 2, IS_VOID, 0)
 	ZEND_ARG_TYPE_MASK(0, filter, MAY_BE_ARRAY|MAY_BE_OBJECT, NULL)
 	ZEND_ARG_TYPE_MASK(0, newObj, MAY_BE_ARRAY|MAY_BE_OBJECT, NULL)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, updateOptions, IS_ARRAY, 0, "[]")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, updateOptions, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 #endif
 
@@ -46,7 +46,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_BulkWrite_update, 0, 2, IS_VOID, 0)
 	ZEND_ARG_INFO(0, filter)
 	ZEND_ARG_INFO(0, newObj)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, updateOptions, IS_ARRAY, 0, "[]")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, updateOptions, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 #endif
 

--- a/src/MongoDB/ClientEncryption.stub.php
+++ b/src/MongoDB/ClientEncryption.stub.php
@@ -41,7 +41,7 @@ final class ClientEncryption
 
     final public function __construct(array $options) {}
 
-    final public function createDataKey(string $kmsProvider, array $options = []): \MongoDB\BSON\Binary {}
+    final public function createDataKey(string $kmsProvider, ?array $options = null): \MongoDB\BSON\Binary {}
 
 #if PHP_VERSION_ID >= 80000
     final public function decrypt(\MongoDB\BSON\Binary $value): mixed {}
@@ -51,10 +51,10 @@ final class ClientEncryption
 #endif
 
 #if PHP_VERSION_ID >= 80000
-    final public function encrypt(mixed $value, array $options = []): \MongoDB\BSON\Binary {}
+    final public function encrypt(mixed $value, ?array $options = null): \MongoDB\BSON\Binary {}
 #else
     /** @param mixed $value */
-    final public function encrypt($value, array $options = []): \MongoDB\BSON\Binary {}
+    final public function encrypt($value, ?array $options = null): \MongoDB\BSON\Binary {}
 #endif
 
     final public function __wakeup(): void {}

--- a/src/MongoDB/ClientEncryption_arginfo.h
+++ b/src/MongoDB/ClientEncryption_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 169e941e986be2158c89ddba5d5f930cb8fa6bfe */
+ * Stub hash: 09ec24f8af5aba4c88dc3ee4bcc77022d7cc0b9c */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_ClientEncryption___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, options, IS_ARRAY, 0)
@@ -7,7 +7,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_ClientEncryption_createDataKey, 0, 1, MongoDB\\BSON\\Binary, 0)
 	ZEND_ARG_TYPE_INFO(0, kmsProvider, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 0, "[]")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 
 #if PHP_VERSION_ID >= 80000
@@ -25,14 +25,14 @@ ZEND_END_ARG_INFO()
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_ClientEncryption_encrypt, 0, 1, MongoDB\\BSON\\Binary, 0)
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 0, "[]")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 #endif
 
 #if !(PHP_VERSION_ID >= 80000)
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_ClientEncryption_encrypt, 0, 1, MongoDB\\BSON\\Binary, 0)
 	ZEND_ARG_INFO(0, value)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 0, "[]")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 #endif
 

--- a/src/MongoDB/Command.stub.php
+++ b/src/MongoDB/Command.stub.php
@@ -10,10 +10,10 @@ namespace MongoDB\Driver;
 final class Command
 {
 #if PHP_VERSION_ID >= 80000
-    final public function __construct(array|object $document, array $commandOptions = []) {}
+    final public function __construct(array|object $document, ?array $commandOptions = null) {}
 #else
     /** @param array|object $document */
-    final public function __construct($document, array $commandOptions = []) {}
+    final public function __construct($document, ?array $commandOptions = null) {}
 #endif
 
     final public function __wakeup(): void {}

--- a/src/MongoDB/Command_arginfo.h
+++ b/src/MongoDB/Command_arginfo.h
@@ -1,17 +1,17 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3902d0f3c6602053c90a7ee4bc97ece0d6534157 */
+ * Stub hash: e181b2dbea612c11c9318cc302901228e887c559 */
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Command___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_MASK(0, document, MAY_BE_ARRAY|MAY_BE_OBJECT, NULL)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, commandOptions, IS_ARRAY, 0, "[]")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, commandOptions, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 #endif
 
 #if !(PHP_VERSION_ID >= 80000)
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Command___construct, 0, 0, 1)
 	ZEND_ARG_INFO(0, document)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, commandOptions, IS_ARRAY, 0, "[]")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, commandOptions, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 #endif
 

--- a/src/MongoDB/Manager.stub.php
+++ b/src/MongoDB/Manager.stub.php
@@ -36,11 +36,11 @@ final class Manager
     final public function executeQuery(string $namespace, Query $query, $options = null): Cursor {}
 #endif
 
-    final public function executeReadCommand(string $db, Command $command, array $options = []): Cursor {}
+    final public function executeReadCommand(string $db, Command $command, ?array $options = null): Cursor {}
 
-    final public function executeReadWriteCommand(string $db, Command $command, array $options = []): Cursor {}
+    final public function executeReadWriteCommand(string $db, Command $command, ?array $options = null): Cursor {}
 
-    final public function executeWriteCommand(string $db, Command $command, array $options = []): Cursor {}
+    final public function executeWriteCommand(string $db, Command $command, ?array $options = null): Cursor {}
 
 #if PHP_VERSION_ID >= 80000
     final public function getEncryptedFieldsMap(): array|object|null {}
@@ -61,7 +61,7 @@ final class Manager
 
     final public function selectServer(?ReadPreference $readPreference = null): Server {}
 
-    final public function startSession(array $options = []): Session {}
+    final public function startSession(?array $options = null): Session {}
 
     final public function __wakeup(): void {}
 }

--- a/src/MongoDB/Manager_arginfo.h
+++ b/src/MongoDB/Manager_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 516a26c70864397ba986d9855f4f876fe84bceb9 */
+ * Stub hash: 4b4373da62f18f2c3ab6aae78a495ed84adbe09b */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Manager___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, uri, IS_STRING, 1, "null")
@@ -66,7 +66,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Manager_executeReadCommand, 0, 2, MongoDB\\Driver\\Cursor, 0)
 	ZEND_ARG_TYPE_INFO(0, db, IS_STRING, 0)
 	ZEND_ARG_OBJ_INFO(0, command, MongoDB\\Driver\\Command, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 0, "[]")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_MongoDB_Driver_Manager_executeReadWriteCommand arginfo_class_MongoDB_Driver_Manager_executeReadCommand
@@ -102,7 +102,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Manager_sele
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Manager_startSession, 0, 0, MongoDB\\Driver\\Session, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 0, "[]")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Manager___wakeup, 0, 0, IS_VOID, 0)

--- a/src/MongoDB/Query.stub.php
+++ b/src/MongoDB/Query.stub.php
@@ -10,10 +10,10 @@ namespace MongoDB\Driver;
 final class Query
 {
 #if PHP_VERSION_ID >= 80000
-    final public function __construct(array|object $filter, array $queryOptions = []) {}
+    final public function __construct(array|object $filter, ?array $queryOptions = null) {}
 #else
     /** @param array|object $filter */
-    final public function __construct($filter, array $queryOptions = []) {}
+    final public function __construct($filter, ?array $queryOptions = null) {}
 #endif
 
     final public function __wakeup(): void {}

--- a/src/MongoDB/Query_arginfo.h
+++ b/src/MongoDB/Query_arginfo.h
@@ -1,17 +1,17 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: eac6cad75d3e8db014b69888b0d139d09cc5c51e */
+ * Stub hash: 896baf668a95c03557d6add9c3a0cc528e5a6468 */
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Query___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_MASK(0, filter, MAY_BE_ARRAY|MAY_BE_OBJECT, NULL)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, queryOptions, IS_ARRAY, 0, "[]")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, queryOptions, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 #endif
 
 #if !(PHP_VERSION_ID >= 80000)
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Query___construct, 0, 0, 1)
 	ZEND_ARG_INFO(0, filter)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, queryOptions, IS_ARRAY, 0, "[]")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, queryOptions, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 #endif
 

--- a/src/MongoDB/Server.stub.php
+++ b/src/MongoDB/Server.stub.php
@@ -92,11 +92,11 @@ final class Server
     final public function executeQuery(string $namespace, Query $query, $options = null): Cursor {}
 #endif
 
-    final public function executeReadCommand(string $db, Command $command, array $options = []): Cursor {}
+    final public function executeReadCommand(string $db, Command $command, ?array $options = null): Cursor {}
 
-    final public function executeReadWriteCommand(string $db, Command $command, array $options = []): Cursor {}
+    final public function executeReadWriteCommand(string $db, Command $command, ?array $options = null): Cursor {}
 
-    final public function executeWriteCommand(string $db, Command $command, array $options = []): Cursor {}
+    final public function executeWriteCommand(string $db, Command $command, ?array $options = null): Cursor {}
 
     final public function getHost(): string {}
 

--- a/src/MongoDB/Server_arginfo.h
+++ b/src/MongoDB/Server_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8c4e8b2bd6a1a5b0047a69ea3cd79399aa474a05 */
+ * Stub hash: 2b5ae022d2f31086681627e159b792dd92b4929e */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Server___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -55,7 +55,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Server_executeReadCommand, 0, 2, MongoDB\\Driver\\Cursor, 0)
 	ZEND_ARG_TYPE_INFO(0, db, IS_STRING, 0)
 	ZEND_ARG_OBJ_INFO(0, command, MongoDB\\Driver\\Command, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 0, "[]")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_MongoDB_Driver_Server_executeReadWriteCommand arginfo_class_MongoDB_Driver_Server_executeReadCommand

--- a/src/MongoDB/Session.stub.php
+++ b/src/MongoDB/Session.stub.php
@@ -72,7 +72,7 @@ final class Session
 
     final public function isInTransaction(): bool {}
 
-    final public function startTransaction(?array $options = []): void {}
+    final public function startTransaction(?array $options = null): void {}
 
     final public function __wakeup(): void {}
 }

--- a/src/MongoDB/Session_arginfo.h
+++ b/src/MongoDB/Session_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: fbf742d6b12a1bf6e04201a81b08e3b26b8e261c */
+ * Stub hash: c6f026b0e22bb1eb53a63956f6c3c40fe99fbd24 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Session___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -51,7 +51,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_MongoDB_Driver_Session_isInTransaction arginfo_class_MongoDB_Driver_Session_isDirty
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Session_startTransaction, 0, 0, IS_VOID, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "[]")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_MongoDB_Driver_Session___wakeup arginfo_class_MongoDB_Driver_Session_abortTransaction


### PR DESCRIPTION
PHPC-2124

While reviewing code for the docs, I realised that these stubs don't correspond to the actual ZPP info, which takes precedence as it enforces parsing rules.