### PR TITLE
Bump required libmongoc version

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1154,9 +1154,9 @@ axes:
     display_name: libmongoc version
     values:
       - id: "lowest-supported"
-        display_name: "1.22.1"
+        display_name: "1.23.0"
         variables:
-          LIBMONGOC_VERSION: "1.22.1"
+          LIBMONGOC_VERSION: "1.23.0"
       - id: "upcoming-stable"
         display_name: "1.23-dev"
         variables:

--- a/config.m4
+++ b/config.m4
@@ -243,14 +243,14 @@ if test "$PHP_MONGODB" != "no"; then
     AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
     AC_MSG_CHECKING(for libbson)
     if test -x "$PKG_CONFIG" && $PKG_CONFIG --exists libbson-1.0; then
-      if $PKG_CONFIG libbson-1.0 --atleast-version 1.22.1; then
+      if $PKG_CONFIG libbson-1.0 --atleast-version 1.23.0; then
         PHP_MONGODB_BSON_CFLAGS=`$PKG_CONFIG libbson-1.0 --cflags`
         PHP_MONGODB_BSON_LIBS=`$PKG_CONFIG libbson-1.0 --libs`
         PHP_MONGODB_BSON_VERSION=`$PKG_CONFIG libbson-1.0 --modversion`
         PHP_MONGODB_BSON_VERSION_STRING="System ($PHP_MONGODB_BSON_VERSION)"
         AC_MSG_RESULT(version $PHP_MONGODB_BSON_VERSION found)
       else
-        AC_MSG_ERROR(system libbson must be upgraded to version >= 1.22.1)
+        AC_MSG_ERROR(system libbson must be upgraded to version >= 1.23.0)
       fi
     else
       AC_MSG_ERROR(pkgconfig and libbson must be installed)
@@ -261,14 +261,14 @@ if test "$PHP_MONGODB" != "no"; then
 
     AC_MSG_CHECKING(for libmongoc)
     if test -x "$PKG_CONFIG" && $PKG_CONFIG --exists libmongoc-1.0; then
-      if $PKG_CONFIG libmongoc-1.0 --atleast-version 1.22.1; then
+      if $PKG_CONFIG libmongoc-1.0 --atleast-version 1.23.0; then
         PHP_MONGODB_MONGOC_CFLAGS=`$PKG_CONFIG libmongoc-1.0 --cflags`
         PHP_MONGODB_MONGOC_LIBS=`$PKG_CONFIG libmongoc-1.0 --libs`
         PHP_MONGODB_MONGOC_VERSION=`$PKG_CONFIG libmongoc-1.0 --modversion`
         PHP_MONGODB_MONGOC_VERSION_STRING="System ($PHP_MONGODB_MONGOC_VERSION)"
         AC_MSG_RESULT(version $PHP_MONGODB_MONGOC_VERSION found)
       else
-        AC_MSG_ERROR(system libmongoc must be upgraded to version >= 1.22.1)
+        AC_MSG_ERROR(system libmongoc must be upgraded to version >= 1.23.0)
       fi
     else
       AC_MSG_ERROR(pkgconfig and libmongoc must be installed)


### PR DESCRIPTION
This updates our evergreen config and build scripts to require libmongoc 1.23.0. #1351 introduced the usage of `mongoc_client_get_crypt_shared_version` and updated the bundled libmongoc to a 1.23 version, but the other scripts were not updated. This caused build failures in the `lowest-supported` libmongoc axis due to it still attempting to build with 1.22.1. See the [patch build](https://spruce.mongodb.com/version/634fe0bca4cf47674d8d5a03/tasks).

Note that building against libmongoc master also fails at the moment, but this is unrelated and probably can't be fixed until we update the build file list to account for new files in libmongoc.