### PR TITLE
PHPC-2168: Use consistent int types for APM fields and snprintf

### DIFF
--- a/src/MongoDB/Monitoring/CommandFailedEvent.c
+++ b/src/MongoDB/Monitoring/CommandFailedEvent.c
@@ -72,14 +72,14 @@ static PHP_METHOD(MongoDB_Driver_Monitoring_CommandFailedEvent, getError)
 static PHP_METHOD(MongoDB_Driver_Monitoring_CommandFailedEvent, getOperationId)
 {
 	php_phongo_commandfailedevent_t* intern;
-	char                             int_as_string[20];
+	char                             operation_id[24];
 
 	intern = Z_COMMANDFAILEDEVENT_OBJ_P(getThis());
 
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	sprintf(int_as_string, "%" PRIu64, intern->operation_id);
-	RETVAL_STRING(int_as_string);
+	snprintf(operation_id, sizeof(operation_id), "%" PRId64, intern->operation_id);
+	RETVAL_STRING(operation_id);
 }
 
 /* Returns the reply document associated with the event */
@@ -106,14 +106,14 @@ static PHP_METHOD(MongoDB_Driver_Monitoring_CommandFailedEvent, getReply)
 static PHP_METHOD(MongoDB_Driver_Monitoring_CommandFailedEvent, getRequestId)
 {
 	php_phongo_commandfailedevent_t* intern;
-	char                             int_as_string[20];
+	char                             request_id[24];
 
 	intern = Z_COMMANDFAILEDEVENT_OBJ_P(getThis());
 
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	sprintf(int_as_string, "%" PRIu64, intern->request_id);
-	RETVAL_STRING(int_as_string);
+	snprintf(request_id, sizeof(request_id), "%" PRId64, intern->request_id);
+	RETVAL_STRING(request_id);
 }
 
 /* Returns the Server from which the event originated */
