### PR TITLE
PHPC-2252: Use correct signature for Serializable::unserialize

### DIFF
--- a/src/BSON/Binary.stub.php
+++ b/src/BSON/Binary.stub.php
@@ -75,8 +75,12 @@ final class Binary implements BinaryInterface, \JsonSerializable, Type, \Seriali
 
     final public function serialize(): string {}
 
+#if PHP_VERSION_ID >= 80000
+    final public function unserialize(string $data): void {}
+#else
     /** @param string $serialized */
     final public function unserialize($serialized): void {}
+#endif
 
     final public function __unserialize(array $data): void {}
 

--- a/src/BSON/Binary_arginfo.h
+++ b/src/BSON/Binary_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 1ad141cbb9c7c2e49660ba16b36c69de97d7e45e */
+ * Stub hash: 3ecb4933da21ef2b58ca95d74e2aac8d26ca6dc6 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_Binary___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
@@ -20,9 +20,17 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_MongoDB_BSON_Binary_serialize arginfo_class_MongoDB_BSON_Binary_getData
 
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Binary_unserialize, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if !(PHP_VERSION_ID >= 80000)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Binary_unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_INFO(0, serialized)
 ZEND_END_ARG_INFO()
+#endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Binary___unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
@@ -48,7 +56,12 @@ static ZEND_METHOD(MongoDB_BSON_Binary, getType);
 static ZEND_METHOD(MongoDB_BSON_Binary, __set_state);
 static ZEND_METHOD(MongoDB_BSON_Binary, __toString);
 static ZEND_METHOD(MongoDB_BSON_Binary, serialize);
+#if PHP_VERSION_ID >= 80000
 static ZEND_METHOD(MongoDB_BSON_Binary, unserialize);
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+static ZEND_METHOD(MongoDB_BSON_Binary, unserialize);
+#endif
 static ZEND_METHOD(MongoDB_BSON_Binary, __unserialize);
 static ZEND_METHOD(MongoDB_BSON_Binary, __serialize);
 #if PHP_VERSION_ID >= 80000
