### PR TITLE
PHPC-1929: ReadConcern tests need not exhaustively test each constant

### DIFF
--- a/tests/readConcern/readconcern-bsonserialize-001.phpt
+++ b/tests/readConcern/readconcern-bsonserialize-001.phpt
@@ -7,11 +7,7 @@ require_once __DIR__ . '/../utils/basic.inc';
 
 $tests = [
     new MongoDB\Driver\ReadConcern(),
-    new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::LINEARIZABLE),
     new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::LOCAL),
-    new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::MAJORITY),
-    new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::AVAILABLE),
-    new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::SNAPSHOT),
 ];
 
 foreach ($tests as $test) {
@@ -23,9 +19,5 @@ foreach ($tests as $test) {
 <?php exit(0); ?>
 --EXPECT--
 { }
-{ "level" : "linearizable" }
 { "level" : "local" }
-{ "level" : "majority" }
-{ "level" : "available" }
-{ "level" : "snapshot" }
 ===DONE===

--- a/tests/readConcern/readconcern-bsonserialize-002.phpt
+++ b/tests/readConcern/readconcern-bsonserialize-002.phpt
@@ -7,11 +7,7 @@ require_once __DIR__ . '/../utils/basic.inc';
 
 $tests = [
     new MongoDB\Driver\ReadConcern(),
-    new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::LINEARIZABLE),
     new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::LOCAL),
-    new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::MAJORITY),
-    new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::AVAILABLE),
-    new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::SNAPSHOT),
 ];
 
 foreach ($tests as $test) {
@@ -26,22 +22,6 @@ object(stdClass)#%d (%d) {
 }
 object(stdClass)#%d (%d) {
   ["level"]=>
-  string(12) "linearizable"
-}
-object(stdClass)#%d (%d) {
-  ["level"]=>
   string(5) "local"
-}
-object(stdClass)#%d (%d) {
-  ["level"]=>
-  string(8) "majority"
-}
-object(stdClass)#%d (%d) {
-  ["level"]=>
-  string(9) "available"
-}
-object(stdClass)#%d (%d) {
-  ["level"]=>
-  string(8) "snapshot"
 }
 ===DONE===

--- a/tests/readConcern/readconcern-ctor-001.phpt
+++ b/tests/readConcern/readconcern-ctor-001.phpt
@@ -6,7 +6,6 @@ MongoDB\Driver\ReadConcern construction
 var_dump(new MongoDB\Driver\ReadConcern());
 var_dump(new MongoDB\Driver\ReadConcern(null));
 var_dump(new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::LOCAL));
-var_dump(new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::MAJORITY));
 var_dump(new MongoDB\Driver\ReadConcern('not-yet-supported'));
 
 ?>
@@ -20,10 +19,6 @@ object(MongoDB\Driver\ReadConcern)#%d (%d) {
 object(MongoDB\Driver\ReadConcern)#%d (%d) {
   ["level"]=>
   string(5) "local"
-}
-object(MongoDB\Driver\ReadConcern)#%d (%d) {
-  ["level"]=>
-  string(8) "majority"
 }
 object(MongoDB\Driver\ReadConcern)#%d (%d) {
   ["level"]=>

--- a/tests/readConcern/readconcern-debug-001.phpt
+++ b/tests/readConcern/readconcern-debug-001.phpt
@@ -7,11 +7,7 @@ require_once __DIR__ . '/../utils/basic.inc';
 
 $tests = [
     new MongoDB\Driver\ReadConcern(),
-    new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::LINEARIZABLE),
     new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::LOCAL),
-    new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::MAJORITY),
-    new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::AVAILABLE),
-    new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::SNAPSHOT),
 ];
 
 foreach ($tests as $test) {
@@ -26,22 +22,6 @@ object(MongoDB\Driver\ReadConcern)#%d (%d) {
 }
 object(MongoDB\Driver\ReadConcern)#%d (%d) {
   ["level"]=>
-  string(12) "linearizable"
-}
-object(MongoDB\Driver\ReadConcern)#%d (%d) {
-  ["level"]=>
   string(5) "local"
-}
-object(MongoDB\Driver\ReadConcern)#%d (%d) {
-  ["level"]=>
-  string(8) "majority"
-}
-object(MongoDB\Driver\ReadConcern)#%d (%d) {
-  ["level"]=>
-  string(9) "available"
-}
-object(MongoDB\Driver\ReadConcern)#%d (%d) {
-  ["level"]=>
-  string(8) "snapshot"
 }
 ===DONE===

