### PR TITLE
PHPC-2222: Ensure packed arrays return PackedArray instances when converted to BSON

### DIFF
--- a/src/phongo_bson.c
+++ b/src/phongo_bson.c
@@ -1042,10 +1042,10 @@ bool php_phongo_bson_to_zval_ex(const bson_t* b, php_phongo_bson_state* state)
 
 		if (state->is_visiting_array) {
 			object_init_ex(&obj, php_phongo_packedarray_ce);
-			bson = &Z_DOCUMENT_OBJ_P(&obj)->bson;
+			bson = &Z_PACKEDARRAY_OBJ_P(&obj)->bson;
 		} else {
 			object_init_ex(&obj, php_phongo_document_ce);
-			bson = &Z_PACKEDARRAY_OBJ_P(&obj)->bson;
+			bson = &Z_DOCUMENT_OBJ_P(&obj)->bson;
 		}
 
 		*bson = bson_copy(b);

--- a/src/phongo_bson.c
+++ b/src/phongo_bson.c
@@ -1035,15 +1035,20 @@ bool php_phongo_bson_to_zval_ex(const bson_t* b, php_phongo_bson_state* state)
 		must_dtor_state = true;
 	}
 
-	// Handle raw root type early to avoid creating an iterator and visiting elements
+	// Handle BSON root type early to avoid creating an iterator and visiting elements
 	if (state->map.root.type == PHONGO_TYPEMAP_BSON) {
-		zval                   obj;
-		php_phongo_document_t* intern;
+		zval     obj;
+		bson_t** bson;
 
-		object_init_ex(&obj, php_phongo_document_ce);
+		if (state->is_visiting_array) {
+			object_init_ex(&obj, php_phongo_packedarray_ce);
+			bson = &Z_DOCUMENT_OBJ_P(&obj)->bson;
+		} else {
+			object_init_ex(&obj, php_phongo_document_ce);
+			bson = &Z_PACKEDARRAY_OBJ_P(&obj)->bson;
+		}
 
-		intern       = Z_DOCUMENT_OBJ_P(&obj);
-		intern->bson = bson_copy(b);
+		*bson = bson_copy(b);
 		zval_ptr_dtor(&state->zchild);
 		ZVAL_COPY_VALUE(&state->zchild, &obj);
 

--- a/tests/bson/bson-packedarray-toPHP-004.phpt
+++ b/tests/bson/bson-packedarray-toPHP-004.phpt
@@ -1,0 +1,19 @@
+--TEST--
+MongoDB\BSON\PackedArray::toPHP(): Use bson as root type
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/basic.inc';
+
+$packedArray = MongoDB\BSON\PackedArray::fromPHP([1, 2, 3]);
+var_dump($packedArray->toPHP(['root' => 'bson']));
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+object(MongoDB\BSON\PackedArray)#%d (%d) {
+  ["data"]=>
+  string(36) "GgAAABAwAAEAAAAQMQACAAAAEDIAAwAAAAA="
+}
+===DONE===


### PR DESCRIPTION
PHPC-2222

While PHPC-2219 may make changes to what can be handled as a root document, serialising a `PackedArray` instance through toPHP with a type map that specifies a BSON root type should always yield a `PackedArray` instance, no matter how absurd the use case may seem.