### PR TITLE
PHPC-2133: Fix building with SRV support on FreeBSD

### DIFF
--- a/scripts/autotools/libmongoc/PlatformFlags.m4
+++ b/scripts/autotools/libmongoc/PlatformFlags.m4
@@ -1,6 +1,7 @@
 dnl Ignore OpenSSL deprecation warnings on OSX
 AS_IF([test "$os_darwin" = "yes"],
       [AX_CHECK_COMPILE_FLAG([-Wno-deprecated-declarations], [STD_CFLAGS="$STD_CFLAGS -Wno-deprecated-declarations"])])
+
 dnl We know there are some cast-align issues on OSX
 AS_IF([test "$os_darwin" = "yes"],
       [AX_CHECK_COMPILE_FLAG([-Wno-cast-align], [STD_CFLAGS="$STD_CFLAGS -Wno-cast-align"])])
@@ -8,3 +9,8 @@ AS_IF([test "$os_darwin" = "yes"],
       [AX_CHECK_COMPILE_FLAG([-Wno-unneeded-internal-declaration], [STD_CFLAGS="$STD_CFLAGS -Wno-unneeded-internal-declaration"])])
 AS_IF([test "$os_darwin" = "yes"],
       [AX_CHECK_COMPILE_FLAG([-Wno-error=unused-command-line-argument], [STD_CFLAGS="$STD_CFLAGS -Wno-error=unused-command-line-argument"])])
+
+dnl Enable non-standard features on FreeBSD with __BSD_VISIBLE=1
+if test "$os_freebsd" = "yes"; then
+    PHP_MONGODB_BUNDLED_CFLAGS="$PHP_MONGODB_BUNDLED_CFLAGS -D__BSD_VISIBLE=1"
+fi


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-2133

Verified locally with an Atlas SRV connection string. I installed FreeBSD 13.2 in a virtual machine and compiled the driver for PHP 8.0 both with and without this patch.

I _think_ the patch might also apply to OpenBSD, where resolve functions exist in libc, but I'm not confident enough to enable that and would rather wait for an actual bug report to come our way before I expend the effort to test it myself.