--- a/tests/readConcern/readconcern-getlevel-001.phpt
+++ b/tests/readConcern/readconcern-getlevel-001.phpt
@@ -6,7 +6,6 @@ MongoDB\Driver\ReadConcern::getLevel()
 $tests = [
     null,
     MongoDB\Driver\ReadConcern::LOCAL,
-    MongoDB\Driver\ReadConcern::MAJORITY,
     'not-yet-supported',
 ];
 
@@ -21,6 +20,5 @@ foreach ($tests as $test) {
 --EXPECT--
 NULL
 string(5) "local"
-string(8) "majority"
 string(17) "not-yet-supported"
 ===DONE===

--- a/tests/readConcern/readconcern-serialization-001.phpt
+++ b/tests/readConcern/readconcern-serialization-001.phpt
@@ -10,11 +10,7 @@ require_once __DIR__ . '/../utils/basic.inc';
 
 $tests = [
     new MongoDB\Driver\ReadConcern(),
-    new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::LINEARIZABLE),
     new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::LOCAL),
-    new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::MAJORITY),
-    new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::AVAILABLE),
-    new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::SNAPSHOT),
 ];
 
 foreach ($tests as $test) {
@@ -38,17 +34,6 @@ object(MongoDB\Driver\ReadConcern)#%d (%d) {
 
 object(MongoDB\Driver\ReadConcern)#%d (%d) {
   ["level"]=>
-  string(12) "linearizable"
-}
-bool(true)
-C:26:"MongoDB\Driver\ReadConcern":38:{a:1:{s:5:"level";s:12:"linearizable";}}
-object(MongoDB\Driver\ReadConcern)#%d (%d) {
-  ["level"]=>
-  string(12) "linearizable"
-}
-
-object(MongoDB\Driver\ReadConcern)#%d (%d) {
-  ["level"]=>
   string(5) "local"
 }
 bool(true)
@@ -56,39 +41,6 @@ C:26:"MongoDB\Driver\ReadConcern":30:{a:1:{s:5:"level";s:5:"local";}}
 object(MongoDB\Driver\ReadConcern)#%d (%d) {
   ["level"]=>
   string(5) "local"
-}
-
-object(MongoDB\Driver\ReadConcern)#%d (%d) {
-  ["level"]=>
-  string(8) "majority"
-}
-bool(true)
-C:26:"MongoDB\Driver\ReadConcern":33:{a:1:{s:5:"level";s:8:"majority";}}
-object(MongoDB\Driver\ReadConcern)#%d (%d) {
-  ["level"]=>
-  string(8) "majority"
-}
-
-object(MongoDB\Driver\ReadConcern)#%d (%d) {
-  ["level"]=>
-  string(9) "available"
-}
-bool(true)
-C:26:"MongoDB\Driver\ReadConcern":34:{a:1:{s:5:"level";s:9:"available";}}
-object(MongoDB\Driver\ReadConcern)#%d (%d) {
-  ["level"]=>
-  string(9) "available"
-}
-
-object(MongoDB\Driver\ReadConcern)#%d (%d) {
-  ["level"]=>
-  string(8) "snapshot"
-}
-bool(true)
-C:26:"MongoDB\Driver\ReadConcern":33:{a:1:{s:5:"level";s:8:"snapshot";}}
-object(MongoDB\Driver\ReadConcern)#%d (%d) {
-  ["level"]=>
-  string(8) "snapshot"
 }
 
 ===DONE===

--- a/tests/readConcern/readconcern-serialization-002.phpt
+++ b/tests/readConcern/readconcern-serialization-002.phpt
@@ -10,11 +10,7 @@ require_once __DIR__ . '/../utils/basic.inc';
 
 $tests = [
     new MongoDB\Driver\ReadConcern(),
-    new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::LINEARIZABLE),
     new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::LOCAL),
-    new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::MAJORITY),
-    new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::AVAILABLE),
-    new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::SNAPSHOT),
 ];
 
 foreach ($tests as $test) {
@@ -36,52 +32,12 @@ object(MongoDB\Driver\ReadConcern)#%d (%d) {
 
 object(MongoDB\Driver\ReadConcern)#%d (%d) {
   ["level"]=>
-  string(12) "linearizable"
-}
-O:26:"MongoDB\Driver\ReadConcern":1:{s:5:"level";s:12:"linearizable";}
-object(MongoDB\Driver\ReadConcern)#%d (%d) {
-  ["level"]=>
-  string(12) "linearizable"
-}
-
-object(MongoDB\Driver\ReadConcern)#%d (%d) {
-  ["level"]=>
   string(5) "local"
 }
 O:26:"MongoDB\Driver\ReadConcern":1:{s:5:"level";s:5:"local";}
 object(MongoDB\Driver\ReadConcern)#%d (%d) {
   ["level"]=>
   string(5) "local"
