### PR TITLE
PHPC-2163: Use PHP 8.2 as latest-stable in edge versions

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1109,9 +1109,9 @@ axes:
     display_name: PHP Version
     values:
       - id: "latest-stable"
-        display_name: "PHP 8.1"
+        display_name: "PHP 8.2"
         variables:
-          PHP_VERSION: "8.1"
+          PHP_VERSION: "8.2"
       - id: "oldest-supported"
         display_name: "PHP 7.2"
         variables:
@@ -1186,7 +1186,7 @@ buildvariants:
   display_name: "${os}, ${mongodb-edge-versions}, ${php-versions}"
   exclude_spec:
     # Exclude "latest-stable" PHP version for Debian 11 (see: test-mongodb-versions matrix)
-    - { "os": "debian11", "mongodb-edge-versions": "*", "php-versions": "8.1" }
+    - { "os": "debian11", "mongodb-edge-versions": "*", "php-versions": "8.2" }
     # PHP 8.1+ is not available on rhel70
     - { "os": "rhel70", "mongodb-edge-versions": "*", "php-versions": ["8.1", "8.2"] }
   tasks:


### PR DESCRIPTION
PHPC-2163