### PR TITLE
PHPC-2146: Refactor typemap struct and BSON encoding/decoding of zvals

### DIFF
--- a/src/BSON/Javascript.c
+++ b/src/BSON/Javascript.c
@@ -94,7 +94,7 @@ HashTable* php_phongo_javascript_get_properties_hash(phongo_compat_object_handle
 			php_phongo_bson_state state;
 
 			PHONGO_BSON_INIT_STATE(state);
-			if (!php_phongo_bson_to_zval_ex(bson_get_data(intern->scope), intern->scope->len, &state)) {
+			if (!php_phongo_bson_to_zval_ex(intern->scope, &state)) {
 				zval_ptr_dtor(&state.zchild);
 				goto failure;
 			}
@@ -194,7 +194,7 @@ static PHP_METHOD(MongoDB_BSON_Javascript, getScope)
 
 		PHONGO_BSON_INIT_STATE(state);
 
-		if (!php_phongo_bson_to_zval_ex(bson_get_data(intern->scope), intern->scope->len, &state)) {
+		if (!php_phongo_bson_to_zval_ex(intern->scope, &state)) {
 			zval_ptr_dtor(&state.zchild);
 			return;
 		}
@@ -220,7 +220,7 @@ static PHP_METHOD(MongoDB_BSON_Javascript, jsonSerialize)
 		php_phongo_bson_state state;
 
 		PHONGO_BSON_INIT_STATE(state);
-		if (!php_phongo_bson_to_zval_ex(bson_get_data(intern->scope), intern->scope->len, &state)) {
+		if (!php_phongo_bson_to_zval_ex(intern->scope, &state)) {
 			zval_ptr_dtor(&state.zchild);
 			return;
 		}
@@ -244,7 +244,7 @@ static PHP_METHOD(MongoDB_BSON_Javascript, serialize)
 	PHONGO_PARSE_PARAMETERS_NONE();
 
 	if (intern->scope && intern->scope->len) {
-		if (!php_phongo_bson_to_zval_ex(bson_get_data(intern->scope), intern->scope->len, &state)) {
+		if (!php_phongo_bson_to_zval_ex(intern->scope, &state)) {
 			zval_ptr_dtor(&state.zchild);
 			return;
 		}

--- a/src/BSON/functions.c
+++ b/src/BSON/functions.c
@@ -65,7 +65,7 @@ PHP_FUNCTION(toPHP)
 		return;
 	}
 
-	if (!php_phongo_bson_to_zval_ex((const unsigned char*) data, data_len, &state)) {
+	if (!php_phongo_bson_data_to_zval_ex((const unsigned char*) data, data_len, &state)) {
 		zval_ptr_dtor(&state.zchild);
 		php_phongo_bson_typemap_dtor(&state.map);
 		RETURN_NULL();

--- a/src/MongoDB/BulkWrite.c
+++ b/src/MongoDB/BulkWrite.c
@@ -40,7 +40,7 @@ static void php_phongo_bulkwrite_extract_id(bson_t* doc, zval** return_value)
 	php_phongo_bson_state state;
 
 	PHONGO_BSON_INIT_STATE(state);
-	state.map.root_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
+	state.map.root.type = PHONGO_TYPEMAP_NATIVE_ARRAY;
 
 	if (!php_phongo_bson_to_zval_ex(doc, &state)) {
 		goto cleanup;

--- a/src/MongoDB/BulkWrite.c
+++ b/src/MongoDB/BulkWrite.c
@@ -42,7 +42,7 @@ static void php_phongo_bulkwrite_extract_id(bson_t* doc, zval** return_value)
 	PHONGO_BSON_INIT_STATE(state);
 	state.map.root_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
 
-	if (!php_phongo_bson_to_zval_ex(bson_get_data(doc), doc->len, &state)) {
+	if (!php_phongo_bson_to_zval_ex(doc, &state)) {
 		goto cleanup;
 	}
 
@@ -632,7 +632,7 @@ static HashTable* php_phongo_bulkwrite_get_debug_info(phongo_compat_object_handl
 	if (intern->let) {
 		zval zv;
 
-		if (!php_phongo_bson_to_zval(bson_get_data(intern->let), intern->let->len, &zv)) {
+		if (!php_phongo_bson_to_zval(intern->let, &zv)) {
 			zval_ptr_dtor(&zv);
 			goto done;
 		}

--- a/src/MongoDB/ClientEncryption.c
+++ b/src/MongoDB/ClientEncryption.c
@@ -40,15 +40,15 @@ static void phongo_clientencryption_create_datakey(php_phongo_clientencryption_t
 static void phongo_clientencryption_encrypt(php_phongo_clientencryption_t* clientencryption, zval* zvalue, zval* zciphertext, zval* options);
 static void phongo_clientencryption_decrypt(php_phongo_clientencryption_t* clientencryption, zval* zciphertext, zval* zvalue);
 
-#define RETVAL_BSON_T(reply)                                                             \
-	do {                                                                                 \
-		php_phongo_bson_state state;                                                     \
-		PHONGO_BSON_INIT_STATE(state);                                                   \
-		if (!php_phongo_bson_to_zval_ex(bson_get_data(&(reply)), (reply).len, &state)) { \
-			zval_ptr_dtor(&state.zchild);                                                \
-			goto cleanup;                                                                \
-		}                                                                                \
-		RETVAL_ZVAL(&state.zchild, 0, 1);                                                \
+#define RETVAL_BSON_T(reply)                                 \
+	do {                                                     \
+		php_phongo_bson_state state;                         \
+		PHONGO_BSON_INIT_STATE(state);                       \
+		if (!php_phongo_bson_to_zval_ex(&(reply), &state)) { \
+			zval_ptr_dtor(&state.zchild);                    \
+			goto cleanup;                                    \
+		}                                                    \
+		RETVAL_ZVAL(&state.zchild, 0, 1);                    \
 	} while (0)
 
 #define RETVAL_OPTIONAL_BSON_T(reply) \

--- a/src/MongoDB/Command.c
+++ b/src/MongoDB/Command.c
@@ -156,7 +156,7 @@ static HashTable* php_phongo_command_get_debug_info(phongo_compat_object_handler
 	if (intern->bson) {
 		zval zv;
 
-		if (!php_phongo_bson_to_zval(bson_get_data(intern->bson), intern->bson->len, &zv)) {
+		if (!php_phongo_bson_to_zval(intern->bson, &zv)) {
 			zval_ptr_dtor(&zv);
 			goto done;
 		}

--- a/src/MongoDB/Cursor.c
+++ b/src/MongoDB/Cursor.c
@@ -90,7 +90,7 @@ static PHP_METHOD(MongoDB_Driver_Cursor, setTypeMap)
 	if (restore_current_element && mongoc_cursor_current(intern->cursor)) {
 		const bson_t* doc = mongoc_cursor_current(intern->cursor);
 
-		if (!php_phongo_bson_to_zval_ex(bson_get_data(doc), doc->len, &intern->visitor_data)) {
+		if (!php_phongo_bson_to_zval_ex(doc, &intern->visitor_data)) {
 			php_phongo_cursor_free_current(intern);
 		}
 	}
@@ -223,7 +223,7 @@ static PHP_METHOD(MongoDB_Driver_Cursor, next)
 	}
 
 	if (mongoc_cursor_next(intern->cursor, &doc)) {
-		if (!php_phongo_bson_to_zval_ex(bson_get_data(doc), doc->len, &intern->visitor_data)) {
+		if (!php_phongo_bson_to_zval_ex(doc, &intern->visitor_data)) {
 			/* Free invalid result, but don't return as we want to free the
 			 * session if the intern is exhausted. */
 			php_phongo_cursor_free_current(intern);
@@ -278,7 +278,7 @@ static PHP_METHOD(MongoDB_Driver_Cursor, rewind)
 	doc = mongoc_cursor_current(intern->cursor);
 
 	if (doc) {
-		if (!php_phongo_bson_to_zval_ex(bson_get_data(doc), doc->len, &intern->visitor_data)) {
+		if (!php_phongo_bson_to_zval_ex(doc, &intern->visitor_data)) {
 			/* Free invalid result, but don't return as we want to free the
 			 * session if the intern is exhausted. */
 			php_phongo_cursor_free_current(intern);

--- a/src/MongoDB/Monitoring/CommandFailedEvent.c
+++ b/src/MongoDB/Monitoring/CommandFailedEvent.c
@@ -94,7 +94,7 @@ static PHP_METHOD(MongoDB_Driver_Monitoring_CommandFailedEvent, getReply)
 
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	if (!php_phongo_bson_to_zval_ex(bson_get_data(intern->reply), intern->reply->len, &state)) {
+	if (!php_phongo_bson_to_zval_ex(intern->reply, &state)) {
 		zval_ptr_dtor(&state.zchild);
 		return;
 	}
@@ -223,7 +223,7 @@ static HashTable* php_phongo_commandfailedevent_get_debug_info(phongo_compat_obj
 	sprintf(operation_id, "%" PRIu64, intern->operation_id);
 	ADD_ASSOC_STRING(&retval, "operationId", operation_id);
 
-	if (!php_phongo_bson_to_zval_ex(bson_get_data(intern->reply), intern->reply->len, &reply_state)) {
+	if (!php_phongo_bson_to_zval_ex(intern->reply, &reply_state)) {
 		zval_ptr_dtor(&reply_state.zchild);
 		goto done;
 	}

--- a/src/MongoDB/Monitoring/CommandStartedEvent.c
+++ b/src/MongoDB/Monitoring/CommandStartedEvent.c
@@ -44,7 +44,7 @@ static PHP_METHOD(MongoDB_Driver_Monitoring_CommandStartedEvent, getCommand)
 
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	if (!php_phongo_bson_to_zval_ex(bson_get_data(intern->command), intern->command->len, &state)) {
+	if (!php_phongo_bson_to_zval_ex(intern->command, &state)) {
 		zval_ptr_dtor(&state.zchild);
 		return;
 	}
@@ -202,7 +202,7 @@ static HashTable* php_phongo_commandstartedevent_get_debug_info(phongo_compat_ob
 	*is_temp = 1;
 	array_init_size(&retval, 6);
 
-	if (!php_phongo_bson_to_zval_ex(bson_get_data(intern->command), intern->command->len, &command_state)) {
+	if (!php_phongo_bson_to_zval_ex(intern->command, &command_state)) {
 		zval_ptr_dtor(&command_state.zchild);
 		goto done;
 	}

--- a/src/MongoDB/Monitoring/CommandSucceededEvent.c
+++ b/src/MongoDB/Monitoring/CommandSucceededEvent.c
@@ -82,7 +82,7 @@ static PHP_METHOD(MongoDB_Driver_Monitoring_CommandSucceededEvent, getReply)
 
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	if (!php_phongo_bson_to_zval_ex(bson_get_data(intern->reply), intern->reply->len, &state)) {
+	if (!php_phongo_bson_to_zval_ex(intern->reply, &state)) {
 		zval_ptr_dtor(&state.zchild);
 		return;
 	}
@@ -204,7 +204,7 @@ static HashTable* php_phongo_commandsucceededevent_get_debug_info(phongo_compat_
 	sprintf(operation_id, "%" PRIu64, intern->operation_id);
 	ADD_ASSOC_STRING(&retval, "operationId", operation_id);
 
-	if (!php_phongo_bson_to_zval_ex(bson_get_data(intern->reply), intern->reply->len, &reply_state)) {
+	if (!php_phongo_bson_to_zval_ex(intern->reply, &reply_state)) {
 		zval_ptr_dtor(&reply_state.zchild);
 		goto done;
 	}

--- a/src/MongoDB/Monitoring/ServerHeartbeatSucceededEvent.c
+++ b/src/MongoDB/Monitoring/ServerHeartbeatSucceededEvent.c
@@ -66,7 +66,7 @@ static PHP_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEvent, getRe
 
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	if (!php_phongo_bson_to_zval_ex(bson_get_data(intern->reply), intern->reply->len, &state)) {
+	if (!php_phongo_bson_to_zval_ex(intern->reply, &state)) {
 		zval_ptr_dtor(&state.zchild);
 		return;
 	}
@@ -126,7 +126,7 @@ static HashTable* php_phongo_serverheartbeatsucceededevent_get_debug_info(phongo
 	ADD_ASSOC_LONG_EX(&retval, "port", intern->host.port);
 	ADD_ASSOC_BOOL_EX(&retval, "awaited", intern->awaited);
 
-	if (!php_phongo_bson_to_zval_ex(bson_get_data(intern->reply), intern->reply->len, &reply_state)) {
+	if (!php_phongo_bson_to_zval_ex(intern->reply, &reply_state)) {
 		zval_ptr_dtor(&reply_state.zchild);
 		goto done;
 	}

--- a/src/MongoDB/Query.c
+++ b/src/MongoDB/Query.c
@@ -471,7 +471,7 @@ static HashTable* php_phongo_query_get_debug_info(phongo_compat_object_handler_t
 	if (intern->filter) {
 		zval zv;
 
-		if (!php_phongo_bson_to_zval(bson_get_data(intern->filter), intern->filter->len, &zv)) {
+		if (!php_phongo_bson_to_zval(intern->filter, &zv)) {
 			zval_ptr_dtor(&zv);
 			goto done;
 		}
@@ -484,7 +484,7 @@ static HashTable* php_phongo_query_get_debug_info(phongo_compat_object_handler_t
 	if (intern->opts) {
 		zval zv;
 
-		if (!php_phongo_bson_to_zval(bson_get_data(intern->opts), intern->opts->len, &zv)) {
+		if (!php_phongo_bson_to_zval(intern->opts, &zv)) {
 			zval_ptr_dtor(&zv);
 			goto done;
 		}

--- a/src/MongoDB/ReadPreference.c
+++ b/src/MongoDB/ReadPreference.c
@@ -341,7 +341,7 @@ static PHP_METHOD(MongoDB_Driver_ReadPreference, getHedge)
 
 		PHONGO_BSON_INIT_STATE(state);
 
-		if (!php_phongo_bson_to_zval_ex(bson_get_data(hedge), hedge->len, &state)) {
+		if (!php_phongo_bson_to_zval_ex(hedge, &state)) {
 			zval_ptr_dtor(&state.zchild);
 			return;
 		}
@@ -412,7 +412,7 @@ static PHP_METHOD(MongoDB_Driver_ReadPreference, getTagSets)
 
 		PHONGO_BSON_INIT_DEBUG_STATE(state);
 
-		if (!php_phongo_bson_to_zval_ex(bson_get_data(tags), tags->len, &state)) {
+		if (!php_phongo_bson_to_zval_ex(tags, &state)) {
 			zval_ptr_dtor(&state.zchild);
 			return;
 		}
@@ -460,7 +460,7 @@ static HashTable* php_phongo_readpreference_get_properties_hash(phongo_compat_ob
 		PHONGO_BSON_INIT_STATE(state);
 		state.map.root_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
 
-		if (!php_phongo_bson_to_zval_ex(bson_get_data(tags), tags->len, &state)) {
+		if (!php_phongo_bson_to_zval_ex(tags, &state)) {
 			zval_ptr_dtor(&state.zchild);
 			goto done;
 		}
@@ -483,7 +483,7 @@ static HashTable* php_phongo_readpreference_get_properties_hash(phongo_compat_ob
 
 		PHONGO_BSON_INIT_STATE(state);
 
-		if (!php_phongo_bson_to_zval_ex(bson_get_data(hedge), hedge->len, &state)) {
+		if (!php_phongo_bson_to_zval_ex(hedge, &state)) {
 			zval_ptr_dtor(&state.zchild);
 			goto done;
 		}
@@ -540,7 +540,7 @@ static PHP_METHOD(MongoDB_Driver_ReadPreference, serialize)
 
 		PHONGO_BSON_INIT_DEBUG_STATE(state);
 
-		if (!php_phongo_bson_to_zval_ex(bson_get_data(tags), tags->len, &state)) {
+		if (!php_phongo_bson_to_zval_ex(tags, &state)) {
 			zval_ptr_dtor(&state.zchild);
 			return;
 		}
@@ -557,7 +557,7 @@ static PHP_METHOD(MongoDB_Driver_ReadPreference, serialize)
 
 		PHONGO_BSON_INIT_STATE(state);
 
-		if (!php_phongo_bson_to_zval_ex(bson_get_data(hedge), hedge->len, &state)) {
+		if (!php_phongo_bson_to_zval_ex(hedge, &state)) {
 			zval_ptr_dtor(&state.zchild);
 			return;
 		}

--- a/src/MongoDB/ReadPreference.c
+++ b/src/MongoDB/ReadPreference.c
@@ -458,7 +458,7 @@ static HashTable* php_phongo_readpreference_get_properties_hash(phongo_compat_ob
 		/* Use PHONGO_TYPEMAP_NATIVE_ARRAY for the root type since tags is an
 		 * array; however, inner documents and arrays can use the default. */
 		PHONGO_BSON_INIT_STATE(state);
-		state.map.root_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
+		state.map.root.type = PHONGO_TYPEMAP_NATIVE_ARRAY;
 
 		if (!php_phongo_bson_to_zval_ex(tags, &state)) {
 			zval_ptr_dtor(&state.zchild);

--- a/src/MongoDB/Server.c
+++ b/src/MongoDB/Server.c
@@ -257,7 +257,7 @@ static PHP_METHOD(MongoDB_Driver_Server, getTags)
 			PHONGO_BSON_INIT_DEBUG_STATE(state);
 			bson_iter_document(&iter, &len, &bytes);
 
-			if (!php_phongo_bson_to_zval_ex(bytes, len, &state)) {
+			if (!php_phongo_bson_data_to_zval_ex(bytes, len, &state)) {
 				/* Exception should already have been thrown */
 				zval_ptr_dtor(&state.zchild);
 				mongoc_server_description_destroy(sd);
@@ -316,7 +316,7 @@ static PHP_METHOD(MongoDB_Driver_Server, getInfo)
 
 	PHONGO_BSON_INIT_DEBUG_STATE(state);
 
-	if (!php_phongo_bson_to_zval_ex(bson_get_data(hello_response), hello_response->len, &state)) {
+	if (!php_phongo_bson_to_zval_ex(hello_response, &state)) {
 		/* Exception should already have been thrown */
 		zval_ptr_dtor(&state.zchild);
 		goto cleanup;
@@ -640,7 +640,7 @@ bool php_phongo_server_to_zval(zval* retval, mongoc_client_t* client, mongoc_ser
 
 		PHONGO_BSON_INIT_DEBUG_STATE(state);
 		bson_iter_document(&iter, &len, &bytes);
-		if (!php_phongo_bson_to_zval_ex(bytes, len, &state)) {
+		if (!php_phongo_bson_data_to_zval_ex(bytes, len, &state)) {
 			/* Exception already thrown */
 			zval_ptr_dtor(&state.zchild);
 			return false;
@@ -666,7 +666,7 @@ bool php_phongo_server_to_zval(zval* retval, mongoc_client_t* client, mongoc_ser
 		PHONGO_BSON_INIT_DEBUG_STATE(state);
 		handshake_response = mongoc_server_description_hello_response(handshake_sd);
 
-		if (!php_phongo_bson_to_zval_ex(bson_get_data(handshake_response), handshake_response->len, &state)) {
+		if (!php_phongo_bson_to_zval_ex(handshake_response, &state)) {
 			/* Exception already thrown */
 			mongoc_server_description_destroy(handshake_sd);
 			zval_ptr_dtor(&state.zchild);
@@ -680,7 +680,7 @@ bool php_phongo_server_to_zval(zval* retval, mongoc_client_t* client, mongoc_ser
 
 		PHONGO_BSON_INIT_DEBUG_STATE(state);
 
-		if (!php_phongo_bson_to_zval_ex(bson_get_data(hello_response), hello_response->len, &state)) {
+		if (!php_phongo_bson_to_zval_ex(hello_response, &state)) {
 			/* Exception already thrown */
 			zval_ptr_dtor(&state.zchild);
 			return false;

--- a/src/MongoDB/ServerDescription.c
+++ b/src/MongoDB/ServerDescription.c
@@ -67,7 +67,7 @@ static PHP_METHOD(MongoDB_Driver_ServerDescription, getHelloResponse)
 
 	PHONGO_BSON_INIT_DEBUG_STATE(state);
 
-	if (!php_phongo_bson_to_zval_ex(bson_get_data(helloResponse), helloResponse->len, &state)) {
+	if (!php_phongo_bson_to_zval_ex(helloResponse, &state)) {
 		/* Exception should already have been thrown */
 		zval_ptr_dtor(&state.zchild);
 		return;
@@ -214,7 +214,7 @@ HashTable* php_phongo_serverdescription_get_properties_hash(phongo_compat_object
 
 		PHONGO_BSON_INIT_DEBUG_STATE(state);
 
-		if (!php_phongo_bson_to_zval_ex(bson_get_data(hello_response), hello_response->len, &state)) {
+		if (!php_phongo_bson_to_zval_ex(hello_response, &state)) {
 			zval_ptr_dtor(&state.zchild);
 			goto done;
 		}

--- a/src/MongoDB/Session.c
+++ b/src/MongoDB/Session.c
@@ -226,7 +226,7 @@ static PHP_METHOD(MongoDB_Driver_Session, getClusterTime)
 		RETURN_NULL();
 	}
 
-	if (!php_phongo_bson_to_zval_ex(bson_get_data(cluster_time), cluster_time->len, &state)) {
+	if (!php_phongo_bson_to_zval_ex(cluster_time, &state)) {
 		/* Exception should already have been thrown */
 		zval_ptr_dtor(&state.zchild);
 		return;
@@ -251,7 +251,7 @@ static PHP_METHOD(MongoDB_Driver_Session, getLogicalSessionId)
 
 	lsid = mongoc_client_session_get_lsid(intern->client_session);
 
-	if (!php_phongo_bson_to_zval_ex(bson_get_data(lsid), lsid->len, &state)) {
+	if (!php_phongo_bson_to_zval_ex(lsid, &state)) {
 		/* Exception should already have been thrown */
 		zval_ptr_dtor(&state.zchild);
 		return;
@@ -602,7 +602,7 @@ static HashTable* php_phongo_session_get_debug_info(phongo_compat_object_handler
 
 		PHONGO_BSON_INIT_DEBUG_STATE(state);
 
-		if (!php_phongo_bson_to_zval_ex(bson_get_data(lsid), lsid->len, &state)) {
+		if (!php_phongo_bson_to_zval_ex(lsid, &state)) {
 			zval_ptr_dtor(&state.zchild);
 			goto done;
 		}
@@ -618,7 +618,7 @@ static HashTable* php_phongo_session_get_debug_info(phongo_compat_object_handler
 
 			PHONGO_BSON_INIT_DEBUG_STATE(state);
 
-			if (!php_phongo_bson_to_zval_ex(bson_get_data(cluster_time), cluster_time->len, &state)) {
+			if (!php_phongo_bson_to_zval_ex(cluster_time, &state)) {
 				zval_ptr_dtor(&state.zchild);
 				goto done;
 			}

--- a/src/MongoDB/WriteConcernError.c
+++ b/src/MongoDB/WriteConcernError.c
@@ -158,7 +158,7 @@ zend_bool phongo_writeconcernerror_init(zval* return_value, bson_t* bson)
 
 		bson_iter_document(&iter, &len, &data);
 
-		if (!php_phongo_bson_to_zval(data, len, &intern->info)) {
+		if (!php_phongo_bson_data_to_zval(data, len, &intern->info)) {
 			zval_ptr_dtor(&intern->info);
 			ZVAL_UNDEF(&intern->info);
 

--- a/src/MongoDB/WriteError.c
+++ b/src/MongoDB/WriteError.c
@@ -173,7 +173,7 @@ zend_bool phongo_writeerror_init(zval* return_value, bson_t* bson)
 
 		bson_iter_document(&iter, &len, &data);
 
-		if (!php_phongo_bson_to_zval(data, len, &intern->info)) {
+		if (!php_phongo_bson_data_to_zval(data, len, &intern->info)) {
 			zval_ptr_dtor(&intern->info);
 			ZVAL_UNDEF(&intern->info);
 

--- a/src/MongoDB/WriteResult.c
+++ b/src/MongoDB/WriteResult.c
@@ -230,7 +230,7 @@ static PHP_METHOD(MongoDB_Driver_WriteResult, getUpsertedIds)
 			/* Use PHONGO_TYPEMAP_NATIVE_ARRAY for the root type so we can
 			 * easily access the "index" and "_id" fields. */
 			PHONGO_BSON_INIT_STATE(state);
-			state.map.root_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
+			state.map.root.type = PHONGO_TYPEMAP_NATIVE_ARRAY;
 
 			if (!BSON_ITER_HOLDS_DOCUMENT(&child)) {
 				continue;

--- a/src/MongoDB/WriteResult.c
+++ b/src/MongoDB/WriteResult.c
@@ -238,7 +238,7 @@ static PHP_METHOD(MongoDB_Driver_WriteResult, getUpsertedIds)
 
 			bson_iter_document(&child, &data_len, &data);
 
-			if (php_phongo_bson_to_zval_ex(data, data_len, &state)) {
+			if (php_phongo_bson_data_to_zval_ex(data, data_len, &state)) {
 				zval* zid = php_array_fetchc(&state.zchild, "_id");
 				add_index_zval(return_value, php_array_fetchc_long(&state.zchild, "index"), zid);
 				zval_add_ref(zid);
@@ -351,7 +351,7 @@ static HashTable* php_phongo_writeresult_get_debug_info(phongo_compat_object_han
 
 		PHONGO_BSON_INIT_DEBUG_STATE(state);
 		bson_iter_array(&iter, &len, &data);
-		if (!php_phongo_bson_to_zval_ex(data, len, &state)) {
+		if (!php_phongo_bson_data_to_zval_ex(data, len, &state)) {
 			zval_ptr_dtor(&state.zchild);
 			goto done;
 		}

--- a/src/phongo_bson.c
+++ b/src/phongo_bson.c
@@ -758,8 +758,8 @@ static void php_phongo_handle_field_path_entry_for_compound_type(php_phongo_bson
 				element->type = entry->node.type;
 				break;
 			case PHONGO_TYPEMAP_CLASS:
-				element->type  = entry->node.type;
-				element->ce    = entry->node.ce;
+				element->type = entry->node.type;
+				element->ce   = entry->node.ce;
 				break;
 			default:
 				/* Do nothing - pacify compiler */
@@ -1267,11 +1267,11 @@ static bool php_phongo_bson_state_parse_type(zval* options, const char* name, ph
 	}
 
 	if (!strcasecmp(classname, "array")) {
-		element->type  = PHONGO_TYPEMAP_NATIVE_ARRAY;
-		element->ce    = NULL;
+		element->type = PHONGO_TYPEMAP_NATIVE_ARRAY;
+		element->ce   = NULL;
 	} else if (!strcasecmp(classname, "stdclass") || !strcasecmp(classname, "object")) {
-		element->type  = PHONGO_TYPEMAP_NATIVE_OBJECT;
-		element->ce    = NULL;
+		element->type = PHONGO_TYPEMAP_NATIVE_OBJECT;
+		element->ce   = NULL;
 	} else {
 		if ((element->ce = php_phongo_bson_state_fetch_class(classname, classname_len, php_phongo_unserializable_ce))) {
 			element->type = PHONGO_TYPEMAP_CLASS;
@@ -1290,8 +1290,8 @@ cleanup:
 
 static void field_path_map_element_set_info(php_phongo_field_path_map_element* element, php_phongo_bson_typemap_element* typemap_element)
 {
-	element->node.type  = typemap_element->type;
-	element->node.ce    = typemap_element->ce;
+	element->node.type = typemap_element->type;
+	element->node.ce   = typemap_element->ce;
 }
 
 static void map_add_field_path_element(php_phongo_bson_typemap* map, php_phongo_field_path_map_element* element)

--- a/src/phongo_bson.c
+++ b/src/phongo_bson.c
@@ -37,7 +37,7 @@
 
 /* Forward declarations */
 static bool php_phongo_bson_visit_document(const bson_iter_t* iter ARG_UNUSED, const char* key, const bson_t* v_document, void* data);
-static bool php_phongo_bson_visit_array(const bson_iter_t* iter ARG_UNUSED, const char* key, const bson_t* v_document, void* data);
+static bool php_phongo_bson_visit_array(const bson_iter_t* iter ARG_UNUSED, const char* key, const bson_t* v_array, void* data);
 
 /* Path builder */
 char* php_phongo_field_path_as_string(php_phongo_field_path* field_path)

--- a/src/phongo_bson.c
+++ b/src/phongo_bson.c
@@ -759,7 +759,7 @@ static void php_phongo_handle_field_path_entry_for_compound_type(php_phongo_bson
 				break;
 			case PHONGO_TYPEMAP_CLASS:
 				element->type  = entry->node.type;
-				element->class = entry->node.class;
+				element->ce    = entry->node.ce;
 				break;
 			default:
 				/* Do nothing - pacify compiler */
@@ -900,7 +900,7 @@ static bool php_phongo_bson_visit_document(const bson_iter_t* iter ARG_UNUSED, c
 
 		case PHONGO_TYPEMAP_CLASS: {
 			zval              obj;
-			zend_class_entry* obj_ce = state.odm ? state.odm : state.map.document.class;
+			zend_class_entry* obj_ce = state.odm ? state.odm : state.map.document.ce;
 
 			if (!php_phongo_bson_init_document_object(&state.zchild, obj_ce, &obj)) {
 				/* Exception already thrown. Clean up and return
@@ -975,7 +975,7 @@ static bool php_phongo_bson_visit_array(const bson_iter_t* iter ARG_UNUSED, cons
 		case PHONGO_TYPEMAP_CLASS: {
 			zval obj;
 
-			object_init_ex(&obj, state.map.array.class);
+			object_init_ex(&obj, state.map.array.ce);
 			zend_call_method_with_1_params(PHONGO_COMPAT_OBJ_P(&obj), NULL, NULL, BSON_UNSERIALIZE_FUNC_NAME, NULL, &state.zchild);
 			zval_ptr_dtor(&state.zchild);
 			ZVAL_COPY_VALUE(&state.zchild, &obj);
@@ -1124,7 +1124,7 @@ bool php_phongo_bson_to_zval_ex(const bson_t* b, php_phongo_bson_state* state)
 
 		case PHONGO_TYPEMAP_CLASS: {
 			zval              obj;
-			zend_class_entry* obj_ce = state->odm ? state->odm : state->map.root.class;
+			zend_class_entry* obj_ce = state->odm ? state->odm : state->map.root.ce;
 
 #if PHP_VERSION_ID >= 80100
 			/* Enums require special handling for instantiation */
@@ -1267,12 +1267,12 @@ static bool php_phongo_bson_state_parse_type(zval* options, const char* name, ph
 
 	if (!strcasecmp(classname, "array")) {
 		element->type  = PHONGO_TYPEMAP_NATIVE_ARRAY;
-		element->class = NULL;
+		element->ce    = NULL;
 	} else if (!strcasecmp(classname, "stdclass") || !strcasecmp(classname, "object")) {
 		element->type  = PHONGO_TYPEMAP_NATIVE_OBJECT;
-		element->class = NULL;
+		element->ce    = NULL;
 	} else {
-		if ((element->class = php_phongo_bson_state_fetch_class(classname, classname_len, php_phongo_unserializable_ce))) {
+		if ((element->ce = php_phongo_bson_state_fetch_class(classname, classname_len, php_phongo_unserializable_ce))) {
 			element->type = PHONGO_TYPEMAP_CLASS;
 		} else {
 			retval = false;
@@ -1290,7 +1290,7 @@ cleanup:
 static void field_path_map_element_set_info(php_phongo_field_path_map_element* element, php_phongo_bson_typemap_element* typemap_element)
 {
 	element->node.type  = typemap_element->type;
-	element->node.class = typemap_element->class;
+	element->node.ce    = typemap_element->ce;
 }
 
 static void map_add_field_path_element(php_phongo_bson_typemap* map, php_phongo_field_path_map_element* element)

--- a/src/phongo_bson.c
+++ b/src/phongo_bson.c
@@ -842,6 +842,7 @@ static bool php_phongo_bson_init_document_object(zval* src, zend_class_entry* ob
 		}
 
 		if (!enum_case) {
+			/* Exception already thrown */
 			return false;
 		}
 

--- a/src/phongo_bson.h
+++ b/src/phongo_bson.h
@@ -48,18 +48,19 @@ typedef enum {
 } php_phongo_bson_typemap_types;
 
 typedef struct {
-	php_phongo_field_path*        entry;
-	php_phongo_bson_typemap_types node_type;
-	zend_class_entry*             node_ce;
+	php_phongo_bson_typemap_types type;
+	zend_class_entry* class;
+} php_phongo_bson_typemap_element;
+
+typedef struct {
+	php_phongo_field_path*          entry;
+	php_phongo_bson_typemap_element node;
 } php_phongo_field_path_map_element;
 
 typedef struct {
-	php_phongo_bson_typemap_types document_type;
-	zend_class_entry*             document;
-	php_phongo_bson_typemap_types array_type;
-	zend_class_entry*             array;
-	php_phongo_bson_typemap_types root_type;
-	zend_class_entry*             root;
+	php_phongo_bson_typemap_element document;
+	php_phongo_bson_typemap_element array;
+	php_phongo_bson_typemap_element root;
 	struct {
 		php_phongo_field_path_map_element** map;
 		size_t                              allocated_size;
@@ -83,8 +84,8 @@ typedef struct {
 #define PHONGO_BSON_INIT_DEBUG_STATE(s)                    \
 	do {                                                   \
 		memset(&(s), 0, sizeof(php_phongo_bson_state));    \
-		s.map.root_type     = PHONGO_TYPEMAP_NATIVE_ARRAY; \
-		s.map.document_type = PHONGO_TYPEMAP_NATIVE_ARRAY; \
+		s.map.root.type     = PHONGO_TYPEMAP_NATIVE_ARRAY; \
+		s.map.document.type = PHONGO_TYPEMAP_NATIVE_ARRAY; \
 	} while (0)
 
 char*                  php_phongo_field_path_as_string(php_phongo_field_path* field_path);

--- a/src/phongo_bson.h
+++ b/src/phongo_bson.h
@@ -95,8 +95,10 @@ void                   php_phongo_field_path_write_type_at_current_level(php_pho
 bool                   php_phongo_field_path_push(php_phongo_field_path* field_path, const char* element, php_phongo_bson_field_path_item_types element_type);
 bool                   php_phongo_field_path_pop(php_phongo_field_path* field_path);
 
-bool php_phongo_bson_to_zval(const unsigned char* data, int data_len, zval* out);
-bool php_phongo_bson_to_zval_ex(const unsigned char* data, int data_len, php_phongo_bson_state* state);
+bool php_phongo_bson_to_zval(const bson_t* b, zval* zv);
+bool php_phongo_bson_to_zval_ex(const bson_t* b, php_phongo_bson_state* state);
+bool php_phongo_bson_data_to_zval(const unsigned char* data, int data_len, zval* zv);
+bool php_phongo_bson_data_to_zval_ex(const unsigned char* data, int data_len, php_phongo_bson_state* state);
 
 bool php_phongo_bson_value_to_zval(const bson_value_t* value, zval* zv);
 

--- a/src/phongo_bson.h
+++ b/src/phongo_bson.h
@@ -49,7 +49,7 @@ typedef enum {
 
 typedef struct {
 	php_phongo_bson_typemap_types type;
-	zend_class_entry* class;
+	zend_class_entry*             ce;
 } php_phongo_bson_typemap_element;
 
 typedef struct {

--- a/src/phongo_error.c
+++ b/src/phongo_error.c
@@ -194,7 +194,7 @@ void phongo_throw_exception_from_bson_error_t_and_reply(bson_error_t* error, con
 		zval zv;
 
 		zend_throw_exception(php_phongo_commandexception_ce, error->message, error->code);
-		if (php_phongo_bson_to_zval(bson_get_data(reply), reply->len, &zv)) {
+		if (php_phongo_bson_to_zval(reply, &zv)) {
 			phongo_add_exception_prop(ZEND_STRL("resultDocument"), &zv);
 		}
 


### PR DESCRIPTION
PHPC-2146

Best reviewed commit by commit. This PR introduces some refactorings that I made while prototyping raw BSON support. No functional changes are introduced as part of this PR. This improves the following:

* `php_phongo_bson_to_zval` and `php_phongo_bson_to_zval_ex` now take a `const bson_t*` instead of `char*` and `int`. Previously, the function would create a new BSON reader to create a `bson_t`, which is unnecessary as we start out with a `bson_t` to begin with. `php_phongo_bson_data_to_zval` and `php_phongo_bson_data_to_zval_ex` were added to accept a `char*` before passing this on to `php_phongo_bson_to_zval_ex`.
* The `php_phongo_bson_typemap` was updated to no longer contain a `php_phongo_bson_typemap_types` and `zend_class_entry*` for each type. Instead, a new `php_phongo_bson_typemap_element` struct containing the type and class entry was added. While better structuring data that belongs together, this also makes it easier to add new fields to the type map (in my prototype, I needed to add a potential `zval*` to this struct which would've made `php_phongo_bson_typemap` have even more fields without this refactoring.
* Instantiation of persistable objects in `php_phongo_bson_visit_document` (including handling for `enum` on PHP 8.1+) was extracted to `php_phongo_bson_init_document_object` to make the code more concise.
* Both `php_phongo_bson_visit_document` and `php_phongo_bson_visit_array` were refactored to avoid the duplication of the logic adding the resulting data structure to the parent. This will make it easier to add more options to the type map.
* The last commit fixes a wrong parameter name in the forward declaration of `php_phongo_bson_visit_array`.