### PR TITLE
PHPC-2064: Use register_shutdown_function to disable caching of skipif results

### DIFF
--- a/tests/utils/skipif.php
+++ b/tests/utils/skipif.php
@@ -15,11 +15,17 @@ require_once __DIR__ . '/tools.php';
  */
 function disable_skipif_caching()
 {
+    static $skipifCachingDisabled;
+
     if (PHP_VERSION_ID < 80100) {
         return;
     }
 
-    echo "nocache\n";
+    if (! isset($skipifCachingDisabled)) {
+        $skipifCachingDisabled = true;
+
+        register_shutdown_function(function() { echo "nocache\n"; });
+    }
 }
 
 /**


### PR DESCRIPTION
PHPC-2064
Replaces #1301

As is, using any logic in a `SKIPIF` block after a previous call to `skip_if_not_clean` leads to the tests not being skipped. This is due to PHP 8.1+ reading the `nocache` output and discarding any subsequent output. To resolve this, we can change `disable_skipif_caching` to register a shutdown function that disables caching by printing `nocache` to `STDOUT`. While this can lead to skip messages containing an extra `nocache` at the end, I believe this is preferable to `SKIPIF` logic being ignored. I also believe it's not worth adding any logic to not print anything if a previous check resulted in `skip ...` being printed.