### PR TITLE
PHPC-2165: Expose server error replies in BulkWriteResult

### DIFF
--- a/src/MongoDB/WriteResult.stub.php
+++ b/src/MongoDB/WriteResult.stub.php
@@ -29,6 +29,8 @@ final class WriteResult
 
     final public function getWriteErrors(): array {}
 
+    final public function getErrorReplies(): array {}
+
     final public function isAcknowledged(): bool {}
 
     final public function __wakeup(): void {}

--- a/src/MongoDB/WriteResult_arginfo.h
+++ b/src/MongoDB/WriteResult_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: eae27215b994b4941296f69331abd6d1a3173df7 */
+ * Stub hash: 279a9a00d54bf67c310f7b8802a5868bf1d507eb */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_WriteResult___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -26,6 +26,8 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_MongoDB_Driver_WriteResult_getWriteErrors arginfo_class_MongoDB_Driver_WriteResult_getUpsertedIds
 
+#define arginfo_class_MongoDB_Driver_WriteResult_getErrorReplies arginfo_class_MongoDB_Driver_WriteResult_getUpsertedIds
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_WriteResult_isAcknowledged, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
@@ -43,6 +45,7 @@ static ZEND_METHOD(MongoDB_Driver_WriteResult, getServer);
 static ZEND_METHOD(MongoDB_Driver_WriteResult, getUpsertedIds);
 static ZEND_METHOD(MongoDB_Driver_WriteResult, getWriteConcernError);
 static ZEND_METHOD(MongoDB_Driver_WriteResult, getWriteErrors);
+static ZEND_METHOD(MongoDB_Driver_WriteResult, getErrorReplies);
 static ZEND_METHOD(MongoDB_Driver_WriteResult, isAcknowledged);
 static ZEND_METHOD(MongoDB_Driver_WriteResult, __wakeup);
 
@@ -58,6 +61,7 @@ static const zend_function_entry class_MongoDB_Driver_WriteResult_methods[] = {
 	ZEND_ME(MongoDB_Driver_WriteResult, getUpsertedIds, arginfo_class_MongoDB_Driver_WriteResult_getUpsertedIds, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_WriteResult, getWriteConcernError, arginfo_class_MongoDB_Driver_WriteResult_getWriteConcernError, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_WriteResult, getWriteErrors, arginfo_class_MongoDB_Driver_WriteResult_getWriteErrors, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+	ZEND_ME(MongoDB_Driver_WriteResult, getErrorReplies, arginfo_class_MongoDB_Driver_WriteResult_getErrorReplies, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_WriteResult, isAcknowledged, arginfo_class_MongoDB_Driver_WriteResult_isAcknowledged, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_WriteResult, __wakeup, arginfo_class_MongoDB_Driver_WriteResult___wakeup, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_FE_END

--- a/tests/exception/bulkwriteexception-getwriteresult-001.phpt
+++ b/tests/exception/bulkwriteexception-getwriteresult-001.phpt
@@ -56,5 +56,8 @@ object(MongoDB\Driver\WriteResult)#%d (%d) {
   ["writeConcern"]=>
   object(MongoDB\Driver\WriteConcern)#%d (%d) {
   }
+  ["errorReplies"]=>
+  array(0) {
+  }
 }
 ===DONE===

--- a/tests/manager/manager-executeBulkWrite_error-005.phpt
+++ b/tests/manager/manager-executeBulkWrite_error-005.phpt
@@ -39,7 +39,7 @@ try {
 --EXPECTF--
 MongoDB\Driver\Exception\BulkWriteException(0): Bulk write failed due to previous MongoDB\Driver\Exception\ConnectionTimeoutException: Failed to send "delete" command with database "%s": Failed to read 4 bytes: socket error or timeout
 MongoDB\Driver\Exception\ConnectionTimeoutException(%d): Failed to send "delete" command with database "%s": Failed to read 4 bytes: socket error or timeout
-object(MongoDB\Driver\WriteResult)#%d (9) {
+object(MongoDB\Driver\WriteResult)#%d (%d) {
   ["nInserted"]=>
   int(1)
   ["nMatched"]=>
@@ -59,7 +59,10 @@ object(MongoDB\Driver\WriteResult)#%d (9) {
   ["writeConcernError"]=>
   NULL
   ["writeConcern"]=>
-  object(MongoDB\Driver\WriteConcern)#%d (0) {
+  object(MongoDB\Driver\WriteConcern)#%d (%d) {
+  }
+  ["errorReplies"]=>
+  array(0) {
   }
 }
 ===DONE===

