### PR TITLE
Expand comparison tests for Int64 to cover scalars

### DIFF
--- a/tests/bson/bson-int64-compare-001.phpt
+++ b/tests/bson/bson-int64-compare-001.phpt
@@ -1,5 +1,5 @@
 --TEST--
-MongoDB\BSON\Int64 comparisons
+MongoDB\BSON\Int64 comparisons between objects
 --FILE--
 <?php
 

--- a/tests/bson/bson-int64-compare-002.phpt
+++ b/tests/bson/bson-int64-compare-002.phpt
@@ -1,0 +1,43 @@
+--TEST--
+MongoDB\BSON\Int64 comparisons with scalars
+--FILE--
+<?php
+
+$int64 = new MongoDB\BSON\Int64('123');
+
+$tests = [
+    'matching int' => 123,
+    'matching numeric string' => '123',
+    'matching float' => 123.0,
+    'matching float string' => '123.0',
+
+    'wrong int' => 456,
+    'wrong numeric string' => '456',
+    'wrong float' => 456.0,
+    'wrong float string' => '456.0',
+    'float with decimals' => 123.456,
+    'string float with decimals' => '123.456',
+
+    'non-numeric string' => 'foo',
+];
+
+foreach ($tests as $name => $value) {
+    printf('Testing %s: %s' . PHP_EOL, $name, var_export($int64 == $value, true));
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+Testing matching int: true
+Testing matching numeric string: true
+Testing matching float: true
+Testing matching float string: true
+Testing wrong int: false
+Testing wrong numeric string: false
+Testing wrong float: false
+Testing wrong float string: false
+Testing float with decimals: false
+Testing string float with decimals: false
+Testing non-numeric string: false
+===DONE===

--- a/tests/bson/bson-int64-compare-003.phpt
+++ b/tests/bson/bson-int64-compare-003.phpt
@@ -1,0 +1,37 @@
+--TEST--
+MongoDB\BSON\Int64 comparisons with scalars (64-bit values)
+--FILE--
+<?php
+
+// Use 2**33 to ensure it still fits in a float
+$int64 = new MongoDB\BSON\Int64('8589934592');
+
+$tests = [
+    'matching numeric string' => '8589934592',
+    'matching float' => 8589934592.0,
+    'matching float string' => '8589934592.0',
+
+    'wrong numeric string' => '8589934593',
+    'wrong float' => 8589934593.0,
+    'wrong float string' => '8589934593.0',
+    'float with decimals' => 8589934592.1,
+    'string float with decimals' => '8589934592.1',
+];
+
+foreach ($tests as $name => $value) {
+    printf('Testing %s: %s' . PHP_EOL, $name, var_export($int64 == $value, true));
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+Testing matching numeric string: true
+Testing matching float: true
+Testing matching float string: true
+Testing wrong numeric string: false
+Testing wrong float: false
+Testing wrong float string: false
+Testing float with decimals: false
+Testing string float with decimals: false
+===DONE===

--- a/tests/bson/bson-int64-compare-004.phpt
+++ b/tests/bson/bson-int64-compare-004.phpt
@@ -1,0 +1,26 @@
+--TEST--
+MongoDB\BSON\Int64 comparisons with scalars (64-bit values, 64-bit platforms only)
+--SKIPIF--
+<?php if (8 !== PHP_INT_SIZE) { die('skip Only for 64-bit platform'); } ?>
+--FILE--
+<?php
+
+// Use 2**33 to ensure it still fits in a float
+$int64 = new MongoDB\BSON\Int64('8589934592');
+
+$tests = [
+    'matching int' => 8589934592,
+    'wrong int' => 8589934593,
+];
+
+foreach ($tests as $name => $value) {
+    printf('Testing %s: %s' . PHP_EOL, $name, var_export($int64 == $value, true));
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+Testing matching int: true
+Testing wrong int: false
+===DONE===


### PR DESCRIPTION
This adds more comparison tests for `MongoDB\BSON\Int64` to ensure correct behaviour.