### PR TITLE
PHPC-2015: Fix wrong return types in stubs

### DIFF
--- a/src/MongoDB/Monitoring/CommandFailedEvent.stub.php
+++ b/src/MongoDB/Monitoring/CommandFailedEvent.stub.php
@@ -15,7 +15,7 @@ final class CommandFailedEvent
 
     final public function getDurationMicros(): int {}
 
-    final public function getError(): \Throwable {}
+    final public function getError(): \Exception {}
 
     final public function getOperationId(): string {}
 

--- a/src/MongoDB/Monitoring/CommandFailedEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/CommandFailedEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 93e23af417425d45e8222ae0fd89b02ef5eb25a2 */
+ * Stub hash: 008d718040430e0251e01cf2fa8da4e1ed4370d6 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_CommandFailedEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -10,7 +10,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_CommandFailedEvent_getDurationMicros, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_CommandFailedEvent_getError, 0, 0, Throwable, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_CommandFailedEvent_getError, 0, 0, Exception, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_MongoDB_Driver_Monitoring_CommandFailedEvent_getOperationId arginfo_class_MongoDB_Driver_Monitoring_CommandFailedEvent_getCommandName

--- a/src/MongoDB/Monitoring/ServerHeartbeatFailedEvent.stub.php
+++ b/src/MongoDB/Monitoring/ServerHeartbeatFailedEvent.stub.php
@@ -13,7 +13,7 @@ final class ServerHeartbeatFailedEvent
 
     final public function getDurationMicros() : int{}
 
-    final public function getError(): \Throwable {}
+    final public function getError(): \Exception {}
 
     final public function getPort(): int {}
 

--- a/src/MongoDB/Monitoring/ServerHeartbeatFailedEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/ServerHeartbeatFailedEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: b8fb8dfe7e269cc0737210f5f2e92fd5359728eb */
+ * Stub hash: 110a67ba94066498759282d2f7ca4b865068dbb0 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -7,7 +7,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent_getDurationMicros, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent_getError, 0, 0, Throwable, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent_getError, 0, 0, Exception, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent_getPort arginfo_class_MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent_getDurationMicros

--- a/src/MongoDB/WriteConcern.stub.php
+++ b/src/MongoDB/WriteConcern.stub.php
@@ -31,7 +31,7 @@ final class WriteConcern implements \MongoDB\BSON\Serializable, \Serializable
     final public function getW() {}
 #endif
 
-    final public function getWtimeout(): ?int {}
+    final public function getWtimeout(): int {}
 
     final public function isDefault(): bool {}
 

--- a/src/MongoDB/WriteConcern_arginfo.h
+++ b/src/MongoDB/WriteConcern_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: ef3b593831b2de652f8bcac0a72eab5b75eeb073 */
+ * Stub hash: b5c797e41b64764dc3b9392110c68a44bcd94932 */
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_WriteConcern___construct, 0, 0, 1)
@@ -30,7 +30,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_WriteConcern_getW, 0, 0, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_WriteConcern_getWtimeout, 0, 0, IS_LONG, 1)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_WriteConcern_getWtimeout, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_WriteConcern_isDefault, 0, 0, _IS_BOOL, 0)


### PR DESCRIPTION
PHPC-2015

This fixes some return types mentioned in https://github.com/alcaeus/doc-en/pull/3