### PR TITLE
PHPLIB-1098: Test on RHEL 8.x

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1154,12 +1154,6 @@ axes:
       - id: rhel76
         display_name: "RHEL 7.6"
         run_on: rhel76-small
-      - id: rhel71-power8
-        display_name: "RHEL 7.1 Power 8"
-        run_on: rhel71-power8-build
-      - id: rhel72-zseries
-        display_name: "RHEL 7.2 zSeries"
-        run_on: rhel72-zseries-build
 
       # Ubuntu LTS
       - id: ubuntu2204
@@ -1256,15 +1250,6 @@ buildvariants:
     - name: "test-standalone-auth"
     - name: "test-standalone-ssl"
     - name: "test-replicaset"
-    - name: "test-replicaset-auth"
-    - name: "test-sharded"
-
-# Test RHEL Power8 and zSeries architectures with MongoDB 4.4
-- matrix_name: "test-alt-archs"
-  matrix_spec: { "os": ["rhel71-power8", "rhel72-zseries"], "mongodb-versions": "4.4", "php-edge-versions": "oldest-supported" }
-  display_name: "${os}, ${mongodb-versions}, ${php-edge-versions}"
-  tasks:
-    - name: "test-standalone-ssl"
     - name: "test-replicaset-auth"
     - name: "test-sharded"
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1139,13 +1139,18 @@ axes:
       - id: rhel90
         display_name: "RHEL 9.0"
         run_on: rhel90-small
-      # TODO: RHEL 8.x is not working yet
-      # - id: rhel82-arm64
-      #   display_name: "RHEL 8.2 ARM64"
-      #   run_on: rhel82-arm64-small
-      # - id: rhel80
-      #   display_name: "RHEL 8.0"
-      #   run_on: rhel80-small
+      - id: rhel83-zseries
+        display_name: "RHEL 8.3 Zseries"
+        run_on: rhel83-zseries-small
+      - id: rhel82-arm64
+        display_name: "RHEL 8.2 ARM64"
+        run_on: rhel82-arm64-small
+      - id: rhel81-power8
+        display_name: "RHEL 8.1 Power8"
+        run_on: rhel81-power8-large
+      - id: rhel80
+        display_name: "RHEL 8.0"
+        run_on: rhel80-small
       - id: rhel76
         display_name: "RHEL 7.6"
         run_on: rhel76-small
@@ -1209,16 +1214,17 @@ axes:
 
 
 buildvariants:
-# Test all PHP versions with latest-stable MongoDB on Debian 11, Debian 10, RHEL 8.0, Ubuntu 20.04
+# Test all PHP versions with latest-stable MongoDB on all operating systems
 - matrix_name: "test-php-versions"
   matrix_spec:
     os:
     - debian11
     - debian10
     - rhel90
-    # TODO: RHEL 8.x is not working yet
-    # - rhel82-arm64
-    # - rhel80
+    - rhel83-zseries
+    - rhel82-arm64
+    - rhel81-power8
+    - rhel80
     - rhel76
     - ubuntu2204-arm64
     - ubuntu2204


### PR DESCRIPTION
PHPLIB-1098

This follows up work in #1442 and removes RHEL 7.1 and 7.2 in favour of RHEL 8.

I've ran a previous patch for these changes: https://spruce.mongodb.com/version/64a65e1be3c331bdcdd56781/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

Note that the zseries builds take a long time due to limited build system availability.