### PR TITLE
Add missing void arg to fix MacOS builds

### DIFF
--- a/src/phongo_client.c
+++ b/src/phongo_client.c
@@ -75,7 +75,7 @@ static const mongoc_client_t* get_first_pclient_client(HashTable* ht)
  * Note: this may incorrectly return NULL if crypt_shared was loaded through a
  * mongoc_client_t since destroyed (e.g. single requested-scoped client);
  * however, that's the best can do with libmongoc's API. */
-const char* php_phongo_crypt_shared_version()
+const char* php_phongo_crypt_shared_version(void)
 {
 	const mongoc_client_t* client = NULL;
 


### PR DESCRIPTION
Upgraded to MacOS 13.3 recently and building the driver exposed this failure. Not sure why this didn't appear earlier as `strict-prototypes` was part of our developer build flags for a long time already.

```
src/phongo_client.c:78:44: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
const char* php_phongo_crypt_shared_version()
```