### PR TITLE
Bump cmb69/setup-php-sdk to 0.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Setup PHP SDK
         id: setup-php
-        uses: cmb69/setup-php-sdk@v0.6
+        uses: cmb69/setup-php-sdk@v0.7
         with:
           version: ${{ matrix.php }}
           arch: ${{ matrix.arch }}


### PR DESCRIPTION
This pulls cmb69/setup-php-sdk@26487290af8a51fa8ce948f9c4ee18e2fa54529e, which migrates deprecated set-output commands to use $GITHUB_OUTPUT

----

Per [GitHub Actions: Deprecating save-state and set-output commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/):

> Starting 1st June 2023 workflows using save-state or set-output commands via stdout will fail with an error.

We may want to backport this to older branches to avoid any trouble if we need to create a patch release down the line.