### PR TITLE
PHPC-2154: Test PHP 8.2 on Appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,6 +15,12 @@ environment:
   CONFIGURE_OPTS: --enable-mongodb --with-mongodb-sasl=yes --with-mongodb-client-side-encryption=yes
 
   matrix:
+    - PHP_VER: 8.2.0RC4
+      TS: 1
+      CRT: vs16
+    - PHP_VER: 8.2.0RC4
+      TS: 0
+      CRT: vs16
     - PHP_VER: 8.1.11
       TS: 1
       CRT: vs16

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,23 +15,23 @@ environment:
   CONFIGURE_OPTS: --enable-mongodb --with-mongodb-sasl=yes --with-mongodb-client-side-encryption=yes
 
   matrix:
-    - PHP_VER: 8.1.1
+    - PHP_VER: 8.1.11
       TS: 1
       CRT: vs16
-    - PHP_VER: 8.1.1
+    - PHP_VER: 8.1.11
       TS: 0
       CRT: vs16
-    - PHP_VER: 8.0.14
+    - PHP_VER: 8.0.24
       TS: 1
       CRT: vs16
-    - PHP_VER: 8.0.14
+    - PHP_VER: 8.0.24
       TS: 0
       CRT: vs16
-    - PHP_VER: 7.4.27
+    - PHP_VER: 7.4.32
       TS: 1
       CRT: vc15
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    - PHP_VER: 7.4.27
+    - PHP_VER: 7.4.32
       TS: 0
       CRT: vc15
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2017
+image: Visual Studio 2019
 version: '{branch}.{build}'
 
 clone_folder: c:\projects\mongodb
@@ -18,37 +18,39 @@ environment:
     - PHP_VER: 8.1.1
       TS: 1
       CRT: vs16
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
     - PHP_VER: 8.1.1
       TS: 0
       CRT: vs16
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
     - PHP_VER: 8.0.14
       TS: 1
       CRT: vs16
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
     - PHP_VER: 8.0.14
       TS: 0
       CRT: vs16
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
     - PHP_VER: 7.4.27
       TS: 1
       CRT: vc15
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     - PHP_VER: 7.4.27
       TS: 0
       CRT: vc15
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     - PHP_VER: 7.3.33
       TS: 1
       CRT: vc15
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     - PHP_VER: 7.3.33
       TS: 0
       CRT: vc15
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     - PHP_VER: 7.2.34
       TS: 1
       CRT: vc15
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     - PHP_VER: 7.2.34
       TS: 0
       CRT: vc15
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
 services:
   - mongodb


### PR DESCRIPTION
This PR updates PHP versions to the latest stable version and adds PHP 8.2.0RC4 to the build matrix.

The default image has been changed to Visual Studio 2019 and the matrix configuration inverted; this is to simplify the configuration when adding new PHP versions.