### PR TITLE
PHPC-2121: Skip failing test

### DIFF
--- a/tests/server/server-executeBulkWrite-005.phpt
+++ b/tests/server/server-executeBulkWrite-005.phpt
@@ -2,6 +2,7 @@
 MongoDB\Driver\Server::executeBulkWrite() with write concern (replica set secondary, local DB)
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_server_version('>=', '6.2'); ?>
 <?php skip_if_not_replica_set(); ?>
 <?php skip_if_no_secondary(); ?>
 <?php skip_if_not_clean('local', COLLECTION_NAME); ?>

--- a/tests/server/server-executeBulkWrite-005.phpt
+++ b/tests/server/server-executeBulkWrite-005.phpt
@@ -2,7 +2,7 @@
 MongoDB\Driver\Server::executeBulkWrite() with write concern (replica set secondary, local DB)
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
-<?php skip_if_server_version('>=', '6.2'); ?>
+<?php skip_if_server_version('>=', '6.2'); /* TODO: Remove this when addressing PHPC-2121 */ ?>
 <?php skip_if_not_replica_set(); ?>
 <?php skip_if_no_secondary(); ?>
 <?php skip_if_not_clean('local', COLLECTION_NAME); ?>


### PR DESCRIPTION
PHPC-2121

In an effort to reach a green CI, I decided to skip this failing test since it's tracked as failing-on-waterfall.

---

As an aside, this sent me down a deep rabbit hole trying to figure out why I couldn't get the test to properly skip. The culprit is the SKIPIF caching introduced in PHP 8.1 (as noticed by @jmikola before - see #1301 and https://github.com/php/php-src/pull/8076). Until we properly fix this, `skip_if_not_clean` has to be the last SKIPIF check. In a case of not optimising early enough, I added the `skip_if_server_version` check to the bottom, which caused `run-tests.php` to truncate its output due to `nocache` appearing before.