### PR TITLE
PHPC-2131: Ensure CRYPT_SHARED_LIB_PATH is exported for tests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -388,6 +388,7 @@ functions:
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
+          export CRYPT_SHARED_LIB_PATH="${client_side_encryption_crypt_shared_lib_path}"
           API_VERSION=${API_VERSION} TESTS=${TESTS} SSL=${SSL} MONGODB_URI="${MONGODB_URI}${APPEND_URI}" sh ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
 
   "cleanup":
@@ -605,8 +606,6 @@ tasks:
             TOPOLOGY: "replica_set"
         - func: "fetch crypt_shared"
         - func: "run tests"
-          vars:
-            CRYPT_SHARED_LIB_PATH: "${client_side_encryption_crypt_shared_lib_path}"
 
     - name: "test-loadBalanced"
       tags: ["loadbalanced"]

--- a/tests/utils/tools.php
+++ b/tests/utils/tools.php
@@ -98,8 +98,12 @@ function create_test_manager(string $uri = null, array $options = [], array $dri
         $driverOptions['serverApi'] = new ServerApi(getenv('API_VERSION'));
     }
 
-    if (getenv('CRYPT_SHARED_LIB_PATH') && ! isset($driverOptions['autoEncryption']['extraOptions']['cryptSharedLibPath'])) {
-        $driverOptions['autoEncryption']['extraOptions']['cryptSharedLibPath'] = getenv('CRYPT_SHARED_LIB_PATH');
+    if (getenv('CRYPT_SHARED_LIB_PATH') && isset($driverOptions['autoEncryption'])) {
+        if (is_array($driverOptions['autoEncryption']) &&
+            (! isset($driverOptions['autoEncryption']['extraOptions']) || is_array($driverOptions['autoEncryption']['extraOptions'])) &&
+            ! isset($driverOptions['autoEncryption']['extraOptions']['cryptSharedLibPath'])) {
+            $driverOptions['autoEncryption']['extraOptions']['cryptSharedLibPath'] = getenv('CRYPT_SHARED_LIB_PATH');
+        }
     }
 
     return new Manager($uri ?? URI, $options, $driverOptions);


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-2131

Note: I opened this against the v1.14 branch to ensure it gets tested with `crypt_shared`, since that's when [PHPC-2045](https://jira.mongodb.org/browse/PHPC-2045) was implemented.

Patch build: https://spruce.mongodb.com/version/630e26002a60ed23408418e7/tasks