### PR TITLE
PHPLIB-1098: Update evergreen build hosts

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1124,27 +1124,52 @@ axes:
   - id: os
     display_name: OS
     values:
+      # Debian
       - id: debian11
         display_name: "Debian 11"
-        run_on: debian11
+        run_on: debian11-small
       - id: debian10
         display_name: "Debian 10"
-        run_on: debian10
+        run_on: debian10-small
       - id: debian92
         display_name: "Debian 9.2"
-        run_on: debian92
-      - id: rhel70
-        display_name: "RHEL 7.0"
-        run_on: rhel70
+        run_on: debian92-small
+
+      # RHEL
+      - id: rhel90
+        display_name: "RHEL 9.0"
+        run_on: rhel90-small
+      # TODO: RHEL 8.x is not working yet
+      # - id: rhel82-arm64
+      #   display_name: "RHEL 8.2 ARM64"
+      #   run_on: rhel82-arm64-small
+      # - id: rhel80
+      #   display_name: "RHEL 8.0"
+      #   run_on: rhel80-small
+      - id: rhel76
+        display_name: "RHEL 7.6"
+        run_on: rhel76-small
       - id: rhel71-power8
         display_name: "RHEL 7.1 Power 8"
         run_on: rhel71-power8-build
       - id: rhel72-zseries
         display_name: "RHEL 7.2 zSeries"
         run_on: rhel72-zseries-build
-      - id: ubuntu1804-arm64
-        display_name: "Ubuntu 18.04 ARM64"
-        run_on: ubuntu1804-arm64-test
+
+      # Ubuntu LTS
+      - id: ubuntu2204
+        display_name: "Ubuntu 22.04 x64"
+        run_on: ubuntu2204-small
+      - id: ubuntu2204-arm64
+        display_name: "Ubuntu 22.04 ARM64"
+        run_on: ubuntu2204-arm64-small
+      - id: ubuntu2004
+        display_name: "Ubuntu 20.04 x64"
+        run_on: ubuntu2004-small
+      - id: ubuntu2004-arm64
+        display_name: "Ubuntu 20.04 ARM64"
+        run_on: ubuntu2004-arm64-small
+
       # Pending installation of PHP toolchain on macOS hosts (see: PHPC-869)
       # - id: macos-1014
       #   display_name: "Mac OS 10.14"
@@ -1184,15 +1209,29 @@ axes:
 
 
 buildvariants:
-# Test all PHP versions with latest-stable MongoDB on Debian 11 and RHEL 7.0
+# Test all PHP versions with latest-stable MongoDB on Debian 11, Debian 10, RHEL 8.0, Ubuntu 20.04
 - matrix_name: "test-php-versions"
-  matrix_spec: { "os": ["rhel70", "debian11"], "mongodb-edge-versions": "latest-stable", "php-versions": "*" }
+  matrix_spec:
+    os:
+    - debian11
+    - debian10
+    - rhel90
+    # TODO: RHEL 8.x is not working yet
+    # - rhel82-arm64
+    # - rhel80
+    - rhel76
+    - ubuntu2204-arm64
+    - ubuntu2204
+    - ubuntu2004-arm64
+    - ubuntu2004
+    mongodb-edge-versions: latest-stable
+    php-versions: "*"
   display_name: "${os}, ${mongodb-edge-versions}, ${php-versions}"
   exclude_spec:
     # Exclude "latest-stable" PHP version for Debian 11 (see: test-mongodb-versions matrix)
     - { "os": "debian11", "mongodb-edge-versions": "*", "php-versions": "8.2" }
-    # PHP 8.1+ is not available on rhel70
-    - { "os": "rhel70", "mongodb-edge-versions": "*", "php-versions": ["8.1", "8.2"] }
+    # Exclude PHP versions older than 8.1 on RHEL 9 and Ubuntu 22.04 (OpenSSL 3 is only supported on PHP 8.1+)
+    - { "os": ["rhel90", "ubuntu2204-arm64", "ubuntu2204"], "mongodb-edge-versions": "*", "php-versions": ["7.2", "7.3", "7.4", "8.0"] }
   tasks:
     - name: "test-standalone-ssl"
     - name: "test-replicaset-auth"
@@ -1214,9 +1253,9 @@ buildvariants:
     - name: "test-replicaset-auth"
     - name: "test-sharded"
 
-# Test ARM64, Power8, and zSeries architectures with MongoDB 4.4
+# Test RHEL Power8 and zSeries architectures with MongoDB 4.4
 - matrix_name: "test-alt-archs"
-  matrix_spec: { "os": ["rhel71-power8", "rhel72-zseries", "ubuntu1804-arm64"], "mongodb-versions": "4.4", "php-edge-versions": "oldest-supported" }
+  matrix_spec: { "os": ["rhel71-power8", "rhel72-zseries"], "mongodb-versions": "4.4", "php-edge-versions": "oldest-supported" }
   display_name: "${os}, ${mongodb-versions}, ${php-edge-versions}"
   tasks:
     - name: "test-standalone-ssl"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -361,7 +361,7 @@ functions:
       params:
         script: |
           ${PREPARE_SHELL}
