### PR TITLE
Increase default timeout for starting MongoDB service on Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -133,6 +133,7 @@ jobs:
 
       - name: Start MongoDB
         run: |
+          reg add HKLM\System\CurrentControlSet\Control /v ServicesPipeTimeout /t REG_DWORD /d 300000 /f
           sc config MongoDB start= auto
           sc start MongoDB
 


### PR DESCRIPTION
This is based on suggestions from actions/runner-images#5949