### PR TITLE
PHPC-2135: Test with consistent version of crypt_shared

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -362,7 +362,7 @@ functions:
         script: |
           ${PREPARE_SHELL}
           MONGODB_VERSION=${VERSION} TOPOLOGY=${TOPOLOGY} AUTH=${AUTH} SSL=${SSL} STORAGE_ENGINE=${STORAGE_ENGINE} LOAD_BALANCER=${LOAD_BALANCER} REQUIRE_API_VERSION=${REQUIRE_API_VERSION} ORCHESTRATION_FILE=${ORCHESTRATION_FILE} sh ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
-    # run-orchestration generates expansion file with the MONGODB_URI for the cluster
+    # run-orchestration generates expansion file with MONGODB_URI and CRYPT_SHARED_LIB_PATH
     - command: expansions.update
       params:
         file: mo-expansion.yml
@@ -388,8 +388,14 @@ functions:
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
-          export CRYPT_SHARED_LIB_PATH="${client_side_encryption_crypt_shared_lib_path}"
-          API_VERSION=${API_VERSION} TESTS=${TESTS} SSL=${SSL} MONGODB_URI="${MONGODB_URI}${APPEND_URI}" sh ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
+          API_VERSION=${API_VERSION} \
+          CRYPT_SHARED_LIB_PATH=${CRYPT_SHARED_LIB_PATH} \
+          MONGODB_URI="${MONGODB_URI}${APPEND_URI}" \
+          SKIP_CRYPT_SHARED=${SKIP_CRYPT_SHARED} \
+          SSL=${SSL} \
+          SSL_DIR=${SSL_DIR} \
+          TESTS=${TESTS} \
+          sh ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
 
   "cleanup":
     - command: shell.exec
@@ -466,18 +472,6 @@ functions:
           if [ -n "${SINGLE_MONGOS_LB_URI}" ]; then
             ${DRIVERS_TOOLS}/.evergreen/run-load-balancer.sh stop
           fi
-
-  "fetch crypt_shared":
-    - command: shell.exec
-      params:
-        script: |
-          # TODO: Specify same version provisioned by download-mongodb.sh (see: DRIVERS-2355)
-          python3 ${DRIVERS_TOOLS}/.evergreen/mongodl.py --component crypt_shared --version latest --only "**/mongo_crypt_v1.so" --out ${DRIVERS_TOOLS}/.evergreen/csfle --strip-path-components 1
-    - command: expansions.update
-      params:
-        updates:
-          - key: client_side_encryption_crypt_shared_lib_path
-            value: ${DRIVERS_TOOLS}/.evergreen/csfle/mongo_crypt_v1.so
 
 pre:
   - func: "fetch source"
@@ -598,14 +592,15 @@ tasks:
           vars:
             TESTS: "tests/atlas.phpt"
 
-    - name: "test-crypt_shared"
+    - name: "test-skip_crypt_shared"
       commands:
         - func: "compile driver"
         - func: "bootstrap mongo-orchestration"
           vars:
             TOPOLOGY: "replica_set"
-        - func: "fetch crypt_shared"
         - func: "run tests"
+          vars:
+            SKIP_CRYPT_SHARED: "yes"
 
     - name: "test-loadBalanced"
       tags: ["loadbalanced"]
@@ -1256,9 +1251,9 @@ buildvariants:
   tasks:
     - name: "test-loadBalanced"
 
-# CSFLE crypt_shared is available from MongoDB 6.0+
-- matrix_name: "test-csfle-crypt_shared"
+# CSFLE crypt_shared is available from MongoDB 6.0+, so explicitly test without it to allow use of mongocryptd
+- matrix_name: "test-csfle-skip_crypt_shared"
   matrix_spec: { "os": "debian11", "mongodb-versions": "6.0", "php-edge-versions": "latest-stable" }
-  display_name: "CSFLE crypt_shared - ${mongodb-versions}"
+  display_name: "CSFLE skip_crypt_shared - ${mongodb-versions}"
   tasks:
-    - name: "test-crypt_shared"
+    - name: "test-skip_crypt_shared"


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-2135

This PR also includes quite a bit of shell script cleanup based on my conversation with @rcsanchez97 in [#driver-devs](https://mongodb.slack.com/archives/C72LB5RPV/p1661962557817589).

Full patch build: https://spruce.mongodb.com/version/630faa1d0305b97199243780/tasks