### PR TITLE
PHPC-2156: Work around crypt_shared log output

### DIFF
--- a/tests/cursor/bug1529-001.phpt
+++ b/tests/cursor/bug1529-001.phpt
@@ -7,6 +7,7 @@ PHPC-1529: Resetting a client should also reset the keyVaultClient
 <?php skip_if_server_version('<', '4.2'); ?>
 <?php skip_if_not_libmongocrypt(); ?>
 <?php skip_if_not_clean(); ?>
+<?php skip_if_crypt_shared(); // Build fails due to SERVER-71049 ?>
 --FILE--
 <?php
 require_once __DIR__ . "/../utils/basic.inc";

--- a/tests/manager/manager-ctor-auto_encryption-001.phpt
+++ b/tests/manager/manager-ctor-auto_encryption-001.phpt
@@ -3,6 +3,7 @@ MongoDB\Driver\Manager::__construct(): autoEncryption options
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_not_libmongocrypt(); ?>
+<?php skip_if_crypt_shared(); // Build fails due to SERVER-71049 ?>
 --FILE--
 <?php
 

--- a/tests/manager/manager-ctor-auto_encryption-002.phpt
+++ b/tests/manager/manager-ctor-auto_encryption-002.phpt
@@ -4,6 +4,8 @@ MongoDB\Driver\Manager::__construct(): crypt_shared is required
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_not_libmongocrypt(); ?>
 <?php skip_if_no_crypt_shared(); ?>
+--XFAIL--
+crypt_shared log output breaks build (PHPC-2156)
 --FILE--
 <?php
 

--- a/tests/manager/manager-getencryptedfieldsmap-001.phpt
+++ b/tests/manager/manager-getencryptedfieldsmap-001.phpt
@@ -1,5 +1,8 @@
 --TEST--
 MongoDB\Driver\Manager::getEncryptedFieldsMap()
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_crypt_shared(); // Build fails due to SERVER-71049 ?>
 --FILE--
 <?php
 


### PR DESCRIPTION
PHPC-2156

Until the fix was backported to 6.0, we need to skip certain tests that fail due to extra log output generated by crypt_shared. This also affects older builds, as drivers-evergreen-tools downloads crypt_shared 6.0 for those versions that don't ship with it.