### PR TITLE
Cross-reference prose tests in session test descriptions

### DIFF
--- a/tests/manager/manager-ctor-ssl-002.phpt
+++ b/tests/manager/manager-ctor-ssl-002.phpt
@@ -7,7 +7,7 @@ PHPC-1239: Passing SSL driverOptions overrides SSL options from URI
 <?php
 require_once __DIR__ . "/../utils/basic.inc";
 
-$manager = create_test_manager(URI, array(), array());
+$manager = create_test_manager(URI);
 
 $manager->executeCommand(DATABASE_NAME, new MongoDB\Driver\Command(['ping' => 1]));
 ?>

--- a/tests/manager/manager-startSession_error-002.phpt
+++ b/tests/manager/manager-startSession_error-002.phpt
@@ -1,8 +1,8 @@
 --TEST--
 MongoDB\Driver\Manager::startSession() snapshot and causalConsistency cannot both be true
 --DESCRIPTION--
-Session spec prose test #1
-https://github.com/mongodb/specifications/blob/master/source/sessions/tests/README.rst#prose-tests
+Session spec prose test #1: Setting both snapshot and causalConsistency to true is not allowed
+https://github.com/mongodb/specifications/blob/master/source/sessions/tests/README.rst#setting-both-snapshot-and-causalconsistency-to-true-is-not-allowed
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_not_libmongoc_crypto(); ?>

--- a/tests/session/session-001.phpt
+++ b/tests/session/session-001.phpt
@@ -1,5 +1,8 @@
 --TEST--
 MongoDB\Driver\Session spec test: Pool is LIFO
+--DESCRIPTION--
+Session spec prose test #2: Pool is LIFO
+https://github.com/mongodb/specifications/blob/master/source/sessions/tests/README.rst#pool-is-lifo
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_not_libmongoc_crypto(); ?>

--- a/tests/session/session-002.phpt
+++ b/tests/session/session-002.phpt
@@ -1,5 +1,8 @@
 --TEST--
 MongoDB\Driver\Session spec test: $clusterTime in commands
+--DESCRIPTION--
+Session spec prose test #3: $clusterTime in commands
+https://github.com/mongodb/specifications/blob/master/source/sessions/tests/README.rst#clustertime-in-commands
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_not_libmongoc_crypto(); ?>

--- a/tests/session/session-003.phpt
+++ b/tests/session/session-003.phpt
@@ -1,5 +1,8 @@
 --TEST--
 MongoDB\Driver\Session spec test: session cannot be used for different clients
+--DESCRIPTION--
+Session spec prose test #5: Session argument is for the right client
+https://github.com/mongodb/specifications/blob/master/source/sessions/tests/README.rst#session-argument-is-for-the-right-client
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_not_libmongoc_crypto(); ?>

--- a/tests/session/session-003.phpt
+++ b/tests/session/session-003.phpt
@@ -11,9 +11,8 @@ https://github.com/mongodb/specifications/blob/master/source/sessions/tests/READ
 <?php
 require_once __DIR__ . "/../utils/basic.inc";
 
-// Vary heartbeatFrequencyMS to ensure each Manager gets a different client
-$manager = create_test_manager(URI, ['heartbeatFrequencyMS' => 60000]);
-$otherManager = create_test_manager(URI, ['heartbeatFrequencyMS' => 90000]);
+$manager = create_test_manager(URI, [], ['disableClientPersistence' => true]);
+$otherManager = create_test_manager(URI, [], ['disableClientPersistence' => true]);
 
 // Create a session with the second Manager (associated with different client)
 $session = $otherManager->startSession();

--- a/tests/standalone/manager-as-singleton.phpt
+++ b/tests/standalone/manager-as-singleton.phpt
@@ -17,7 +17,7 @@ class Database {
     private static $Instance;
  
     public function __construct() {
-        $Manager = create_test_manager(URI, array(), array());
+        $Manager = create_test_manager(URI);
         $this->Database = $Manager;
     }
  


### PR DESCRIPTION
Also cleans up some `create_test_manager()` calls in related tests.