@@ -205,7 +205,7 @@ static HashTable* php_phongo_commandfailedevent_get_debug_info(phongo_compat_obj
 {
 	php_phongo_commandfailedevent_t* intern;
 	zval                             retval = ZVAL_STATIC_INIT;
-	char                             operation_id[20], request_id[20];
+	char                             operation_id[24], request_id[24];
 	php_phongo_bson_state            reply_state;
 
 	PHONGO_BSON_INIT_STATE(reply_state);
@@ -215,12 +215,12 @@ static HashTable* php_phongo_commandfailedevent_get_debug_info(phongo_compat_obj
 	array_init_size(&retval, 6);
 
 	ADD_ASSOC_STRING(&retval, "commandName", intern->command_name);
-	ADD_ASSOC_INT64(&retval, "durationMicros", (int64_t) intern->duration_micros);
+	ADD_ASSOC_INT64(&retval, "durationMicros", intern->duration_micros);
 
 	ADD_ASSOC_ZVAL_EX(&retval, "error", &intern->z_error);
 	Z_ADDREF(intern->z_error);
 
-	sprintf(operation_id, "%" PRIu64, intern->operation_id);
+	snprintf(operation_id, sizeof(operation_id), "%" PRId64, intern->operation_id);
 	ADD_ASSOC_STRING(&retval, "operationId", operation_id);
 
 	if (!php_phongo_bson_to_zval_ex(intern->reply, &reply_state)) {
@@ -230,7 +230,7 @@ static HashTable* php_phongo_commandfailedevent_get_debug_info(phongo_compat_obj
 
 	ADD_ASSOC_ZVAL(&retval, "reply", &reply_state.zchild);
 
-	sprintf(request_id, "%" PRIu64, intern->request_id);
+	snprintf(request_id, sizeof(request_id), "%" PRId64, intern->request_id);
 	ADD_ASSOC_STRING(&retval, "requestId", request_id);
 
 	{

--- a/src/MongoDB/Monitoring/CommandStartedEvent.c
+++ b/src/MongoDB/Monitoring/CommandStartedEvent.c
@@ -80,28 +80,28 @@ static PHP_METHOD(MongoDB_Driver_Monitoring_CommandStartedEvent, getDatabaseName
 static PHP_METHOD(MongoDB_Driver_Monitoring_CommandStartedEvent, getOperationId)
 {
 	php_phongo_commandstartedevent_t* intern;
-	char                              int_as_string[20];
+	char                              operation_id[24];
 
 	intern = Z_COMMANDSTARTEDEVENT_OBJ_P(getThis());
 
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	sprintf(int_as_string, "%" PRIu64, intern->operation_id);
-	RETVAL_STRING(int_as_string);
+	snprintf(operation_id, sizeof(operation_id), "%" PRId64, intern->operation_id);
+	RETVAL_STRING(operation_id);
 }
 
 /* Returns the event's request ID */
 static PHP_METHOD(MongoDB_Driver_Monitoring_CommandStartedEvent, getRequestId)
 {
 	php_phongo_commandstartedevent_t* intern;
-	char                              int_as_string[20];
+	char                              request_id[24];
 
 	intern = Z_COMMANDSTARTEDEVENT_OBJ_P(getThis());
 
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	sprintf(int_as_string, "%" PRIu64, intern->request_id);
-	RETVAL_STRING(int_as_string);
+	snprintf(request_id, sizeof(request_id), "%" PRId64, intern->request_id);
+	RETVAL_STRING(request_id);
 }
 
 /* Returns the Server from which the event originated */
@@ -193,7 +193,7 @@ static HashTable* php_phongo_commandstartedevent_get_debug_info(phongo_compat_ob
 {
 	php_phongo_commandstartedevent_t* intern;
 	zval                              retval = ZVAL_STATIC_INIT;
-	char                              operation_id[20], request_id[20];
+	char                              operation_id[24], request_id[24];
 	php_phongo_bson_state             command_state;
 
 	PHONGO_BSON_INIT_STATE(command_state);
@@ -212,10 +212,10 @@ static HashTable* php_phongo_commandstartedevent_get_debug_info(phongo_compat_ob
 	ADD_ASSOC_STRING(&retval, "commandName", intern->command_name);
 	ADD_ASSOC_STRING(&retval, "databaseName", intern->database_name);
 
-	sprintf(operation_id, "%" PRIu64, intern->operation_id);
+	snprintf(operation_id, sizeof(operation_id), "%" PRId64, intern->operation_id);
 	ADD_ASSOC_STRING(&retval, "operationId", operation_id);
 
-	sprintf(request_id, "%" PRIu64, intern->request_id);
+	snprintf(request_id, sizeof(request_id), "%" PRId64, intern->request_id);
 	ADD_ASSOC_STRING(&retval, "requestId", request_id);
 
 	{

--- a/src/MongoDB/Monitoring/CommandSucceededEvent.c
+++ b/src/MongoDB/Monitoring/CommandSucceededEvent.c
@@ -60,14 +60,14 @@ static PHP_METHOD(MongoDB_Driver_Monitoring_CommandSucceededEvent, getDurationMi
 static PHP_METHOD(MongoDB_Driver_Monitoring_CommandSucceededEvent, getOperationId)
 {
 	php_phongo_commandsucceededevent_t* intern;
-	char                                int_as_string[20];
+	char                                operation_id[24];
 
 	intern = Z_COMMANDSUCCEEDEDEVENT_OBJ_P(getThis());
 
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	sprintf(int_as_string, "%" PRIu64, intern->operation_id);
-	RETVAL_STRING(int_as_string);
+	snprintf(operation_id, sizeof(operation_id), "%" PRId64, intern->operation_id);
+	RETVAL_STRING(operation_id);
 }
 
 /* Returns the reply document associated with the event */
@@ -94,14 +94,14 @@ static PHP_METHOD(MongoDB_Driver_Monitoring_CommandSucceededEvent, getReply)
 static PHP_METHOD(MongoDB_Driver_Monitoring_CommandSucceededEvent, getRequestId)
 {
 	php_phongo_commandsucceededevent_t* intern;
-	char                                int_as_string[20];
+	char                                request_id[24];
 
 	intern = Z_COMMANDSUCCEEDEDEVENT_OBJ_P(getThis());
 
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	sprintf(int_as_string, "%" PRIu64, intern->request_id);
-	RETVAL_STRING(int_as_string);
+	snprintf(request_id, sizeof(request_id), "%" PRId64, intern->request_id);
+	RETVAL_STRING(request_id);
 }
 
 /* Returns the Server from which the event originated */
@@ -189,7 +189,7 @@ static HashTable* php_phongo_commandsucceededevent_get_debug_info(phongo_compat_
 {
 	php_phongo_commandsucceededevent_t* intern;
 	zval                                retval = ZVAL_STATIC_INIT;
-	char                                operation_id[20], request_id[20];
+	char                                operation_id[24], request_id[24];
 	php_phongo_bson_state               reply_state;
 
 	PHONGO_BSON_INIT_STATE(reply_state);
@@ -199,9 +199,9 @@ static HashTable* php_phongo_commandsucceededevent_get_debug_info(phongo_compat_
 	array_init_size(&retval, 6);
 
 	ADD_ASSOC_STRING(&retval, "commandName", intern->command_name);
-	ADD_ASSOC_INT64(&retval, "durationMicros", (int64_t) intern->duration_micros);
+	ADD_ASSOC_INT64(&retval, "durationMicros", intern->duration_micros);
 
-	sprintf(operation_id, "%" PRIu64, intern->operation_id);
+	snprintf(operation_id, sizeof(operation_id), "%" PRId64, intern->operation_id);
 	ADD_ASSOC_STRING(&retval, "operationId", operation_id);
 
 	if (!php_phongo_bson_to_zval_ex(intern->reply, &reply_state)) {
@@ -211,7 +211,7 @@ static HashTable* php_phongo_commandsucceededevent_get_debug_info(phongo_compat_
 
 	ADD_ASSOC_ZVAL(&retval, "reply", &reply_state.zchild);
 
-	sprintf(request_id, "%" PRIu64, intern->request_id);
+	snprintf(request_id, sizeof(request_id), "%" PRId64, intern->request_id);
 	ADD_ASSOC_STRING(&retval, "requestId", request_id);
 
 	{

--- a/src/phongo_structs.h
+++ b/src/phongo_structs.h
@@ -261,9 +261,9 @@ typedef struct {
 	zval        manager;
 	char*       command_name;
 	uint32_t    server_id;
-	uint64_t    operation_id;
-	uint64_t    request_id;
-	uint64_t    duration_micros;
+	int64_t     operation_id;
+	int64_t     request_id;
+	int64_t     duration_micros;
 	bson_t*     reply;
 	zval        z_error;
 	bool        has_service_id;
@@ -276,8 +276,8 @@ typedef struct {
 	zval        manager;
 	char*       command_name;
 	uint32_t    server_id;
-	uint64_t    operation_id;
-	uint64_t    request_id;
+	int64_t     operation_id;
+	int64_t     request_id;
 	bson_t*     command;
 	char*       database_name;
 	bool        has_service_id;
@@ -290,9 +290,9 @@ typedef struct {
 	zval        manager;
 	char*       command_name;
 	uint32_t    server_id;
-	uint64_t    operation_id;
-	uint64_t    request_id;
-	uint64_t    duration_micros;
+	int64_t     operation_id;
+	int64_t     request_id;
+	int64_t     duration_micros;
 	bson_t*     reply;
 	bool        has_service_id;
 	bson_oid_t  service_id;


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-2168

The buffer for snprintf is slightly larger than necessary (21 bytes), but this is consistent with the buffer size we use elsewhere.