-          MONGODB_VERSION=${MONGODB_VERSION} TOPOLOGY=${TOPOLOGY} AUTH=${AUTH} SSL=${SSL} STORAGE_ENGINE=${STORAGE_ENGINE} LOAD_BALANCER=${LOAD_BALANCER} REQUIRE_API_VERSION=${REQUIRE_API_VERSION} ORCHESTRATION_FILE=${ORCHESTRATION_FILE} sh ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
+          SKIP_LEGACY_SHELL=${SKIP_LEGACY_SHELL} MONGODB_VERSION=${MONGODB_VERSION} TOPOLOGY=${TOPOLOGY} AUTH=${AUTH} SSL=${SSL} STORAGE_ENGINE=${STORAGE_ENGINE} LOAD_BALANCER=${LOAD_BALANCER} REQUIRE_API_VERSION=${REQUIRE_API_VERSION} ORCHESTRATION_FILE=${ORCHESTRATION_FILE} sh ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
     # run-orchestration generates expansion file with MONGODB_URI and CRYPT_SHARED_LIB_PATH
     - command: expansions.update
       params:
@@ -1139,6 +1139,8 @@ axes:
       - id: rhel90
         display_name: "RHEL 9.0"
         run_on: rhel90-small
+        variables:
+          SKIP_LEGACY_SHELL: "true"
       # TODO: RHEL 8.x is not working yet
       # - id: rhel82-arm64
       #   display_name: "RHEL 8.2 ARM64"
@@ -1160,9 +1162,13 @@ axes:
       - id: ubuntu2204
         display_name: "Ubuntu 22.04 x64"
         run_on: ubuntu2204-small
+        variables:
+          SKIP_LEGACY_SHELL: "true"
       - id: ubuntu2204-arm64
         display_name: "Ubuntu 22.04 ARM64"
         run_on: ubuntu2204-arm64-small
+        variables:
+          SKIP_LEGACY_SHELL: "true"
       - id: ubuntu2004
         display_name: "Ubuntu 20.04 x64"
         run_on: ubuntu2004-small

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -361,7 +361,7 @@ functions:
       params:
         script: |
           ${PREPARE_SHELL}
-          SKIP_LEGACY_SHELL=${SKIP_LEGACY_SHELL} MONGODB_VERSION=${MONGODB_VERSION} TOPOLOGY=${TOPOLOGY} AUTH=${AUTH} SSL=${SSL} STORAGE_ENGINE=${STORAGE_ENGINE} LOAD_BALANCER=${LOAD_BALANCER} REQUIRE_API_VERSION=${REQUIRE_API_VERSION} ORCHESTRATION_FILE=${ORCHESTRATION_FILE} sh ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
+          SKIP_LEGACY_SHELL=true MONGODB_VERSION=${MONGODB_VERSION} TOPOLOGY=${TOPOLOGY} AUTH=${AUTH} SSL=${SSL} STORAGE_ENGINE=${STORAGE_ENGINE} LOAD_BALANCER=${LOAD_BALANCER} REQUIRE_API_VERSION=${REQUIRE_API_VERSION} ORCHESTRATION_FILE=${ORCHESTRATION_FILE} sh ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
     # run-orchestration generates expansion file with MONGODB_URI and CRYPT_SHARED_LIB_PATH
     - command: expansions.update
       params:
@@ -1139,8 +1139,6 @@ axes:
       - id: rhel90
         display_name: "RHEL 9.0"
         run_on: rhel90-small
-        variables:
-          SKIP_LEGACY_SHELL: "true"
       # TODO: RHEL 8.x is not working yet
       # - id: rhel82-arm64
       #   display_name: "RHEL 8.2 ARM64"
@@ -1162,13 +1160,9 @@ axes:
       - id: ubuntu2204
         display_name: "Ubuntu 22.04 x64"
         run_on: ubuntu2204-small
-        variables:
-          SKIP_LEGACY_SHELL: "true"
       - id: ubuntu2204-arm64
         display_name: "Ubuntu 22.04 ARM64"
         run_on: ubuntu2204-arm64-small
-        variables:
-          SKIP_LEGACY_SHELL: "true"
       - id: ubuntu2004
         display_name: "Ubuntu 20.04 x64"
         run_on: ubuntu2004-small


### PR DESCRIPTION
PHPLIB-1098

This PR changes the evergreen configuration to only build on supported hosts.
This includes:
- Drop testing on Ubuntu 18.04
- Drop testing on RHEL 7.0
- Add Ubuntu 22.04 and 20.04
- Add RHEL 9.0 and 7.6

RHEL 7.1 and 7.2 are kept to keep testing on the Z and Power architectures. Once the toolchain is available, RHEL 8.0 will take their place.