@@ -66,7 +79,12 @@ static const zend_function_entry class_MongoDB_BSON_Binary_methods[] = {
 	ZEND_ME(MongoDB_BSON_Binary, __set_state, arginfo_class_MongoDB_BSON_Binary___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_Binary, __toString, arginfo_class_MongoDB_BSON_Binary___toString, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_Binary, serialize, arginfo_class_MongoDB_BSON_Binary_serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#if PHP_VERSION_ID >= 80000
 	ZEND_ME(MongoDB_BSON_Binary, unserialize, arginfo_class_MongoDB_BSON_Binary_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+	ZEND_ME(MongoDB_BSON_Binary, unserialize, arginfo_class_MongoDB_BSON_Binary_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
 	ZEND_ME(MongoDB_BSON_Binary, __unserialize, arginfo_class_MongoDB_BSON_Binary___unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_Binary, __serialize, arginfo_class_MongoDB_BSON_Binary___serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 #if PHP_VERSION_ID >= 80000

--- a/src/BSON/DBPointer.stub.php
+++ b/src/BSON/DBPointer.stub.php
@@ -16,8 +16,12 @@ final class DBPointer implements \JsonSerializable, Type, \Serializable
 
     final public function serialize(): string {}
 
+#if PHP_VERSION_ID >= 80000
+    final public function unserialize(string $data): void {}
+#else
     /** @param string $serialized */
     final public function unserialize($serialized): void {}
+#endif
 
     final public function __unserialize(array $data): void {}
 

--- a/src/BSON/DBPointer_arginfo.h
+++ b/src/BSON/DBPointer_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 2e26331e12fe64ef077d0d2b37433d291cb87943 */
+ * Stub hash: 6470b07511dad346b124a9ab7c3dbe9f67140a23 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_DBPointer___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -13,9 +13,17 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_MongoDB_BSON_DBPointer_serialize arginfo_class_MongoDB_BSON_DBPointer___toString
 
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_DBPointer_unserialize, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if !(PHP_VERSION_ID >= 80000)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_DBPointer_unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_INFO(0, serialized)
 ZEND_END_ARG_INFO()
+#endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_DBPointer___unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
@@ -39,7 +47,12 @@ static ZEND_METHOD(MongoDB_BSON_DBPointer, __construct);
 static ZEND_METHOD(MongoDB_BSON_DBPointer, __set_state);
 static ZEND_METHOD(MongoDB_BSON_DBPointer, __toString);
 static ZEND_METHOD(MongoDB_BSON_DBPointer, serialize);
+#if PHP_VERSION_ID >= 80000
 static ZEND_METHOD(MongoDB_BSON_DBPointer, unserialize);
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+static ZEND_METHOD(MongoDB_BSON_DBPointer, unserialize);
+#endif
 static ZEND_METHOD(MongoDB_BSON_DBPointer, __unserialize);
 static ZEND_METHOD(MongoDB_BSON_DBPointer, __serialize);
 #if PHP_VERSION_ID >= 80000
@@ -55,7 +68,12 @@ static const zend_function_entry class_MongoDB_BSON_DBPointer_methods[] = {
 	ZEND_ME(MongoDB_BSON_DBPointer, __set_state, arginfo_class_MongoDB_BSON_DBPointer___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_DBPointer, __toString, arginfo_class_MongoDB_BSON_DBPointer___toString, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_DBPointer, serialize, arginfo_class_MongoDB_BSON_DBPointer_serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#if PHP_VERSION_ID >= 80000
 	ZEND_ME(MongoDB_BSON_DBPointer, unserialize, arginfo_class_MongoDB_BSON_DBPointer_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+	ZEND_ME(MongoDB_BSON_DBPointer, unserialize, arginfo_class_MongoDB_BSON_DBPointer_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
 	ZEND_ME(MongoDB_BSON_DBPointer, __unserialize, arginfo_class_MongoDB_BSON_DBPointer___unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_DBPointer, __serialize, arginfo_class_MongoDB_BSON_DBPointer___serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 #if PHP_VERSION_ID >= 80000

--- a/src/BSON/Decimal128.stub.php
+++ b/src/BSON/Decimal128.stub.php
@@ -17,8 +17,12 @@ final class Decimal128 implements Decimal128Interface, \JsonSerializable, Type, 
 
     final public function serialize(): string {}
 
+#if PHP_VERSION_ID >= 80000
+    final public function unserialize(string $data): void {}
+#else
     /** @param string $serialized */
     final public function unserialize($serialized): void {}
+#endif
 
     final public function __unserialize(array $data): void {}
 

--- a/src/BSON/Decimal128_arginfo.h
+++ b/src/BSON/Decimal128_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 7a4bde2dfe8793610977f97c6bc1337d5238b0bc */
+ * Stub hash: 032c048d73e8fe95972e1150f5925e13de4ecc94 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_Decimal128___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
@@ -14,9 +14,17 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_MongoDB_BSON_Decimal128_serialize arginfo_class_MongoDB_BSON_Decimal128___toString
 
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Decimal128_unserialize, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if !(PHP_VERSION_ID >= 80000)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Decimal128_unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_INFO(0, serialized)
 ZEND_END_ARG_INFO()
+#endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Decimal128___unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
@@ -40,7 +48,12 @@ static ZEND_METHOD(MongoDB_BSON_Decimal128, __construct);
 static ZEND_METHOD(MongoDB_BSON_Decimal128, __toString);
 static ZEND_METHOD(MongoDB_BSON_Decimal128, __set_state);
 static ZEND_METHOD(MongoDB_BSON_Decimal128, serialize);
+#if PHP_VERSION_ID >= 80000
 static ZEND_METHOD(MongoDB_BSON_Decimal128, unserialize);
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+static ZEND_METHOD(MongoDB_BSON_Decimal128, unserialize);
+#endif
 static ZEND_METHOD(MongoDB_BSON_Decimal128, __unserialize);
 static ZEND_METHOD(MongoDB_BSON_Decimal128, __serialize);
 #if PHP_VERSION_ID >= 80000
@@ -56,7 +69,12 @@ static const zend_function_entry class_MongoDB_BSON_Decimal128_methods[] = {
 	ZEND_ME(MongoDB_BSON_Decimal128, __toString, arginfo_class_MongoDB_BSON_Decimal128___toString, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_Decimal128, __set_state, arginfo_class_MongoDB_BSON_Decimal128___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_Decimal128, serialize, arginfo_class_MongoDB_BSON_Decimal128_serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#if PHP_VERSION_ID >= 80000
 	ZEND_ME(MongoDB_BSON_Decimal128, unserialize, arginfo_class_MongoDB_BSON_Decimal128_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+	ZEND_ME(MongoDB_BSON_Decimal128, unserialize, arginfo_class_MongoDB_BSON_Decimal128_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
 	ZEND_ME(MongoDB_BSON_Decimal128, __unserialize, arginfo_class_MongoDB_BSON_Decimal128___unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_Decimal128, __serialize, arginfo_class_MongoDB_BSON_Decimal128___serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 #if PHP_VERSION_ID >= 80000

--- a/src/BSON/Document.stub.php
+++ b/src/BSON/Document.stub.php
@@ -50,8 +50,12 @@ final class Document implements \IteratorAggregate, \Serializable
 
     final public function serialize(): string {}
 
+#if PHP_VERSION_ID >= 80000
+    final public function unserialize(string $data): void {}
+#else
     /** @param string $serialized */
     final public function unserialize($serialized): void {}
+#endif
 
     final public function __unserialize(array $data): void {}
 

--- a/src/BSON/Document_arginfo.h
+++ b/src/BSON/Document_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 5994291bf2bfdac1b9d8bad9b96d4f443c2f49aa */
+ * Stub hash: e00ccf66afed0f51040527ee5ee24513f0c1f495 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_Document___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -68,9 +68,17 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_MongoDB_BSON_Document_serialize arginfo_class_MongoDB_BSON_Document_toCanonicalExtendedJSON
 
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Document_unserialize, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if !(PHP_VERSION_ID >= 80000)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Document_unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_INFO(0, serialized)
 ZEND_END_ARG_INFO()
+#endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Document___unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
@@ -108,7 +116,12 @@ static ZEND_METHOD(MongoDB_BSON_Document, toRelaxedExtendedJSON);
 static ZEND_METHOD(MongoDB_BSON_Document, __toString);
 static ZEND_METHOD(MongoDB_BSON_Document, __set_state);
 static ZEND_METHOD(MongoDB_BSON_Document, serialize);
+#if PHP_VERSION_ID >= 80000
 static ZEND_METHOD(MongoDB_BSON_Document, unserialize);
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+static ZEND_METHOD(MongoDB_BSON_Document, unserialize);
+#endif
 static ZEND_METHOD(MongoDB_BSON_Document, __unserialize);
 static ZEND_METHOD(MongoDB_BSON_Document, __serialize);
 
@@ -142,7 +155,12 @@ static const zend_function_entry class_MongoDB_BSON_Document_methods[] = {
 	ZEND_ME(MongoDB_BSON_Document, __toString, arginfo_class_MongoDB_BSON_Document___toString, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_Document, __set_state, arginfo_class_MongoDB_BSON_Document___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_Document, serialize, arginfo_class_MongoDB_BSON_Document_serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#if PHP_VERSION_ID >= 80000
 	ZEND_ME(MongoDB_BSON_Document, unserialize, arginfo_class_MongoDB_BSON_Document_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+	ZEND_ME(MongoDB_BSON_Document, unserialize, arginfo_class_MongoDB_BSON_Document_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
 	ZEND_ME(MongoDB_BSON_Document, __unserialize, arginfo_class_MongoDB_BSON_Document___unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_Document, __serialize, arginfo_class_MongoDB_BSON_Document___serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_FE_END

--- a/src/BSON/Int64.stub.php
+++ b/src/BSON/Int64.stub.php
@@ -22,8 +22,12 @@ final class Int64 implements \JsonSerializable, Type, \Serializable
 
     final public function serialize(): string {}
 
+#if PHP_VERSION_ID >= 80000
+    final public function unserialize(string $data): void {}
+#else
     /** @param string $serialized */
     final public function unserialize($serialized): void {}
+#endif
 
     final public function __unserialize(array $data): void {}
 

--- a/src/BSON/Int64_arginfo.h
+++ b/src/BSON/Int64_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 550f788abef6e985ed78953b6aae044cabb56b0f */
+ * Stub hash: 86352e04686201023d5cad5ee577c8a3ce324628 */
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_Int64___construct, 0, 0, 1)
@@ -22,9 +22,17 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_MongoDB_BSON_Int64_serialize arginfo_class_MongoDB_BSON_Int64___toString
 
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Int64_unserialize, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if !(PHP_VERSION_ID >= 80000)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Int64_unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_INFO(0, serialized)
 ZEND_END_ARG_INFO()
+#endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Int64___unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
@@ -53,7 +61,12 @@ static ZEND_METHOD(MongoDB_BSON_Int64, __construct);
 static ZEND_METHOD(MongoDB_BSON_Int64, __toString);
 static ZEND_METHOD(MongoDB_BSON_Int64, __set_state);
 static ZEND_METHOD(MongoDB_BSON_Int64, serialize);
+#if PHP_VERSION_ID >= 80000
 static ZEND_METHOD(MongoDB_BSON_Int64, unserialize);
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+static ZEND_METHOD(MongoDB_BSON_Int64, unserialize);
+#endif
 static ZEND_METHOD(MongoDB_BSON_Int64, __unserialize);
 static ZEND_METHOD(MongoDB_BSON_Int64, __serialize);
 #if PHP_VERSION_ID >= 80000
@@ -74,7 +87,12 @@ static const zend_function_entry class_MongoDB_BSON_Int64_methods[] = {
 	ZEND_ME(MongoDB_BSON_Int64, __toString, arginfo_class_MongoDB_BSON_Int64___toString, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_Int64, __set_state, arginfo_class_MongoDB_BSON_Int64___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_Int64, serialize, arginfo_class_MongoDB_BSON_Int64_serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#if PHP_VERSION_ID >= 80000
 	ZEND_ME(MongoDB_BSON_Int64, unserialize, arginfo_class_MongoDB_BSON_Int64_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+	ZEND_ME(MongoDB_BSON_Int64, unserialize, arginfo_class_MongoDB_BSON_Int64_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
 	ZEND_ME(MongoDB_BSON_Int64, __unserialize, arginfo_class_MongoDB_BSON_Int64___unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_Int64, __serialize, arginfo_class_MongoDB_BSON_Int64___serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 #if PHP_VERSION_ID >= 80000

--- a/src/BSON/Javascript.stub.php
+++ b/src/BSON/Javascript.stub.php
@@ -26,8 +26,12 @@ final class Javascript implements JavascriptInterface, \JsonSerializable, Type, 
 
     final public function serialize(): string {}
 
+#if PHP_VERSION_ID >= 80000
+    final public function unserialize(string $data): void {}
+#else
     /** @param string $serialized */
     final public function unserialize($serialized): void {}
+#endif
 
     final public function __unserialize(array $data): void {}
 

--- a/src/BSON/Javascript_arginfo.h
+++ b/src/BSON/Javascript_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a26f3f81298ed3571f27bad3ade4a8540ca986f7 */
+ * Stub hash: 0ab7273525fae116007a65f91a92f6fbb80a6534 */
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_Javascript___construct, 0, 0, 1)
@@ -29,9 +29,17 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_MongoDB_BSON_Javascript_serialize arginfo_class_MongoDB_BSON_Javascript_getCode
 
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Javascript_unserialize, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if !(PHP_VERSION_ID >= 80000)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Javascript_unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_INFO(0, serialized)
 ZEND_END_ARG_INFO()
+#endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Javascript___unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
@@ -62,7 +70,12 @@ static ZEND_METHOD(MongoDB_BSON_Javascript, getCode);
 static ZEND_METHOD(MongoDB_BSON_Javascript, getScope);
 static ZEND_METHOD(MongoDB_BSON_Javascript, __toString);
 static ZEND_METHOD(MongoDB_BSON_Javascript, serialize);
+#if PHP_VERSION_ID >= 80000
 static ZEND_METHOD(MongoDB_BSON_Javascript, unserialize);
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+static ZEND_METHOD(MongoDB_BSON_Javascript, unserialize);
+#endif
 static ZEND_METHOD(MongoDB_BSON_Javascript, __unserialize);
 static ZEND_METHOD(MongoDB_BSON_Javascript, __serialize);
 #if PHP_VERSION_ID >= 80000
@@ -85,7 +98,12 @@ static const zend_function_entry class_MongoDB_BSON_Javascript_methods[] = {
 	ZEND_ME(MongoDB_BSON_Javascript, getScope, arginfo_class_MongoDB_BSON_Javascript_getScope, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_Javascript, __toString, arginfo_class_MongoDB_BSON_Javascript___toString, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_Javascript, serialize, arginfo_class_MongoDB_BSON_Javascript_serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#if PHP_VERSION_ID >= 80000
 	ZEND_ME(MongoDB_BSON_Javascript, unserialize, arginfo_class_MongoDB_BSON_Javascript_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+	ZEND_ME(MongoDB_BSON_Javascript, unserialize, arginfo_class_MongoDB_BSON_Javascript_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
 	ZEND_ME(MongoDB_BSON_Javascript, __unserialize, arginfo_class_MongoDB_BSON_Javascript___unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_Javascript, __serialize, arginfo_class_MongoDB_BSON_Javascript___serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 #if PHP_VERSION_ID >= 80000

--- a/src/BSON/MaxKey.stub.php
+++ b/src/BSON/MaxKey.stub.php
@@ -13,8 +13,12 @@ final class MaxKey implements MaxKeyInterface, \JsonSerializable, Type, \Seriali
 
     final public function serialize(): string {}
 
+#if PHP_VERSION_ID >= 80000
+    final public function unserialize(string $data): void {}
+#else
     /** @param string $serialized */
     final public function unserialize($serialized): void {}
+#endif
 
     final public function __unserialize(array $data): void {}
 

--- a/src/BSON/MaxKey_arginfo.h
+++ b/src/BSON/MaxKey_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 2c46622b8d9c8a1c600bb5384a1a56de1150f4d5 */
+ * Stub hash: 619fb546b185f6ca1019829cf031e2a9e51c8f46 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_BSON_MaxKey___set_state, 0, 1, MongoDB\\BSON\\MaxKey, 0)
 	ZEND_ARG_TYPE_INFO(0, properties, IS_ARRAY, 0)
@@ -8,9 +8,17 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_MaxKey_serialize, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_MaxKey_unserialize, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if !(PHP_VERSION_ID >= 80000)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_MaxKey_unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_INFO(0, serialized)
 ZEND_END_ARG_INFO()
+#endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_MaxKey___unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
@@ -32,7 +40,12 @@ ZEND_END_ARG_INFO()
 
 static ZEND_METHOD(MongoDB_BSON_MaxKey, __set_state);
 static ZEND_METHOD(MongoDB_BSON_MaxKey, serialize);
+#if PHP_VERSION_ID >= 80000
 static ZEND_METHOD(MongoDB_BSON_MaxKey, unserialize);
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+static ZEND_METHOD(MongoDB_BSON_MaxKey, unserialize);
+#endif
 static ZEND_METHOD(MongoDB_BSON_MaxKey, __unserialize);
 static ZEND_METHOD(MongoDB_BSON_MaxKey, __serialize);
 #if PHP_VERSION_ID >= 80000
@@ -46,7 +59,12 @@ static ZEND_METHOD(MongoDB_BSON_MaxKey, jsonSerialize);
 static const zend_function_entry class_MongoDB_BSON_MaxKey_methods[] = {
 	ZEND_ME(MongoDB_BSON_MaxKey, __set_state, arginfo_class_MongoDB_BSON_MaxKey___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_MaxKey, serialize, arginfo_class_MongoDB_BSON_MaxKey_serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#if PHP_VERSION_ID >= 80000
 	ZEND_ME(MongoDB_BSON_MaxKey, unserialize, arginfo_class_MongoDB_BSON_MaxKey_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+	ZEND_ME(MongoDB_BSON_MaxKey, unserialize, arginfo_class_MongoDB_BSON_MaxKey_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
 	ZEND_ME(MongoDB_BSON_MaxKey, __unserialize, arginfo_class_MongoDB_BSON_MaxKey___unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_MaxKey, __serialize, arginfo_class_MongoDB_BSON_MaxKey___serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 #if PHP_VERSION_ID >= 80000

--- a/src/BSON/MinKey.stub.php
+++ b/src/BSON/MinKey.stub.php
@@ -13,8 +13,12 @@ final class MinKey implements MinKeyInterface, \JsonSerializable, Type, \Seriali
 
     final public function serialize(): string {}
 
+#if PHP_VERSION_ID >= 80000
+    final public function unserialize(string $data): void {}
+#else
     /** @param string $serialized */
     final public function unserialize($serialized): void {}
+#endif
 
     final public function __unserialize(array $data): void {}
 

--- a/src/BSON/MinKey_arginfo.h
+++ b/src/BSON/MinKey_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: e0cecac78204d3f892c33bd0921b5af8b3cffc11 */
+ * Stub hash: 9557766098ca988ffae1c30a0ccf46258f1f6621 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_BSON_MinKey___set_state, 0, 1, MongoDB\\BSON\\MinKey, 0)
 	ZEND_ARG_TYPE_INFO(0, properties, IS_ARRAY, 0)
@@ -8,9 +8,17 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_MinKey_serialize, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_MinKey_unserialize, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if !(PHP_VERSION_ID >= 80000)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_MinKey_unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_INFO(0, serialized)
 ZEND_END_ARG_INFO()
+#endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_MinKey___unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
@@ -32,7 +40,12 @@ ZEND_END_ARG_INFO()
 
 static ZEND_METHOD(MongoDB_BSON_MinKey, __set_state);
 static ZEND_METHOD(MongoDB_BSON_MinKey, serialize);
+#if PHP_VERSION_ID >= 80000
 static ZEND_METHOD(MongoDB_BSON_MinKey, unserialize);
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+static ZEND_METHOD(MongoDB_BSON_MinKey, unserialize);
+#endif
 static ZEND_METHOD(MongoDB_BSON_MinKey, __unserialize);
 static ZEND_METHOD(MongoDB_BSON_MinKey, __serialize);
 #if PHP_VERSION_ID >= 80000
@@ -46,7 +59,12 @@ static ZEND_METHOD(MongoDB_BSON_MinKey, jsonSerialize);
 static const zend_function_entry class_MongoDB_BSON_MinKey_methods[] = {
 	ZEND_ME(MongoDB_BSON_MinKey, __set_state, arginfo_class_MongoDB_BSON_MinKey___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_MinKey, serialize, arginfo_class_MongoDB_BSON_MinKey_serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#if PHP_VERSION_ID >= 80000
 	ZEND_ME(MongoDB_BSON_MinKey, unserialize, arginfo_class_MongoDB_BSON_MinKey_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+	ZEND_ME(MongoDB_BSON_MinKey, unserialize, arginfo_class_MongoDB_BSON_MinKey_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
 	ZEND_ME(MongoDB_BSON_MinKey, __unserialize, arginfo_class_MongoDB_BSON_MinKey___unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_MinKey, __serialize, arginfo_class_MongoDB_BSON_MinKey___serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 #if PHP_VERSION_ID >= 80000

--- a/src/BSON/ObjectId.stub.php
+++ b/src/BSON/ObjectId.stub.php
@@ -19,8 +19,12 @@ final class ObjectId implements ObjectIdInterface, \JsonSerializable, Type, \Ser
 
     final public function serialize(): string {}
 
+#if PHP_VERSION_ID >= 80000
+    final public function unserialize(string $data): void {}
+#else
     /** @param string $serialized */
     final public function unserialize($serialized): void {}
+#endif
 
     final public function __unserialize(array $data): void {}
 

--- a/src/BSON/ObjectId_arginfo.h
+++ b/src/BSON/ObjectId_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 9cd65d4b38b64b047724d97593fdb6934f6fa896 */
+ * Stub hash: bb3d1616e135d65abe0a645a1746ef0afd27c82e */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_ObjectId___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, id, IS_STRING, 1, "null")
@@ -17,9 +17,17 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_MongoDB_BSON_ObjectId_serialize arginfo_class_MongoDB_BSON_ObjectId___toString
 
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_ObjectId_unserialize, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if !(PHP_VERSION_ID >= 80000)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_ObjectId_unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_INFO(0, serialized)
 ZEND_END_ARG_INFO()
+#endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_ObjectId___unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
@@ -44,7 +52,12 @@ static ZEND_METHOD(MongoDB_BSON_ObjectId, getTimestamp);
 static ZEND_METHOD(MongoDB_BSON_ObjectId, __toString);
 static ZEND_METHOD(MongoDB_BSON_ObjectId, __set_state);
 static ZEND_METHOD(MongoDB_BSON_ObjectId, serialize);
+#if PHP_VERSION_ID >= 80000
 static ZEND_METHOD(MongoDB_BSON_ObjectId, unserialize);
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+static ZEND_METHOD(MongoDB_BSON_ObjectId, unserialize);
+#endif
 static ZEND_METHOD(MongoDB_BSON_ObjectId, __unserialize);
 static ZEND_METHOD(MongoDB_BSON_ObjectId, __serialize);
 #if PHP_VERSION_ID >= 80000
@@ -61,7 +74,12 @@ static const zend_function_entry class_MongoDB_BSON_ObjectId_methods[] = {
 	ZEND_ME(MongoDB_BSON_ObjectId, __toString, arginfo_class_MongoDB_BSON_ObjectId___toString, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_ObjectId, __set_state, arginfo_class_MongoDB_BSON_ObjectId___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_ObjectId, serialize, arginfo_class_MongoDB_BSON_ObjectId_serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#if PHP_VERSION_ID >= 80000
 	ZEND_ME(MongoDB_BSON_ObjectId, unserialize, arginfo_class_MongoDB_BSON_ObjectId_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+	ZEND_ME(MongoDB_BSON_ObjectId, unserialize, arginfo_class_MongoDB_BSON_ObjectId_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
 	ZEND_ME(MongoDB_BSON_ObjectId, __unserialize, arginfo_class_MongoDB_BSON_ObjectId___unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_ObjectId, __serialize, arginfo_class_MongoDB_BSON_ObjectId___serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 #if PHP_VERSION_ID >= 80000

--- a/src/BSON/PackedArray.stub.php
+++ b/src/BSON/PackedArray.stub.php
@@ -37,8 +37,12 @@ final class PackedArray implements \IteratorAggregate, \Serializable
 
     final public function serialize(): string {}
 
+#if PHP_VERSION_ID >= 80000
+    final public function unserialize(string $data): void {}
+#else
     /** @param string $serialized */
     final public function unserialize($serialized): void {}
+#endif
 
     final public function __unserialize(array $data): void {}
 

--- a/src/BSON/PackedArray_arginfo.h
+++ b/src/BSON/PackedArray_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3668c2846f7f546547f3203320342b4ef816b117 */
+ * Stub hash: e9b57c4051440170531560cc355e0af1b43f3424 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_PackedArray___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -48,9 +48,17 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_MongoDB_BSON_PackedArray_serialize arginfo_class_MongoDB_BSON_PackedArray___toString
 
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_PackedArray_unserialize, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if !(PHP_VERSION_ID >= 80000)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_PackedArray_unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_INFO(0, serialized)
 ZEND_END_ARG_INFO()
+#endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_PackedArray___unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
@@ -79,7 +87,12 @@ static ZEND_METHOD(MongoDB_BSON_PackedArray, toPHP);
 static ZEND_METHOD(MongoDB_BSON_PackedArray, __toString);
 static ZEND_METHOD(MongoDB_BSON_PackedArray, __set_state);
 static ZEND_METHOD(MongoDB_BSON_PackedArray, serialize);
+#if PHP_VERSION_ID >= 80000
 static ZEND_METHOD(MongoDB_BSON_PackedArray, unserialize);
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+static ZEND_METHOD(MongoDB_BSON_PackedArray, unserialize);
+#endif
 static ZEND_METHOD(MongoDB_BSON_PackedArray, __unserialize);
 static ZEND_METHOD(MongoDB_BSON_PackedArray, __serialize);
 
@@ -104,7 +117,12 @@ static const zend_function_entry class_MongoDB_BSON_PackedArray_methods[] = {
 	ZEND_ME(MongoDB_BSON_PackedArray, __toString, arginfo_class_MongoDB_BSON_PackedArray___toString, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_PackedArray, __set_state, arginfo_class_MongoDB_BSON_PackedArray___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_PackedArray, serialize, arginfo_class_MongoDB_BSON_PackedArray_serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#if PHP_VERSION_ID >= 80000
 	ZEND_ME(MongoDB_BSON_PackedArray, unserialize, arginfo_class_MongoDB_BSON_PackedArray_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+	ZEND_ME(MongoDB_BSON_PackedArray, unserialize, arginfo_class_MongoDB_BSON_PackedArray_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
 	ZEND_ME(MongoDB_BSON_PackedArray, __unserialize, arginfo_class_MongoDB_BSON_PackedArray___unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_PackedArray, __serialize, arginfo_class_MongoDB_BSON_PackedArray___serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_FE_END

--- a/src/BSON/Regex.stub.php
+++ b/src/BSON/Regex.stub.php
@@ -21,8 +21,12 @@ final class Regex implements RegexInterface, \JsonSerializable, Type, \Serializa
 
     final public function serialize(): string {}
 
+#if PHP_VERSION_ID >= 80000
+    final public function unserialize(string $data): void {}
+#else
     /** @param string $serialized */
     final public function unserialize($serialized): void {}
+#endif
 
     final public function __unserialize(array $data): void {}
 

--- a/src/BSON/Regex_arginfo.h
+++ b/src/BSON/Regex_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 7a1ba95f7cc89a83201d46f43ab7e5f2ae93cb5f */
+ * Stub hash: 5b1d9031775fd7c2a0c9585da00887ddf5c1dbe2 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_Regex___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, pattern, IS_STRING, 0)
@@ -19,9 +19,17 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_MongoDB_BSON_Regex_serialize arginfo_class_MongoDB_BSON_Regex_getPattern
 
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Regex_unserialize, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if !(PHP_VERSION_ID >= 80000)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Regex_unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_INFO(0, serialized)
 ZEND_END_ARG_INFO()
+#endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Regex___unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
@@ -47,7 +55,12 @@ static ZEND_METHOD(MongoDB_BSON_Regex, getFlags);
 static ZEND_METHOD(MongoDB_BSON_Regex, __toString);
 static ZEND_METHOD(MongoDB_BSON_Regex, __set_state);
 static ZEND_METHOD(MongoDB_BSON_Regex, serialize);
+#if PHP_VERSION_ID >= 80000
 static ZEND_METHOD(MongoDB_BSON_Regex, unserialize);
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+static ZEND_METHOD(MongoDB_BSON_Regex, unserialize);
+#endif
 static ZEND_METHOD(MongoDB_BSON_Regex, __unserialize);
 static ZEND_METHOD(MongoDB_BSON_Regex, __serialize);
 #if PHP_VERSION_ID >= 80000
@@ -65,7 +78,12 @@ static const zend_function_entry class_MongoDB_BSON_Regex_methods[] = {
 	ZEND_ME(MongoDB_BSON_Regex, __toString, arginfo_class_MongoDB_BSON_Regex___toString, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_Regex, __set_state, arginfo_class_MongoDB_BSON_Regex___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_Regex, serialize, arginfo_class_MongoDB_BSON_Regex_serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#if PHP_VERSION_ID >= 80000
 	ZEND_ME(MongoDB_BSON_Regex, unserialize, arginfo_class_MongoDB_BSON_Regex_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+	ZEND_ME(MongoDB_BSON_Regex, unserialize, arginfo_class_MongoDB_BSON_Regex_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
 	ZEND_ME(MongoDB_BSON_Regex, __unserialize, arginfo_class_MongoDB_BSON_Regex___unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_Regex, __serialize, arginfo_class_MongoDB_BSON_Regex___serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 #if PHP_VERSION_ID >= 80000

--- a/src/BSON/Symbol.stub.php
+++ b/src/BSON/Symbol.stub.php
@@ -17,8 +17,12 @@ final class Symbol implements \JsonSerializable, Type, \Serializable
 
     final public function serialize(): string {}
 
+#if PHP_VERSION_ID >= 80000
+    final public function unserialize(string $data): void {}
+#else
     /** @param string $serialized */
     final public function unserialize($serialized): void {}
+#endif
 
     final public function __unserialize(array $data): void {}
 

--- a/src/BSON/Symbol_arginfo.h
+++ b/src/BSON/Symbol_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 4b1e0dec72d27036b3bdb3838dd7bee506f1dc38 */
+ * Stub hash: 0d7ad975a26b424f5109301f7e8d070ce2574b48 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_Symbol___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -13,9 +13,17 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_MongoDB_BSON_Symbol_serialize arginfo_class_MongoDB_BSON_Symbol___toString
 
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Symbol_unserialize, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if !(PHP_VERSION_ID >= 80000)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Symbol_unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_INFO(0, serialized)
 ZEND_END_ARG_INFO()
+#endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Symbol___unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
@@ -39,7 +47,12 @@ static ZEND_METHOD(MongoDB_BSON_Symbol, __construct);
 static ZEND_METHOD(MongoDB_BSON_Symbol, __toString);
 static ZEND_METHOD(MongoDB_BSON_Symbol, __set_state);
 static ZEND_METHOD(MongoDB_BSON_Symbol, serialize);
+#if PHP_VERSION_ID >= 80000
 static ZEND_METHOD(MongoDB_BSON_Symbol, unserialize);
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+static ZEND_METHOD(MongoDB_BSON_Symbol, unserialize);
+#endif
 static ZEND_METHOD(MongoDB_BSON_Symbol, __unserialize);
 static ZEND_METHOD(MongoDB_BSON_Symbol, __serialize);
 #if PHP_VERSION_ID >= 80000
@@ -55,7 +68,12 @@ static const zend_function_entry class_MongoDB_BSON_Symbol_methods[] = {
 	ZEND_ME(MongoDB_BSON_Symbol, __toString, arginfo_class_MongoDB_BSON_Symbol___toString, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_Symbol, __set_state, arginfo_class_MongoDB_BSON_Symbol___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_Symbol, serialize, arginfo_class_MongoDB_BSON_Symbol_serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#if PHP_VERSION_ID >= 80000
 	ZEND_ME(MongoDB_BSON_Symbol, unserialize, arginfo_class_MongoDB_BSON_Symbol_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+	ZEND_ME(MongoDB_BSON_Symbol, unserialize, arginfo_class_MongoDB_BSON_Symbol_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
 	ZEND_ME(MongoDB_BSON_Symbol, __unserialize, arginfo_class_MongoDB_BSON_Symbol___unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_Symbol, __serialize, arginfo_class_MongoDB_BSON_Symbol___serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 #if PHP_VERSION_ID >= 80000

--- a/src/BSON/Timestamp.stub.php
+++ b/src/BSON/Timestamp.stub.php
@@ -29,8 +29,12 @@ final class Timestamp implements TimestampInterface, \JsonSerializable, Type, \S
 
     final public function serialize(): string {}
 
+#if PHP_VERSION_ID >= 80000
+    final public function unserialize(string $data): void {}
+#else
     /** @param string $serialized */
     final public function unserialize($serialized): void {}
+#endif
 
     final public function __unserialize(array $data): void {}
 

--- a/src/BSON/Timestamp_arginfo.h
+++ b/src/BSON/Timestamp_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 2bcdcaf75a5fda393b84df469ca046e7ba720601 */
+ * Stub hash: 619c2fd0276dd6de1b8585e4cfeb038d8e4b753f */
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_Timestamp___construct, 0, 0, 2)
@@ -29,9 +29,17 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_MongoDB_BSON_Timestamp_serialize arginfo_class_MongoDB_BSON_Timestamp___toString
 
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Timestamp_unserialize, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if !(PHP_VERSION_ID >= 80000)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Timestamp_unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_INFO(0, serialized)
 ZEND_END_ARG_INFO()
+#endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Timestamp___unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
@@ -62,7 +70,12 @@ static ZEND_METHOD(MongoDB_BSON_Timestamp, getIncrement);
 static ZEND_METHOD(MongoDB_BSON_Timestamp, __toString);
 static ZEND_METHOD(MongoDB_BSON_Timestamp, __set_state);
 static ZEND_METHOD(MongoDB_BSON_Timestamp, serialize);
+#if PHP_VERSION_ID >= 80000
 static ZEND_METHOD(MongoDB_BSON_Timestamp, unserialize);
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+static ZEND_METHOD(MongoDB_BSON_Timestamp, unserialize);
+#endif
 static ZEND_METHOD(MongoDB_BSON_Timestamp, __unserialize);
 static ZEND_METHOD(MongoDB_BSON_Timestamp, __serialize);
 #if PHP_VERSION_ID >= 80000
@@ -85,7 +98,12 @@ static const zend_function_entry class_MongoDB_BSON_Timestamp_methods[] = {
 	ZEND_ME(MongoDB_BSON_Timestamp, __toString, arginfo_class_MongoDB_BSON_Timestamp___toString, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_Timestamp, __set_state, arginfo_class_MongoDB_BSON_Timestamp___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_Timestamp, serialize, arginfo_class_MongoDB_BSON_Timestamp_serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#if PHP_VERSION_ID >= 80000
 	ZEND_ME(MongoDB_BSON_Timestamp, unserialize, arginfo_class_MongoDB_BSON_Timestamp_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+	ZEND_ME(MongoDB_BSON_Timestamp, unserialize, arginfo_class_MongoDB_BSON_Timestamp_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
 	ZEND_ME(MongoDB_BSON_Timestamp, __unserialize, arginfo_class_MongoDB_BSON_Timestamp___unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_Timestamp, __serialize, arginfo_class_MongoDB_BSON_Timestamp___serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 #if PHP_VERSION_ID >= 80000

--- a/src/BSON/UTCDateTime.stub.php
+++ b/src/BSON/UTCDateTime.stub.php
@@ -24,8 +24,12 @@ final class UTCDateTime implements UTCDateTimeInterface, \JsonSerializable, Type
 
     final public function serialize(): string {}
 
+#if PHP_VERSION_ID >= 80000
+    final public function unserialize(string $data): void {}
+#else
     /** @param string $serialized */
     final public function unserialize($serialized): void {}
+#endif
 
     final public function __unserialize(array $data): void {}
 

--- a/src/BSON/UTCDateTime_arginfo.h
+++ b/src/BSON/UTCDateTime_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8ba1df46e121e8ce37a671414d00504e06cb89cd */
+ * Stub hash: c4d05eaa04380f7a4adcb8f9c1562d7013c37121 */
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_UTCDateTime___construct, 0, 0, 0)
@@ -25,9 +25,17 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_MongoDB_BSON_UTCDateTime_serialize arginfo_class_MongoDB_BSON_UTCDateTime___toString
 
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_UTCDateTime_unserialize, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if !(PHP_VERSION_ID >= 80000)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_UTCDateTime_unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_INFO(0, serialized)
 ZEND_END_ARG_INFO()
+#endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_UTCDateTime___unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
@@ -57,7 +65,12 @@ static ZEND_METHOD(MongoDB_BSON_UTCDateTime, toDateTime);
 static ZEND_METHOD(MongoDB_BSON_UTCDateTime, __toString);
 static ZEND_METHOD(MongoDB_BSON_UTCDateTime, __set_state);
 static ZEND_METHOD(MongoDB_BSON_UTCDateTime, serialize);
+#if PHP_VERSION_ID >= 80000
 static ZEND_METHOD(MongoDB_BSON_UTCDateTime, unserialize);
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+static ZEND_METHOD(MongoDB_BSON_UTCDateTime, unserialize);
+#endif
 static ZEND_METHOD(MongoDB_BSON_UTCDateTime, __unserialize);
 static ZEND_METHOD(MongoDB_BSON_UTCDateTime, __serialize);
 #if PHP_VERSION_ID >= 80000
@@ -79,7 +92,12 @@ static const zend_function_entry class_MongoDB_BSON_UTCDateTime_methods[] = {
 	ZEND_ME(MongoDB_BSON_UTCDateTime, __toString, arginfo_class_MongoDB_BSON_UTCDateTime___toString, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_UTCDateTime, __set_state, arginfo_class_MongoDB_BSON_UTCDateTime___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_UTCDateTime, serialize, arginfo_class_MongoDB_BSON_UTCDateTime_serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#if PHP_VERSION_ID >= 80000
 	ZEND_ME(MongoDB_BSON_UTCDateTime, unserialize, arginfo_class_MongoDB_BSON_UTCDateTime_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+	ZEND_ME(MongoDB_BSON_UTCDateTime, unserialize, arginfo_class_MongoDB_BSON_UTCDateTime_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
 	ZEND_ME(MongoDB_BSON_UTCDateTime, __unserialize, arginfo_class_MongoDB_BSON_UTCDateTime___unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_UTCDateTime, __serialize, arginfo_class_MongoDB_BSON_UTCDateTime___serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 #if PHP_VERSION_ID >= 80000

--- a/src/BSON/Undefined.stub.php
+++ b/src/BSON/Undefined.stub.php
@@ -17,8 +17,12 @@ final class Undefined implements \JsonSerializable, Type, \Serializable
 
     final public function serialize(): string {}
 
+#if PHP_VERSION_ID >= 80000
+    final public function unserialize(string $data): void {}
+#else
     /** @param string $serialized */
     final public function unserialize($serialized): void {}
+#endif
 
     final public function __unserialize(array $data): void {}
 

--- a/src/BSON/Undefined_arginfo.h
+++ b/src/BSON/Undefined_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 25e10ed435dd89bbfbb49da077a37abcc79ef2d5 */
+ * Stub hash: f86341a6f6509aa4bdcd8d82dabb696e25b5a67d */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_Undefined___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -13,9 +13,17 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_MongoDB_BSON_Undefined_serialize arginfo_class_MongoDB_BSON_Undefined___toString
 
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Undefined_unserialize, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if !(PHP_VERSION_ID >= 80000)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Undefined_unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_INFO(0, serialized)
 ZEND_END_ARG_INFO()
+#endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Undefined___unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
@@ -39,7 +47,12 @@ static ZEND_METHOD(MongoDB_BSON_Undefined, __construct);
 static ZEND_METHOD(MongoDB_BSON_Undefined, __toString);
 static ZEND_METHOD(MongoDB_BSON_Undefined, __set_state);
 static ZEND_METHOD(MongoDB_BSON_Undefined, serialize);
+#if PHP_VERSION_ID >= 80000
 static ZEND_METHOD(MongoDB_BSON_Undefined, unserialize);
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+static ZEND_METHOD(MongoDB_BSON_Undefined, unserialize);
+#endif
 static ZEND_METHOD(MongoDB_BSON_Undefined, __unserialize);
 static ZEND_METHOD(MongoDB_BSON_Undefined, __serialize);
 #if PHP_VERSION_ID >= 80000
@@ -55,7 +68,12 @@ static const zend_function_entry class_MongoDB_BSON_Undefined_methods[] = {
 	ZEND_ME(MongoDB_BSON_Undefined, __toString, arginfo_class_MongoDB_BSON_Undefined___toString, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_Undefined, __set_state, arginfo_class_MongoDB_BSON_Undefined___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_Undefined, serialize, arginfo_class_MongoDB_BSON_Undefined_serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#if PHP_VERSION_ID >= 80000
 	ZEND_ME(MongoDB_BSON_Undefined, unserialize, arginfo_class_MongoDB_BSON_Undefined_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+	ZEND_ME(MongoDB_BSON_Undefined, unserialize, arginfo_class_MongoDB_BSON_Undefined_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
 	ZEND_ME(MongoDB_BSON_Undefined, __unserialize, arginfo_class_MongoDB_BSON_Undefined___unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_Undefined, __serialize, arginfo_class_MongoDB_BSON_Undefined___serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 #if PHP_VERSION_ID >= 80000

--- a/src/MongoDB/CursorId.stub.php
+++ b/src/MongoDB/CursorId.stub.php
@@ -17,8 +17,12 @@ final class CursorId implements \Serializable
 
     final public function serialize(): string {}
 
+#if PHP_VERSION_ID >= 80000
+    final public function unserialize(string $data): void {}
+#else
     /** @param string $serialized */
     final public function unserialize($serialized): void {}
+#endif
 
     final public function __unserialize(array $data): void {}
 

--- a/src/MongoDB/CursorId_arginfo.h
+++ b/src/MongoDB/CursorId_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 38869945e39a889c85c1074ab4d3843c51738674 */
+ * Stub hash: 7f5bb1818756794e7ac1d2fe75f1a0f3d8d710a1 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_CursorId___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -13,9 +13,17 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_MongoDB_Driver_CursorId_serialize arginfo_class_MongoDB_Driver_CursorId___toString
 
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_CursorId_unserialize, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if !(PHP_VERSION_ID >= 80000)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_CursorId_unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_INFO(0, serialized)
 ZEND_END_ARG_INFO()
+#endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_CursorId___unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
@@ -29,7 +37,12 @@ static ZEND_METHOD(MongoDB_Driver_CursorId, __construct);
 static ZEND_METHOD(MongoDB_Driver_CursorId, __set_state);
 static ZEND_METHOD(MongoDB_Driver_CursorId, __toString);
 static ZEND_METHOD(MongoDB_Driver_CursorId, serialize);
+#if PHP_VERSION_ID >= 80000
 static ZEND_METHOD(MongoDB_Driver_CursorId, unserialize);
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+static ZEND_METHOD(MongoDB_Driver_CursorId, unserialize);
+#endif
 static ZEND_METHOD(MongoDB_Driver_CursorId, __unserialize);
 static ZEND_METHOD(MongoDB_Driver_CursorId, __serialize);
 
@@ -39,7 +52,12 @@ static const zend_function_entry class_MongoDB_Driver_CursorId_methods[] = {
 	ZEND_ME(MongoDB_Driver_CursorId, __set_state, arginfo_class_MongoDB_Driver_CursorId___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_CursorId, __toString, arginfo_class_MongoDB_Driver_CursorId___toString, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_CursorId, serialize, arginfo_class_MongoDB_Driver_CursorId_serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#if PHP_VERSION_ID >= 80000
 	ZEND_ME(MongoDB_Driver_CursorId, unserialize, arginfo_class_MongoDB_Driver_CursorId_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+	ZEND_ME(MongoDB_Driver_CursorId, unserialize, arginfo_class_MongoDB_Driver_CursorId_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
 	ZEND_ME(MongoDB_Driver_CursorId, __unserialize, arginfo_class_MongoDB_Driver_CursorId___unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_CursorId, __serialize, arginfo_class_MongoDB_Driver_CursorId___serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_FE_END

--- a/src/MongoDB/ReadConcern.stub.php
+++ b/src/MongoDB/ReadConcern.stub.php
@@ -56,8 +56,12 @@ final class ReadConcern implements \MongoDB\BSON\Serializable, \Serializable
 
     final public function serialize(): string {}
 
+#if PHP_VERSION_ID >= 80000
+    final public function unserialize(string $data): void {}
+#else
     /** @param string $serialized */
     final public function unserialize($serialized): void {}
+#endif
 
     final public function __unserialize(array $data): void {}
 

--- a/src/MongoDB/ReadConcern_arginfo.h
+++ b/src/MongoDB/ReadConcern_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a017ad20fa8005cedbf7305aae5b45dd558356aa */
+ * Stub hash: cc214d2fd99e6191747053214210d07da48831a7 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_ReadConcern___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, level, IS_STRING, 1, "null")
@@ -28,9 +28,17 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_ReadConcern_serialize, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_ReadConcern_unserialize, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if !(PHP_VERSION_ID >= 80000)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_ReadConcern_unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_INFO(0, serialized)
 ZEND_END_ARG_INFO()
+#endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_ReadConcern___unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
@@ -51,7 +59,12 @@ static ZEND_METHOD(MongoDB_Driver_ReadConcern, bsonSerialize);
 static ZEND_METHOD(MongoDB_Driver_ReadConcern, bsonSerialize);
 #endif
 static ZEND_METHOD(MongoDB_Driver_ReadConcern, serialize);
+#if PHP_VERSION_ID >= 80000
 static ZEND_METHOD(MongoDB_Driver_ReadConcern, unserialize);
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+static ZEND_METHOD(MongoDB_Driver_ReadConcern, unserialize);
+#endif
 static ZEND_METHOD(MongoDB_Driver_ReadConcern, __unserialize);
 static ZEND_METHOD(MongoDB_Driver_ReadConcern, __serialize);
 
@@ -68,7 +81,12 @@ static const zend_function_entry class_MongoDB_Driver_ReadConcern_methods[] = {
 	ZEND_ME(MongoDB_Driver_ReadConcern, bsonSerialize, arginfo_class_MongoDB_Driver_ReadConcern_bsonSerialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 #endif
 	ZEND_ME(MongoDB_Driver_ReadConcern, serialize, arginfo_class_MongoDB_Driver_ReadConcern_serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#if PHP_VERSION_ID >= 80000
 	ZEND_ME(MongoDB_Driver_ReadConcern, unserialize, arginfo_class_MongoDB_Driver_ReadConcern_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+	ZEND_ME(MongoDB_Driver_ReadConcern, unserialize, arginfo_class_MongoDB_Driver_ReadConcern_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
 	ZEND_ME(MongoDB_Driver_ReadConcern, __unserialize, arginfo_class_MongoDB_Driver_ReadConcern___unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_ReadConcern, __serialize, arginfo_class_MongoDB_Driver_ReadConcern___serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_FE_END
@@ -84,35 +102,35 @@ static zend_class_entry *register_class_MongoDB_Driver_ReadConcern(zend_class_en
 	zend_class_implements(class_entry, 2, class_entry_MongoDB_BSON_Serializable, class_entry_Serializable);
 
 	zval const_LINEARIZABLE_value;
-	zend_string *const_LINEARIZABLE_value_str = zend_string_init(MONGOC_READ_CONCERN_LEVEL_LINEARIZABLE, sizeof(MONGOC_READ_CONCERN_LEVEL_LINEARIZABLE) - 1, 1);
+	zend_string *const_LINEARIZABLE_value_str = zend_string_init(MONGOC_READ_CONCERN_LEVEL_LINEARIZABLE, strlen(MONGOC_READ_CONCERN_LEVEL_LINEARIZABLE), 1);
 	ZVAL_STR(&const_LINEARIZABLE_value, const_LINEARIZABLE_value_str);
 	zend_string *const_LINEARIZABLE_name = zend_string_init_interned("LINEARIZABLE", sizeof("LINEARIZABLE") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_LINEARIZABLE_name, &const_LINEARIZABLE_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_LINEARIZABLE_name);
 
 	zval const_LOCAL_value;
-	zend_string *const_LOCAL_value_str = zend_string_init(MONGOC_READ_CONCERN_LEVEL_LOCAL, sizeof(MONGOC_READ_CONCERN_LEVEL_LOCAL) - 1, 1);
+	zend_string *const_LOCAL_value_str = zend_string_init(MONGOC_READ_CONCERN_LEVEL_LOCAL, strlen(MONGOC_READ_CONCERN_LEVEL_LOCAL), 1);
 	ZVAL_STR(&const_LOCAL_value, const_LOCAL_value_str);
 	zend_string *const_LOCAL_name = zend_string_init_interned("LOCAL", sizeof("LOCAL") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_LOCAL_name, &const_LOCAL_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_LOCAL_name);
 
 	zval const_MAJORITY_value;
-	zend_string *const_MAJORITY_value_str = zend_string_init(MONGOC_READ_CONCERN_LEVEL_MAJORITY, sizeof(MONGOC_READ_CONCERN_LEVEL_MAJORITY) - 1, 1);
+	zend_string *const_MAJORITY_value_str = zend_string_init(MONGOC_READ_CONCERN_LEVEL_MAJORITY, strlen(MONGOC_READ_CONCERN_LEVEL_MAJORITY), 1);
 	ZVAL_STR(&const_MAJORITY_value, const_MAJORITY_value_str);
 	zend_string *const_MAJORITY_name = zend_string_init_interned("MAJORITY", sizeof("MAJORITY") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_MAJORITY_name, &const_MAJORITY_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_MAJORITY_name);
 
 	zval const_AVAILABLE_value;
-	zend_string *const_AVAILABLE_value_str = zend_string_init(MONGOC_READ_CONCERN_LEVEL_AVAILABLE, sizeof(MONGOC_READ_CONCERN_LEVEL_AVAILABLE) - 1, 1);
+	zend_string *const_AVAILABLE_value_str = zend_string_init(MONGOC_READ_CONCERN_LEVEL_AVAILABLE, strlen(MONGOC_READ_CONCERN_LEVEL_AVAILABLE), 1);
 	ZVAL_STR(&const_AVAILABLE_value, const_AVAILABLE_value_str);
 	zend_string *const_AVAILABLE_name = zend_string_init_interned("AVAILABLE", sizeof("AVAILABLE") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_AVAILABLE_name, &const_AVAILABLE_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_AVAILABLE_name);
 
 	zval const_SNAPSHOT_value;
-	zend_string *const_SNAPSHOT_value_str = zend_string_init(MONGOC_READ_CONCERN_LEVEL_SNAPSHOT, sizeof(MONGOC_READ_CONCERN_LEVEL_SNAPSHOT) - 1, 1);
+	zend_string *const_SNAPSHOT_value_str = zend_string_init(MONGOC_READ_CONCERN_LEVEL_SNAPSHOT, strlen(MONGOC_READ_CONCERN_LEVEL_SNAPSHOT), 1);
 	ZVAL_STR(&const_SNAPSHOT_value, const_SNAPSHOT_value_str);
 	zend_string *const_SNAPSHOT_name = zend_string_init_interned("SNAPSHOT", sizeof("SNAPSHOT") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_SNAPSHOT_name, &const_SNAPSHOT_value, ZEND_ACC_PUBLIC, NULL);

--- a/src/MongoDB/ReadPreference.stub.php
+++ b/src/MongoDB/ReadPreference.stub.php
@@ -109,8 +109,12 @@ final class ReadPreference implements \MongoDB\BSON\Serializable, \Serializable
 
     final public function serialize(): string {}
 
+#if PHP_VERSION_ID >= 80000
+    final public function unserialize(string $data): void {}
+#else
     /** @param string $serialized */
     final public function unserialize($serialized): void {}
+#endif
 
     final public function __unserialize(array $data): void {}
 

--- a/src/MongoDB/ReadPreference_arginfo.h
+++ b/src/MongoDB/ReadPreference_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 6b575f8790ca320a45d772c788e2d23a913885ef */
+ * Stub hash: df8b13e252c05cbb7603dec8c1659fb88845ed73 */
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_ReadPreference___construct, 0, 0, 1)
@@ -47,9 +47,17 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_MongoDB_Driver_ReadPreference_serialize arginfo_class_MongoDB_Driver_ReadPreference_getModeString
 
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_ReadPreference_unserialize, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if !(PHP_VERSION_ID >= 80000)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_ReadPreference_unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_INFO(0, serialized)
 ZEND_END_ARG_INFO()
+#endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_ReadPreference___unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
@@ -77,7 +85,12 @@ static ZEND_METHOD(MongoDB_Driver_ReadPreference, bsonSerialize);
 static ZEND_METHOD(MongoDB_Driver_ReadPreference, bsonSerialize);
 #endif
 static ZEND_METHOD(MongoDB_Driver_ReadPreference, serialize);
+#if PHP_VERSION_ID >= 80000
 static ZEND_METHOD(MongoDB_Driver_ReadPreference, unserialize);
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+static ZEND_METHOD(MongoDB_Driver_ReadPreference, unserialize);
+#endif
 static ZEND_METHOD(MongoDB_Driver_ReadPreference, __unserialize);
 static ZEND_METHOD(MongoDB_Driver_ReadPreference, __serialize);
 
@@ -102,7 +115,12 @@ static const zend_function_entry class_MongoDB_Driver_ReadPreference_methods[] =
 	ZEND_ME(MongoDB_Driver_ReadPreference, bsonSerialize, arginfo_class_MongoDB_Driver_ReadPreference_bsonSerialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 #endif
 	ZEND_ME(MongoDB_Driver_ReadPreference, serialize, arginfo_class_MongoDB_Driver_ReadPreference_serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#if PHP_VERSION_ID >= 80000
 	ZEND_ME(MongoDB_Driver_ReadPreference, unserialize, arginfo_class_MongoDB_Driver_ReadPreference_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+	ZEND_ME(MongoDB_Driver_ReadPreference, unserialize, arginfo_class_MongoDB_Driver_ReadPreference_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
 	ZEND_ME(MongoDB_Driver_ReadPreference, __unserialize, arginfo_class_MongoDB_Driver_ReadPreference___unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_ReadPreference, __serialize, arginfo_class_MongoDB_Driver_ReadPreference___serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_FE_END
@@ -148,35 +166,35 @@ static zend_class_entry *register_class_MongoDB_Driver_ReadPreference(zend_class
 	zend_string_release(const_RP_NEAREST_name);
 
 	zval const_PRIMARY_value;
-	zend_string *const_PRIMARY_value_str = zend_string_init(PHONGO_READ_PRIMARY, sizeof(PHONGO_READ_PRIMARY) - 1, 1);
+	zend_string *const_PRIMARY_value_str = zend_string_init(PHONGO_READ_PRIMARY, strlen(PHONGO_READ_PRIMARY), 1);
 	ZVAL_STR(&const_PRIMARY_value, const_PRIMARY_value_str);
 	zend_string *const_PRIMARY_name = zend_string_init_interned("PRIMARY", sizeof("PRIMARY") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_PRIMARY_name, &const_PRIMARY_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_PRIMARY_name);
 
 	zval const_PRIMARY_PREFERRED_value;
-	zend_string *const_PRIMARY_PREFERRED_value_str = zend_string_init(PHONGO_READ_PRIMARY_PREFERRED, sizeof(PHONGO_READ_PRIMARY_PREFERRED) - 1, 1);
+	zend_string *const_PRIMARY_PREFERRED_value_str = zend_string_init(PHONGO_READ_PRIMARY_PREFERRED, strlen(PHONGO_READ_PRIMARY_PREFERRED), 1);
 	ZVAL_STR(&const_PRIMARY_PREFERRED_value, const_PRIMARY_PREFERRED_value_str);
 	zend_string *const_PRIMARY_PREFERRED_name = zend_string_init_interned("PRIMARY_PREFERRED", sizeof("PRIMARY_PREFERRED") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_PRIMARY_PREFERRED_name, &const_PRIMARY_PREFERRED_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_PRIMARY_PREFERRED_name);
 
 	zval const_SECONDARY_value;
-	zend_string *const_SECONDARY_value_str = zend_string_init(PHONGO_READ_SECONDARY, sizeof(PHONGO_READ_SECONDARY) - 1, 1);
+	zend_string *const_SECONDARY_value_str = zend_string_init(PHONGO_READ_SECONDARY, strlen(PHONGO_READ_SECONDARY), 1);
 	ZVAL_STR(&const_SECONDARY_value, const_SECONDARY_value_str);
 	zend_string *const_SECONDARY_name = zend_string_init_interned("SECONDARY", sizeof("SECONDARY") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_SECONDARY_name, &const_SECONDARY_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_SECONDARY_name);
 
 	zval const_SECONDARY_PREFERRED_value;
-	zend_string *const_SECONDARY_PREFERRED_value_str = zend_string_init(PHONGO_READ_SECONDARY_PREFERRED, sizeof(PHONGO_READ_SECONDARY_PREFERRED) - 1, 1);
+	zend_string *const_SECONDARY_PREFERRED_value_str = zend_string_init(PHONGO_READ_SECONDARY_PREFERRED, strlen(PHONGO_READ_SECONDARY_PREFERRED), 1);
 	ZVAL_STR(&const_SECONDARY_PREFERRED_value, const_SECONDARY_PREFERRED_value_str);
 	zend_string *const_SECONDARY_PREFERRED_name = zend_string_init_interned("SECONDARY_PREFERRED", sizeof("SECONDARY_PREFERRED") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_SECONDARY_PREFERRED_name, &const_SECONDARY_PREFERRED_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_SECONDARY_PREFERRED_name);
 
 	zval const_NEAREST_value;
-	zend_string *const_NEAREST_value_str = zend_string_init(PHONGO_READ_NEAREST, sizeof(PHONGO_READ_NEAREST) - 1, 1);
+	zend_string *const_NEAREST_value_str = zend_string_init(PHONGO_READ_NEAREST, strlen(PHONGO_READ_NEAREST), 1);
 	ZVAL_STR(&const_NEAREST_value, const_NEAREST_value_str);
 	zend_string *const_NEAREST_name = zend_string_init_interned("NEAREST", sizeof("NEAREST") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_NEAREST_name, &const_NEAREST_value, ZEND_ACC_PUBLIC, NULL);

--- a/src/MongoDB/ServerApi.stub.php
+++ b/src/MongoDB/ServerApi.stub.php
@@ -25,8 +25,12 @@ final class ServerApi implements \MongoDB\BSON\Serializable, \Serializable
 
     final public function serialize(): string {}
 
+#if PHP_VERSION_ID >= 80000
+    final public function unserialize(string $data): void {}
+#else
     /** @param string $serialized */
     final public function unserialize($serialized): void {}
+#endif
 
     final public function __unserialize(array $data): void {}
 

--- a/src/MongoDB/ServerApi_arginfo.h
+++ b/src/MongoDB/ServerApi_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 11bb54c6ca6c5d8dedd66b7d77b89779b1e81614 */
+ * Stub hash: 27db2a958d63eaf3ca813416bf0756c981dd013f */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_ServerApi___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, version, IS_STRING, 0)
@@ -24,9 +24,17 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_ServerApi_serialize, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_ServerApi_unserialize, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if !(PHP_VERSION_ID >= 80000)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_ServerApi_unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_INFO(0, serialized)
 ZEND_END_ARG_INFO()
+#endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_ServerApi___unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
@@ -45,7 +53,12 @@ static ZEND_METHOD(MongoDB_Driver_ServerApi, bsonSerialize);
 static ZEND_METHOD(MongoDB_Driver_ServerApi, bsonSerialize);
 #endif
 static ZEND_METHOD(MongoDB_Driver_ServerApi, serialize);
+#if PHP_VERSION_ID >= 80000
 static ZEND_METHOD(MongoDB_Driver_ServerApi, unserialize);
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+static ZEND_METHOD(MongoDB_Driver_ServerApi, unserialize);
+#endif
 static ZEND_METHOD(MongoDB_Driver_ServerApi, __unserialize);
 static ZEND_METHOD(MongoDB_Driver_ServerApi, __serialize);
 
@@ -60,7 +73,12 @@ static const zend_function_entry class_MongoDB_Driver_ServerApi_methods[] = {
 	ZEND_ME(MongoDB_Driver_ServerApi, bsonSerialize, arginfo_class_MongoDB_Driver_ServerApi_bsonSerialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 #endif
 	ZEND_ME(MongoDB_Driver_ServerApi, serialize, arginfo_class_MongoDB_Driver_ServerApi_serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#if PHP_VERSION_ID >= 80000
 	ZEND_ME(MongoDB_Driver_ServerApi, unserialize, arginfo_class_MongoDB_Driver_ServerApi_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+	ZEND_ME(MongoDB_Driver_ServerApi, unserialize, arginfo_class_MongoDB_Driver_ServerApi_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
 	ZEND_ME(MongoDB_Driver_ServerApi, __unserialize, arginfo_class_MongoDB_Driver_ServerApi___unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_ServerApi, __serialize, arginfo_class_MongoDB_Driver_ServerApi___serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_FE_END
@@ -76,7 +94,7 @@ static zend_class_entry *register_class_MongoDB_Driver_ServerApi(zend_class_entr
 	zend_class_implements(class_entry, 2, class_entry_MongoDB_BSON_Serializable, class_entry_Serializable);
 
 	zval const_V1_value;
-	zend_string *const_V1_value_str = zend_string_init("1", sizeof("1") - 1, 1);
+	zend_string *const_V1_value_str = zend_string_init("1", strlen("1"), 1);
 	ZVAL_STR(&const_V1_value, const_V1_value_str);
 	zend_string *const_V1_name = zend_string_init_interned("V1", sizeof("V1") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_V1_name, &const_V1_value, ZEND_ACC_PUBLIC, NULL);

--- a/src/MongoDB/WriteConcern.stub.php
+++ b/src/MongoDB/WriteConcern.stub.php
@@ -46,8 +46,12 @@ final class WriteConcern implements \MongoDB\BSON\Serializable, \Serializable
 
     final public function serialize(): string {}
 
+#if PHP_VERSION_ID >= 80000
+    final public function unserialize(string $data): void {}
+#else
     /** @param string $serialized */
     final public function unserialize($serialized): void {}
+#endif
 
     final public function __unserialize(array $data): void {}
 

--- a/src/MongoDB/WriteConcern_arginfo.h
+++ b/src/MongoDB/WriteConcern_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 697b55c640ce07590e4fdb8bbc9d12d316ecf412 */
+ * Stub hash: 071d716b692ad1d3abdaf61bc96e9671f64f71e1 */
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_WriteConcern___construct, 0, 0, 1)
@@ -52,9 +52,17 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_WriteConcern_serialize, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_WriteConcern_unserialize, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if !(PHP_VERSION_ID >= 80000)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_WriteConcern_unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_INFO(0, serialized)
 ZEND_END_ARG_INFO()
+#endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_WriteConcern___unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
@@ -87,7 +95,12 @@ static ZEND_METHOD(MongoDB_Driver_WriteConcern, bsonSerialize);
 static ZEND_METHOD(MongoDB_Driver_WriteConcern, bsonSerialize);
 #endif
 static ZEND_METHOD(MongoDB_Driver_WriteConcern, serialize);
+#if PHP_VERSION_ID >= 80000
 static ZEND_METHOD(MongoDB_Driver_WriteConcern, unserialize);
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+static ZEND_METHOD(MongoDB_Driver_WriteConcern, unserialize);
+#endif
 static ZEND_METHOD(MongoDB_Driver_WriteConcern, __unserialize);
 static ZEND_METHOD(MongoDB_Driver_WriteConcern, __serialize);
 
@@ -116,7 +129,12 @@ static const zend_function_entry class_MongoDB_Driver_WriteConcern_methods[] = {
 	ZEND_ME(MongoDB_Driver_WriteConcern, bsonSerialize, arginfo_class_MongoDB_Driver_WriteConcern_bsonSerialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 #endif
 	ZEND_ME(MongoDB_Driver_WriteConcern, serialize, arginfo_class_MongoDB_Driver_WriteConcern_serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#if PHP_VERSION_ID >= 80000
 	ZEND_ME(MongoDB_Driver_WriteConcern, unserialize, arginfo_class_MongoDB_Driver_WriteConcern_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+	ZEND_ME(MongoDB_Driver_WriteConcern, unserialize, arginfo_class_MongoDB_Driver_WriteConcern_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#endif
 	ZEND_ME(MongoDB_Driver_WriteConcern, __unserialize, arginfo_class_MongoDB_Driver_WriteConcern___unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_WriteConcern, __serialize, arginfo_class_MongoDB_Driver_WriteConcern___serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_FE_END
@@ -132,7 +150,7 @@ static zend_class_entry *register_class_MongoDB_Driver_WriteConcern(zend_class_e
 	zend_class_implements(class_entry, 2, class_entry_MongoDB_BSON_Serializable, class_entry_Serializable);
 
 	zval const_MAJORITY_value;
-	zend_string *const_MAJORITY_value_str = zend_string_init(PHONGO_WRITE_CONCERN_W_MAJORITY, sizeof(PHONGO_WRITE_CONCERN_W_MAJORITY) - 1, 1);
+	zend_string *const_MAJORITY_value_str = zend_string_init(PHONGO_WRITE_CONCERN_W_MAJORITY, strlen(PHONGO_WRITE_CONCERN_W_MAJORITY), 1);
 	ZVAL_STR(&const_MAJORITY_value, const_MAJORITY_value_str);
 	zend_string *const_MAJORITY_name = zend_string_init_interned("MAJORITY", sizeof("MAJORITY") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_MAJORITY_name, &const_MAJORITY_value, ZEND_ACC_PUBLIC, NULL);


### PR DESCRIPTION
PHPC-2252

The signature of `Serializable::unserialize` was changed in PHP 8: the argument was renamed from `$serialized` to `$data`, and a string type was added. Since users are unlikely to call this method manually AND be using named arguments on a single-parameter method, this does not have a significant downstream impact. The old signature is kept in place for PHP < 8 as adding the type would violate the original contract (which technically accepts any argument type).

This also allows us to remove a workaround in the function map generation that was necessary due to the renamed parameter (see https://github.com/mongodb/mongo-php-driver/pull/1436#discussion_r1236066223 for discussion).