### PR TITLE
PHPC-2208: Fix fragile assertion on session IDs

### DIFF
--- a/tests/session/session-debug-001.phpt
+++ b/tests/session/session-debug-001.phpt
@@ -23,7 +23,7 @@ object(MongoDB\Driver\Session)#%d (%d) {
     ["id"]=>
     object(MongoDB\BSON\Binary)#%d (%d) {
       ["data"]=>
-      string(16) "%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c"
+      string(16) "%a"
       ["type"]=>
       int(4)
     }

--- a/tests/session/session-debug-002.phpt
+++ b/tests/session/session-debug-002.phpt
@@ -26,7 +26,7 @@ object(MongoDB\Driver\Session)#%d (%d) {
     ["id"]=>
     object(MongoDB\BSON\Binary)#%d (%d) {
       ["data"]=>
-      string(16) "%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c"
+      string(16) "%a"
       ["type"]=>
       int(4)
     }

--- a/tests/session/session-debug-003.phpt
+++ b/tests/session/session-debug-003.phpt
@@ -23,7 +23,7 @@ object(MongoDB\Driver\Session)#%d (%d) {
     ["id"]=>
     object(MongoDB\BSON\Binary)#%d (%d) {
       ["data"]=>
-      string(16) "%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c"
+      string(16) "%a"
       ["type"]=>
       int(4)
     }

--- a/tests/session/session-debug-005.phpt
+++ b/tests/session/session-debug-005.phpt
@@ -34,7 +34,7 @@ object(MongoDB\Driver\Session)#%d (%d) {
     ["id"]=>
     object(MongoDB\BSON\Binary)#%d (%d) {
       ["data"]=>
-      string(16) "%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c"
+      string(16) "%a"
       ["type"]=>
       int(4)
     }

--- a/tests/session/session-debug-006.phpt
+++ b/tests/session/session-debug-006.phpt
@@ -32,7 +32,7 @@ object(MongoDB\Driver\Session)#%d (%d) {
     ["id"]=>
     object(MongoDB\BSON\Binary)#%d (%d) {
       ["data"]=>
-      string(16) "%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c"
+      string(16) "%a"
       ["type"]=>
       int(4)
     }

--- a/tests/session/session-debug-007.phpt
+++ b/tests/session/session-debug-007.phpt
@@ -23,7 +23,7 @@ object(MongoDB\Driver\Session)#%d (%d) {
     ["id"]=>
     object(MongoDB\BSON\Binary)#%d (%d) {
       ["data"]=>
-      string(16) "%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c"
+      string(16) "%a"
       ["type"]=>
       int(4)
     }


### PR DESCRIPTION
PHPC-2208

A short investigation has led me to conclude that `%c` should definitely match the end-of-line character, as run-tests.php replaces it with a `.` in the regular expression, which is then matched using the `PCRE_DOTALL` modifier. However, since trying to figure this out is inconsequential and the previous fix (applied in #974 to work around PHPC-1345) doesn't work in this case, I replaced the sequence of `%c` with a single `%a` across the tests. While this may match more or fewer than 16 characters unlike the previous solution, as the debug output also contains `string(16)` any binary data that isn't 16 characters long would fail the checks based on that part, apart from being improbable due to the verification employed for BSON subtype 0x04 (UUID).