### PR TITLE
PHPC-2141: Emit deprecation notice for WriteResult getters with unacknowledged writes

### DIFF
--- a/src/MongoDB/WriteResult.c
+++ b/src/MongoDB/WriteResult.c
@@ -31,10 +31,17 @@
 #include "MongoDB/WriteError.h"
 #include "WriteResult_arginfo.h"
 
+#define PHONGO_WRITERESULT_CHECK_ACKNOWLEDGED(method)                                                                                                                                        \
+	if (!mongoc_write_concern_is_acknowledged(intern->write_concern)) {                                                                                                                      \
+		php_error_docref(NULL, E_DEPRECATED, "Calling MongoDB\\Driver\\WriteResult::" method "() for an unacknowledged write is deprecated and will throw an exception in ext-mongodb 2.0"); \
+		RETURN_NULL();                                                                                                                                                                       \
+	}
+
 #define PHONGO_WRITERESULT_RETURN_LONG_FROM_BSON_INT32(iter, bson, key)                \
 	if (bson_iter_init_find((iter), (bson), (key)) && BSON_ITER_HOLDS_INT32((iter))) { \
 		RETURN_LONG(bson_iter_int32((iter)));                                          \
-	}
+	}                                                                                  \
+	RETURN_LONG(0);
 
 zend_class_entry* php_phongo_writeresult_ce;
 
@@ -123,6 +130,8 @@ static PHP_METHOD(MongoDB_Driver_WriteResult, getInsertedCount)
 
 	PHONGO_PARSE_PARAMETERS_NONE();
 
+	PHONGO_WRITERESULT_CHECK_ACKNOWLEDGED("getInsertedCount");
+
 	PHONGO_WRITERESULT_RETURN_LONG_FROM_BSON_INT32(&iter, intern->reply, "nInserted");
 }
 
@@ -135,6 +144,8 @@ static PHP_METHOD(MongoDB_Driver_WriteResult, getMatchedCount)
 	intern = Z_WRITERESULT_OBJ_P(getThis());
 
 	PHONGO_PARSE_PARAMETERS_NONE();
+
+	PHONGO_WRITERESULT_CHECK_ACKNOWLEDGED("getMatchedCount");
 
 	PHONGO_WRITERESULT_RETURN_LONG_FROM_BSON_INT32(&iter, intern->reply, "nMatched");
 }
@@ -149,6 +160,8 @@ static PHP_METHOD(MongoDB_Driver_WriteResult, getModifiedCount)
 
 	PHONGO_PARSE_PARAMETERS_NONE();
 
+	PHONGO_WRITERESULT_CHECK_ACKNOWLEDGED("getModifiedCount");
+
 	PHONGO_WRITERESULT_RETURN_LONG_FROM_BSON_INT32(&iter, intern->reply, "nModified");
 }
 
@@ -162,6 +175,8 @@ static PHP_METHOD(MongoDB_Driver_WriteResult, getDeletedCount)
 
 	PHONGO_PARSE_PARAMETERS_NONE();
 
+	PHONGO_WRITERESULT_CHECK_ACKNOWLEDGED("getDeletedCount");
+
 	PHONGO_WRITERESULT_RETURN_LONG_FROM_BSON_INT32(&iter, intern->reply, "nRemoved");
 }
 
@@ -174,6 +189,8 @@ static PHP_METHOD(MongoDB_Driver_WriteResult, getUpsertedCount)
 	intern = Z_WRITERESULT_OBJ_P(getThis());
 
 	PHONGO_PARSE_PARAMETERS_NONE();
+
+	PHONGO_WRITERESULT_CHECK_ACKNOWLEDGED("getUpsertedCount");
 
 	PHONGO_WRITERESULT_RETURN_LONG_FROM_BSON_INT32(&iter, intern->reply, "nUpserted");
 }
@@ -199,6 +216,8 @@ static PHP_METHOD(MongoDB_Driver_WriteResult, getUpsertedIds)
 	intern = Z_WRITERESULT_OBJ_P(getThis());
 
 	PHONGO_PARSE_PARAMETERS_NONE();
+
+	PHONGO_WRITERESULT_CHECK_ACKNOWLEDGED("getUpsertedIds");
 
 	array_init(return_value);
 