-}
-
-object(MongoDB\Driver\ReadConcern)#%d (%d) {
-  ["level"]=>
-  string(8) "majority"
-}
-O:26:"MongoDB\Driver\ReadConcern":1:{s:5:"level";s:8:"majority";}
-object(MongoDB\Driver\ReadConcern)#%d (%d) {
-  ["level"]=>
-  string(8) "majority"
-}
-
-object(MongoDB\Driver\ReadConcern)#%d (%d) {
-  ["level"]=>
-  string(9) "available"
-}
-O:26:"MongoDB\Driver\ReadConcern":1:{s:5:"level";s:9:"available";}
-object(MongoDB\Driver\ReadConcern)#%d (%d) {
-  ["level"]=>
-  string(9) "available"
-}
-
-object(MongoDB\Driver\ReadConcern)#%d (%d) {
-  ["level"]=>
-  string(8) "snapshot"
-}
-O:26:"MongoDB\Driver\ReadConcern":1:{s:5:"level";s:8:"snapshot";}
-object(MongoDB\Driver\ReadConcern)#%d (%d) {
-  ["level"]=>
-  string(8) "snapshot"
 }
 
 ===DONE===

--- a/tests/readConcern/readconcern-set_state-001.phpt
+++ b/tests/readConcern/readconcern-set_state-001.phpt
@@ -3,20 +3,10 @@ MongoDB\Driver\ReadConcern::__set_state()
 --FILE--
 <?php
 
-$tests = [
-    MongoDB\Driver\ReadConcern::AVAILABLE,
-    MongoDB\Driver\ReadConcern::LINEARIZABLE,
-    MongoDB\Driver\ReadConcern::LOCAL,
-    MongoDB\Driver\ReadConcern::MAJORITY,
-    MongoDB\Driver\ReadConcern::SNAPSHOT,
-];
-
-foreach ($tests as $level) {
-    var_export(MongoDB\Driver\ReadConcern::__set_state([
-        'level' => $level,
-    ]));
-    echo "\n\n";
-}
+var_export(MongoDB\Driver\ReadConcern::__set_state([
+    'level' => MongoDB\Driver\ReadConcern::AVAILABLE,
+]));
+echo "\n\n";
 
 /* Test with level unset */
 var_export(MongoDB\Driver\ReadConcern::__set_state([
@@ -29,22 +19,6 @@ echo "\n\n";
 --EXPECTF--
 %r\\?%rMongoDB\Driver\ReadConcern::__set_state(array(
 %w'level' => 'available',
-))
-
-%r\\?%rMongoDB\Driver\ReadConcern::__set_state(array(
-%w'level' => 'linearizable',
-))
-
-%r\\?%rMongoDB\Driver\ReadConcern::__set_state(array(
-%w'level' => 'local',
-))
-
-%r\\?%rMongoDB\Driver\ReadConcern::__set_state(array(
-%w'level' => 'majority',
-))
-
-%r\\?%rMongoDB\Driver\ReadConcern::__set_state(array(
-%w'level' => 'snapshot',
 ))
 
 %r\\?%rMongoDB\Driver\ReadConcern::__set_state(array(

--- a/tests/readConcern/readconcern-var_export-001.phpt
+++ b/tests/readConcern/readconcern-var_export-001.phpt
@@ -7,11 +7,7 @@ require_once __DIR__ . '/../utils/basic.inc';
 
 $tests = [
     new MongoDB\Driver\ReadConcern(),
-    new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::LINEARIZABLE),
     new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::LOCAL),
-    new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::MAJORITY),
-    new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::AVAILABLE),
-    new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::SNAPSHOT),
 ];
 
 foreach ($tests as $test) {
@@ -25,18 +21,6 @@ foreach ($tests as $test) {
 %r\\?%rMongoDB\Driver\ReadConcern::__set_state(array(
 ))
 %r\\?%rMongoDB\Driver\ReadConcern::__set_state(array(
-   'level' => 'linearizable',
-))
-%r\\?%rMongoDB\Driver\ReadConcern::__set_state(array(
    'level' => 'local',
-))
-%r\\?%rMongoDB\Driver\ReadConcern::__set_state(array(
-   'level' => 'majority',
-))
-%r\\?%rMongoDB\Driver\ReadConcern::__set_state(array(
-   'level' => 'available',
-))
-%r\\?%rMongoDB\Driver\ReadConcern::__set_state(array(
-   'level' => 'snapshot',
 ))
 ===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1929

Related to https://jira.mongodb.org/browse/PHPC-1761