--- a/tests/replicaset/writeresult-getserver-002.phpt
+++ b/tests/replicaset/writeresult-getserver-002.phpt
@@ -83,6 +83,9 @@ object(MongoDB\Driver\WriteResult)#%d (%d) {
     ["w"]=>
     int(1)
   }
+  ["errorReplies"]=>
+  array(0) {
+  }
 }
 string(%d) "%s"
 int(%d)

--- a/tests/server/server-executeBulkWrite-001.phpt
+++ b/tests/server/server-executeBulkWrite-001.phpt
@@ -73,6 +73,9 @@ object(MongoDB\Driver\WriteResult)#%d (%d) {
   ["writeConcern"]=>
   object(MongoDB\Driver\WriteConcern)#%d (%d) {
   }
+  ["errorReplies"]=>
+  array(0) {
+  }
 }
 
 ===> Collection

--- a/tests/standalone/writeresult-isacknowledged-001.phpt
+++ b/tests/standalone/writeresult-isacknowledged-001.phpt
@@ -44,5 +44,8 @@ object(MongoDB\Driver\WriteResult)#%d (%d) {
   ["writeConcern"]=>
   object(MongoDB\Driver\WriteConcern)#%d (%d) {
   }
+  ["errorReplies"]=>
+  array(0) {
+  }
 }
 ===DONE===

--- a/tests/standalone/writeresult-isacknowledged-002.phpt
+++ b/tests/standalone/writeresult-isacknowledged-002.phpt
@@ -49,5 +49,8 @@ object(MongoDB\Driver\WriteResult)#%d (%d) {
     ["w"]=>
     int(0)
   }
+  ["errorReplies"]=>
+  array(0) {
+  }
 }
 ===DONE===

--- a/tests/standalone/writeresult-isacknowledged-003.phpt
+++ b/tests/standalone/writeresult-isacknowledged-003.phpt
@@ -46,5 +46,8 @@ object(MongoDB\Driver\WriteResult)#%d (%d) {
     ["w"]=>
     int(0)
   }
+  ["errorReplies"]=>
+  array(0) {
+  }
 }
 ===DONE===

--- a/tests/writeResult/writeresult-debug-001.phpt
+++ b/tests/writeResult/writeresult-debug-001.phpt
@@ -67,5 +67,8 @@ object(MongoDB\Driver\WriteResult)#%d (%d) {
   ["writeConcern"]=>
   object(MongoDB\Driver\WriteConcern)#%d (%d) {
   }
+  ["errorReplies"]=>
+  array(0) {
+  }
 }
 ===DONE===

--- a/tests/writeResult/writeresult-debug-002.phpt
+++ b/tests/writeResult/writeresult-debug-002.phpt
@@ -115,5 +115,8 @@ object(MongoDB\Driver\WriteResult)#%d (%d) {
     ["w"]=>
     int(30)
   }
+  ["errorReplies"]=>
+  array(0) {
+  }
 }
 ===DONE===

--- a/tests/writeResult/writeresult-getErrorReplies-001.phpt
+++ b/tests/writeResult/writeresult-getErrorReplies-001.phpt
@@ -1,0 +1,40 @@
+--TEST--
+MongoDB\Driver\WriteResult::getErrorReplies()
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_not_live(); ?>
+<?php skip_if_not_clean(); ?>
+<?php skip_if_no_failcommand_failpoint(); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = create_test_manager();
+$server = $manager->selectServer();
+
+configureTargetedFailPoint(
+    $server,
+    'failCommand',
+    ['times' => 1] ,
+    ['errorCode' => 8, 'failCommands' => ['insert']]
+);
+
+$errors = [];
+try {
+    $bulk = new MongoDB\Driver\BulkWrite;
+    $bulk->insert(['_id' => 1, 'x' => 'bar']);
+    $server->executeBulkWrite(NS, $bulk);
+} catch (MongoDB\Driver\Exception\BulkWriteException $e) {
+    $errors = $e->getWriteResult()->getErrorReplies();
+}
+
+var_dump(count($errors));
+var_dump($errors[0]->code);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+int(1)
+int(8)
+===DONE===


### PR DESCRIPTION
PHPC-2165

Includes an update to libmongoc 1.24-dev

I only added a simple test for `getErrorReplies` as this will be comprehensively tested by the unified spec tests in PHPLIB.