--- a/tests/manager/manager-executeBulkWrite-012.phpt
+++ b/tests/manager/manager-executeBulkWrite-012.phpt
@@ -29,8 +29,10 @@ foreach ($writeConcerns as $wc) {
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECT--
+--EXPECTF--
 bool(false)
+
+Deprecated: MongoDB\Driver\WriteResult::getInsertedCount(): Calling MongoDB\Driver\WriteResult::getInsertedCount() for an unacknowledged write is deprecated and will throw an exception in ext-mongodb 2.0 in %s
 NULL
 bool(true)
 int(1)

--- a/tests/server/server-executeBulkWrite-002.phpt
+++ b/tests/server/server-executeBulkWrite-002.phpt
@@ -25,8 +25,10 @@ foreach ($writeConcerns as $writeConcern) {
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECT--
+--EXPECTF--
 bool(false)
+
+Deprecated: MongoDB\Driver\WriteResult::getInsertedCount(): Calling MongoDB\Driver\WriteResult::getInsertedCount() for an unacknowledged write is deprecated and will throw an exception in ext-mongodb 2.0 in %s
 NULL
 bool(true)
 int(1)

--- a/tests/server/server-executeBulkWrite-003.phpt
+++ b/tests/server/server-executeBulkWrite-003.phpt
@@ -26,8 +26,10 @@ foreach ($writeConcerns as $wc) {
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECT--
+--EXPECTF--
 bool(false)
+
+Deprecated: MongoDB\Driver\WriteResult::getInsertedCount(): Calling MongoDB\Driver\WriteResult::getInsertedCount() for an unacknowledged write is deprecated and will throw an exception in ext-mongodb 2.0 in %s
 NULL
 bool(true)
 int(1)

--- a/tests/server/server-executeBulkWrite-005.phpt
+++ b/tests/server/server-executeBulkWrite-005.phpt
@@ -35,8 +35,10 @@ $server->executeBulkWrite('local.' . COLLECTION_NAME, $bulk);
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECT--
+--EXPECTF--
 bool(false)
+
+Deprecated: MongoDB\Driver\WriteResult::getInsertedCount(): Calling MongoDB\Driver\WriteResult::getInsertedCount() for an unacknowledged write is deprecated and will throw an exception in ext-mongodb 2.0 in %s
 NULL
 bool(true)
 int(1)

--- a/tests/server/server-executeBulkWrite-006.phpt
+++ b/tests/server/server-executeBulkWrite-006.phpt
@@ -30,8 +30,10 @@ foreach ($writeConcerns as $wc) {
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECT--
+--EXPECTF--
 bool(false)
+
+Deprecated: MongoDB\Driver\WriteResult::getInsertedCount(): Calling MongoDB\Driver\WriteResult::getInsertedCount() for an unacknowledged write is deprecated and will throw an exception in ext-mongodb 2.0 in %s
 NULL
 bool(true)
 int(1)

--- a/tests/writeResult/writeresult-getdeletedcount-002.phpt
+++ b/tests/writeResult/writeresult-getdeletedcount-002.phpt
@@ -24,6 +24,7 @@ var_dump($result->getDeletedCount());
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECT--
+--EXPECTF--
+Deprecated: MongoDB\Driver\WriteResult::getDeletedCount(): Calling MongoDB\Driver\WriteResult::getDeletedCount() for an unacknowledged write is deprecated and will throw an exception in ext-mongodb 2.0 in %s
 NULL
 ===DONE===

--- a/tests/writeResult/writeresult-getinsertedcount-002.phpt
+++ b/tests/writeResult/writeresult-getinsertedcount-002.phpt
@@ -24,6 +24,7 @@ var_dump($result->getInsertedCount());
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECT--
+--EXPECTF--
+Deprecated: MongoDB\Driver\WriteResult::getInsertedCount(): Calling MongoDB\Driver\WriteResult::getInsertedCount() for an unacknowledged write is deprecated and will throw an exception in ext-mongodb 2.0 in %s
 NULL
 ===DONE===

--- a/tests/writeResult/writeresult-getmatchedcount-002.phpt
+++ b/tests/writeResult/writeresult-getmatchedcount-002.phpt
@@ -24,6 +24,7 @@ var_dump($result->getMatchedCount());
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECT--
+--EXPECTF--
+Deprecated: MongoDB\Driver\WriteResult::getMatchedCount(): Calling MongoDB\Driver\WriteResult::getMatchedCount() for an unacknowledged write is deprecated and will throw an exception in %s
 NULL
 ===DONE===

--- a/tests/writeResult/writeresult-getmodifiedcount-002.phpt
+++ b/tests/writeResult/writeresult-getmodifiedcount-002.phpt
@@ -24,6 +24,7 @@ var_dump($result->getModifiedCount());
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECT--
+--EXPECTF--
+Deprecated: MongoDB\Driver\WriteResult::getModifiedCount(): Calling MongoDB\Driver\WriteResult::getModifiedCount() for an unacknowledged write is deprecated and will throw an exception in ext-mongodb 2.0 in %s
 NULL
 ===DONE===

--- a/tests/writeResult/writeresult-getupsertedcount-002.phpt
+++ b/tests/writeResult/writeresult-getupsertedcount-002.phpt
@@ -24,6 +24,7 @@ var_dump($result->getUpsertedCount());
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECT--
+--EXPECTF--
+Deprecated: MongoDB\Driver\WriteResult::getUpsertedCount(): Calling MongoDB\Driver\WriteResult::getUpsertedCount() for an unacknowledged write is deprecated and will throw an exception in ext-mongodb 2.0 in %s
 NULL
 ===DONE===


### PR DESCRIPTION
PHPC-2141

With this change, we're deprecating calling the various `get<field>Count` methods on unacknowledged write results. In 2.0, this will throw an exception, as is already done in the PHP library. For fields missing in the response, we no longer return `null`, but rather `0` to make the method signature more compatible. In 2.0, the return value of these methods will change from `int|null` to `int`.