### PR TITLE
PHPC-1000: Allow bsonSerialize to return BSON structure

### DIFF
--- a/src/BSON/Document.c
+++ b/src/BSON/Document.c
@@ -473,7 +473,7 @@ static HashTable* php_phongo_document_get_properties(phongo_compat_object_handle
 
 void php_phongo_document_init_ce(INIT_FUNC_ARGS)
 {
-	php_phongo_document_ce                = register_class_MongoDB_BSON_Document(zend_ce_aggregate, zend_ce_serializable);
+	php_phongo_document_ce                = register_class_MongoDB_BSON_Document(zend_ce_aggregate, zend_ce_serializable, php_phongo_type_ce);
 	php_phongo_document_ce->create_object = php_phongo_document_create_object;
 
 #if PHP_VERSION_ID >= 80000

--- a/src/BSON/Document.stub.php
+++ b/src/BSON/Document.stub.php
@@ -7,7 +7,7 @@
 
 namespace MongoDB\BSON;
 
-final class Document implements \IteratorAggregate, \Serializable
+final class Document implements \IteratorAggregate, \Serializable, Type
 {
     private function __construct() {}
 

--- a/src/BSON/Document_arginfo.h
+++ b/src/BSON/Document_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: e00ccf66afed0f51040527ee5ee24513f0c1f495 */
+ * Stub hash: 703e15f17b01dd2b6f04cb89c080ba83a5a420d0 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_Document___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -166,14 +166,14 @@ static const zend_function_entry class_MongoDB_BSON_Document_methods[] = {
 	ZEND_FE_END
 };
 
-static zend_class_entry *register_class_MongoDB_BSON_Document(zend_class_entry *class_entry_IteratorAggregate, zend_class_entry *class_entry_Serializable)
+static zend_class_entry *register_class_MongoDB_BSON_Document(zend_class_entry *class_entry_IteratorAggregate, zend_class_entry *class_entry_Serializable, zend_class_entry *class_entry_MongoDB_BSON_Type)
 {
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "Document", class_MongoDB_BSON_Document_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
-	zend_class_implements(class_entry, 2, class_entry_IteratorAggregate, class_entry_Serializable);
+	zend_class_implements(class_entry, 3, class_entry_IteratorAggregate, class_entry_Serializable, class_entry_MongoDB_BSON_Type);
 
 	return class_entry;
 }

--- a/src/BSON/PackedArray.c
+++ b/src/BSON/PackedArray.c
@@ -403,7 +403,7 @@ static HashTable* php_phongo_packedarray_get_properties(phongo_compat_object_han
 
 void php_phongo_packedarray_init_ce(INIT_FUNC_ARGS)
 {
-	php_phongo_packedarray_ce                = register_class_MongoDB_BSON_PackedArray(zend_ce_aggregate, zend_ce_serializable);
+	php_phongo_packedarray_ce                = register_class_MongoDB_BSON_PackedArray(zend_ce_aggregate, zend_ce_serializable, php_phongo_type_ce);
 	php_phongo_packedarray_ce->create_object = php_phongo_packedarray_create_object;
 
 #if PHP_VERSION_ID >= 80000

--- a/src/BSON/PackedArray.stub.php
+++ b/src/BSON/PackedArray.stub.php
@@ -7,7 +7,7 @@
 
 namespace MongoDB\BSON;
 
-final class PackedArray implements \IteratorAggregate, \Serializable
+final class PackedArray implements \IteratorAggregate, \Serializable, Type
 {
     private function __construct() {}
 

--- a/src/BSON/PackedArray_arginfo.h
+++ b/src/BSON/PackedArray_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: e9b57c4051440170531560cc355e0af1b43f3424 */
+ * Stub hash: f9813432d7811e068f62a4b34d86919a52f63984 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_PackedArray___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -128,14 +128,14 @@ static const zend_function_entry class_MongoDB_BSON_PackedArray_methods[] = {
 	ZEND_FE_END
 };
 
-static zend_class_entry *register_class_MongoDB_BSON_PackedArray(zend_class_entry *class_entry_IteratorAggregate, zend_class_entry *class_entry_Serializable)
+static zend_class_entry *register_class_MongoDB_BSON_PackedArray(zend_class_entry *class_entry_IteratorAggregate, zend_class_entry *class_entry_Serializable, zend_class_entry *class_entry_MongoDB_BSON_Type)
 {
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "PackedArray", class_MongoDB_BSON_PackedArray_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
-	zend_class_implements(class_entry, 2, class_entry_IteratorAggregate, class_entry_Serializable);
+	zend_class_implements(class_entry, 3, class_entry_IteratorAggregate, class_entry_Serializable, class_entry_MongoDB_BSON_Type);
 
 	return class_entry;
 }

--- a/src/BSON/Persistable.stub.php
+++ b/src/BSON/Persistable.stub.php
@@ -9,4 +9,11 @@ namespace MongoDB\BSON;
 
 interface Persistable extends Serializable, Unserializable
 {
+#if PHP_VERSION_ID >= 80000
+    /** @tentative-return-type */
+    public function bsonSerialize(): array|\stdClass|Document;
+#else
+    /** @return array|\stdClass|Document */
+    public function bsonSerialize();
+#endif
 }

--- a/src/BSON/Persistable_arginfo.h
+++ b/src/BSON/Persistable_arginfo.h
@@ -1,10 +1,30 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: babd07f95f47c3b66228ef23b66ab0446cd5c308 */
+ * Stub hash: e61c06a90093af5468c6c29f6cbf16c5db8d54d1 */
+
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_MongoDB_BSON_Persistable_bsonSerialize, 0, 0, stdClass|MongoDB\\BSON\\Document, MAY_BE_ARRAY)
+ZEND_END_ARG_INFO()
+#endif
+
+#if !(PHP_VERSION_ID >= 80000)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_Persistable_bsonSerialize, 0, 0, 0)
+ZEND_END_ARG_INFO()
+#endif
 
 
+#if PHP_VERSION_ID >= 80000
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+#endif
 
 
 static const zend_function_entry class_MongoDB_BSON_Persistable_methods[] = {
+#if PHP_VERSION_ID >= 80000
+	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_BSON_Persistable, bsonSerialize, arginfo_class_MongoDB_BSON_Persistable_bsonSerialize, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_BSON_Persistable, bsonSerialize, arginfo_class_MongoDB_BSON_Persistable_bsonSerialize, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
 	ZEND_FE_END
 };
 

--- a/src/BSON/Serializable.stub.php
+++ b/src/BSON/Serializable.stub.php
@@ -11,9 +11,9 @@ interface Serializable extends Type
 {
 #if PHP_VERSION_ID >= 80000
     /** @tentative-return-type */
-    public function bsonSerialize(): array|object;
+    public function bsonSerialize(): array|\stdClass;
 #else
-    /** @return array|object */
+    /** @return array|\stdClass */
     public function bsonSerialize();
 #endif
 }

--- a/src/BSON/Serializable.stub.php
+++ b/src/BSON/Serializable.stub.php
@@ -11,9 +11,9 @@ interface Serializable extends Type
 {
 #if PHP_VERSION_ID >= 80000
     /** @tentative-return-type */
-    public function bsonSerialize(): array|\stdClass;
+    public function bsonSerialize(): array|\stdClass|Document|PackedArray;
 #else
-    /** @return array|\stdClass */
+    /** @return array|\stdClass|Document|PackedArray */
     public function bsonSerialize();
 #endif
 }

--- a/src/BSON/Serializable_arginfo.h
+++ b/src/BSON/Serializable_arginfo.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: cbb517e1d922625ff18bdc81620686a44a87e85c */
+ * Stub hash: cc59819a80929f30a89bde0ded725ee4de9d37f5 */
 
 #if PHP_VERSION_ID >= 80000
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_MASK_EX(arginfo_class_MongoDB_BSON_Serializable_bsonSerialize, 0, 0, MAY_BE_ARRAY|MAY_BE_OBJECT)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_MongoDB_BSON_Serializable_bsonSerialize, 0, 0, stdClass, MAY_BE_ARRAY)
 ZEND_END_ARG_INFO()
 #endif
 

--- a/src/BSON/Serializable_arginfo.h
+++ b/src/BSON/Serializable_arginfo.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: cc59819a80929f30a89bde0ded725ee4de9d37f5 */
+ * Stub hash: 92732bafa65af8a12b291f7bcb52b069c45724a7 */
 
 #if PHP_VERSION_ID >= 80000
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_MongoDB_BSON_Serializable_bsonSerialize, 0, 0, stdClass, MAY_BE_ARRAY)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_MongoDB_BSON_Serializable_bsonSerialize, 0, 0, stdClass|MongoDB\\BSON\\Document|MongoDB\\BSON\\PackedArray, MAY_BE_ARRAY)
 ZEND_END_ARG_INFO()
 #endif
 

--- a/src/MongoDB/ReadConcern.stub.php
+++ b/src/MongoDB/ReadConcern.stub.php
@@ -47,12 +47,7 @@ final class ReadConcern implements \MongoDB\BSON\Serializable, \Serializable
 
     final public static function __set_state(array $properties): ReadConcern {}
 
-#if PHP_VERSION_ID >= 80000
-    final public function bsonSerialize(): array|\stdClass {}
-#else
-    /** @return array|\stdClass */
-    final public function bsonSerialize() {}
-#endif
+    final public function bsonSerialize(): \stdClass {}
 
     final public function serialize(): string {}
 

--- a/src/MongoDB/ReadConcern.stub.php
+++ b/src/MongoDB/ReadConcern.stub.php
@@ -48,9 +48,9 @@ final class ReadConcern implements \MongoDB\BSON\Serializable, \Serializable
     final public static function __set_state(array $properties): ReadConcern {}
 
 #if PHP_VERSION_ID >= 80000
-    final public function bsonSerialize(): array|object {}
+    final public function bsonSerialize(): array|\stdClass {}
 #else
-    /** @return array|object */
+    /** @return array|\stdClass */
     final public function bsonSerialize() {}
 #endif
 

--- a/src/MongoDB/ReadConcern_arginfo.h
+++ b/src/MongoDB/ReadConcern_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: cc214d2fd99e6191747053214210d07da48831a7 */
+ * Stub hash: b8616bced8b4b9fcc10eb931a081c4476ff5d134 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_ReadConcern___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, level, IS_STRING, 1, "null")
@@ -16,7 +16,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_ReadConcern_
 ZEND_END_ARG_INFO()
 
 #if PHP_VERSION_ID >= 80000
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_MongoDB_Driver_ReadConcern_bsonSerialize, 0, 0, MAY_BE_ARRAY|MAY_BE_OBJECT)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_MongoDB_Driver_ReadConcern_bsonSerialize, 0, 0, stdClass, MAY_BE_ARRAY)
 ZEND_END_ARG_INFO()
 #endif
 

--- a/src/MongoDB/ReadConcern_arginfo.h
+++ b/src/MongoDB/ReadConcern_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: b8616bced8b4b9fcc10eb931a081c4476ff5d134 */
+ * Stub hash: da6e980fbfe2102334158e3018b827e0bb0a9ec3 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_ReadConcern___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, level, IS_STRING, 1, "null")
@@ -15,15 +15,8 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_ReadConcern_
 	ZEND_ARG_TYPE_INFO(0, properties, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
-#if PHP_VERSION_ID >= 80000
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_MongoDB_Driver_ReadConcern_bsonSerialize, 0, 0, stdClass, MAY_BE_ARRAY)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_ReadConcern_bsonSerialize, 0, 0, stdClass, 0)
 ZEND_END_ARG_INFO()
-#endif
-
-#if !(PHP_VERSION_ID >= 80000)
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_ReadConcern_bsonSerialize, 0, 0, 0)
-ZEND_END_ARG_INFO()
-#endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_ReadConcern_serialize, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -52,12 +45,7 @@ static ZEND_METHOD(MongoDB_Driver_ReadConcern, __construct);
 static ZEND_METHOD(MongoDB_Driver_ReadConcern, getLevel);
 static ZEND_METHOD(MongoDB_Driver_ReadConcern, isDefault);
 static ZEND_METHOD(MongoDB_Driver_ReadConcern, __set_state);
-#if PHP_VERSION_ID >= 80000
 static ZEND_METHOD(MongoDB_Driver_ReadConcern, bsonSerialize);
-#endif
-#if !(PHP_VERSION_ID >= 80000)
-static ZEND_METHOD(MongoDB_Driver_ReadConcern, bsonSerialize);
-#endif
 static ZEND_METHOD(MongoDB_Driver_ReadConcern, serialize);
 #if PHP_VERSION_ID >= 80000
 static ZEND_METHOD(MongoDB_Driver_ReadConcern, unserialize);
@@ -74,12 +62,7 @@ static const zend_function_entry class_MongoDB_Driver_ReadConcern_methods[] = {
 	ZEND_ME(MongoDB_Driver_ReadConcern, getLevel, arginfo_class_MongoDB_Driver_ReadConcern_getLevel, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_ReadConcern, isDefault, arginfo_class_MongoDB_Driver_ReadConcern_isDefault, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_ReadConcern, __set_state, arginfo_class_MongoDB_Driver_ReadConcern___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_FINAL)
-#if PHP_VERSION_ID >= 80000
 	ZEND_ME(MongoDB_Driver_ReadConcern, bsonSerialize, arginfo_class_MongoDB_Driver_ReadConcern_bsonSerialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
-#endif
-#if !(PHP_VERSION_ID >= 80000)
-	ZEND_ME(MongoDB_Driver_ReadConcern, bsonSerialize, arginfo_class_MongoDB_Driver_ReadConcern_bsonSerialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
-#endif
 	ZEND_ME(MongoDB_Driver_ReadConcern, serialize, arginfo_class_MongoDB_Driver_ReadConcern_serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 #if PHP_VERSION_ID >= 80000
 	ZEND_ME(MongoDB_Driver_ReadConcern, unserialize, arginfo_class_MongoDB_Driver_ReadConcern_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)

--- a/src/MongoDB/ReadPreference.stub.php
+++ b/src/MongoDB/ReadPreference.stub.php
@@ -100,12 +100,7 @@ final class ReadPreference implements \MongoDB\BSON\Serializable, \Serializable
 
     final public static function __set_state(array $properties): ReadPreference {}
 
-#if PHP_VERSION_ID >= 80000
-    final public function bsonSerialize(): array|\stdClass {}
-#else
-    /** @return array|\stdClass */
-    final public function bsonSerialize() {}
-#endif
+    final public function bsonSerialize(): \stdClass {}
 
     final public function serialize(): string {}
 

--- a/src/MongoDB/ReadPreference.stub.php
+++ b/src/MongoDB/ReadPreference.stub.php
@@ -101,9 +101,9 @@ final class ReadPreference implements \MongoDB\BSON\Serializable, \Serializable
     final public static function __set_state(array $properties): ReadPreference {}
 
 #if PHP_VERSION_ID >= 80000
-    final public function bsonSerialize(): array|object {}
+    final public function bsonSerialize(): array|\stdClass {}
 #else
-    /** @return array|object */
+    /** @return array|\stdClass */
     final public function bsonSerialize() {}
 #endif
 

--- a/src/MongoDB/ReadPreference_arginfo.h
+++ b/src/MongoDB/ReadPreference_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: df8b13e252c05cbb7603dec8c1659fb88845ed73 */
+ * Stub hash: 9868e4e3be9c2df920f996b7b881c67e2d46e6ea */
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_ReadPreference___construct, 0, 0, 1)
@@ -36,7 +36,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_ReadPreferen
 ZEND_END_ARG_INFO()
 
 #if PHP_VERSION_ID >= 80000
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_MongoDB_Driver_ReadPreference_bsonSerialize, 0, 0, MAY_BE_ARRAY|MAY_BE_OBJECT)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_MongoDB_Driver_ReadPreference_bsonSerialize, 0, 0, stdClass, MAY_BE_ARRAY)
 ZEND_END_ARG_INFO()
 #endif
 

--- a/src/MongoDB/ReadPreference_arginfo.h
+++ b/src/MongoDB/ReadPreference_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 9868e4e3be9c2df920f996b7b881c67e2d46e6ea */
+ * Stub hash: 1a1a31ef5910ddfbe66ba6c350df216ffe25b5dd */
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_ReadPreference___construct, 0, 0, 1)
@@ -35,15 +35,8 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_ReadPreferen
 	ZEND_ARG_TYPE_INFO(0, properties, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
-#if PHP_VERSION_ID >= 80000
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_MongoDB_Driver_ReadPreference_bsonSerialize, 0, 0, stdClass, MAY_BE_ARRAY)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_ReadPreference_bsonSerialize, 0, 0, stdClass, 0)
 ZEND_END_ARG_INFO()
-#endif
-
-#if !(PHP_VERSION_ID >= 80000)
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_ReadPreference_bsonSerialize, 0, 0, 0)
-ZEND_END_ARG_INFO()
-#endif
 
 #define arginfo_class_MongoDB_Driver_ReadPreference_serialize arginfo_class_MongoDB_Driver_ReadPreference_getModeString
 
@@ -78,12 +71,7 @@ static ZEND_METHOD(MongoDB_Driver_ReadPreference, getMode);
 static ZEND_METHOD(MongoDB_Driver_ReadPreference, getModeString);
 static ZEND_METHOD(MongoDB_Driver_ReadPreference, getTagSets);
 static ZEND_METHOD(MongoDB_Driver_ReadPreference, __set_state);
-#if PHP_VERSION_ID >= 80000
 static ZEND_METHOD(MongoDB_Driver_ReadPreference, bsonSerialize);
-#endif
-#if !(PHP_VERSION_ID >= 80000)
-static ZEND_METHOD(MongoDB_Driver_ReadPreference, bsonSerialize);
-#endif
 static ZEND_METHOD(MongoDB_Driver_ReadPreference, serialize);
 #if PHP_VERSION_ID >= 80000
 static ZEND_METHOD(MongoDB_Driver_ReadPreference, unserialize);
@@ -108,12 +96,7 @@ static const zend_function_entry class_MongoDB_Driver_ReadPreference_methods[] =
 	ZEND_ME(MongoDB_Driver_ReadPreference, getModeString, arginfo_class_MongoDB_Driver_ReadPreference_getModeString, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_ReadPreference, getTagSets, arginfo_class_MongoDB_Driver_ReadPreference_getTagSets, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_ReadPreference, __set_state, arginfo_class_MongoDB_Driver_ReadPreference___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_FINAL)
-#if PHP_VERSION_ID >= 80000
 	ZEND_ME(MongoDB_Driver_ReadPreference, bsonSerialize, arginfo_class_MongoDB_Driver_ReadPreference_bsonSerialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
-#endif
-#if !(PHP_VERSION_ID >= 80000)
-	ZEND_ME(MongoDB_Driver_ReadPreference, bsonSerialize, arginfo_class_MongoDB_Driver_ReadPreference_bsonSerialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
-#endif
 	ZEND_ME(MongoDB_Driver_ReadPreference, serialize, arginfo_class_MongoDB_Driver_ReadPreference_serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 #if PHP_VERSION_ID >= 80000
 	ZEND_ME(MongoDB_Driver_ReadPreference, unserialize, arginfo_class_MongoDB_Driver_ReadPreference_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)

--- a/src/MongoDB/ServerApi.stub.php
+++ b/src/MongoDB/ServerApi.stub.php
@@ -16,12 +16,7 @@ final class ServerApi implements \MongoDB\BSON\Serializable, \Serializable
 
     final public static function __set_state(array $properties): ServerApi {}
 
-#if PHP_VERSION_ID >= 80000
-    final public function bsonSerialize(): array|\stdClass {}
-#else
-    /** @return array|\stdClass */
-    final public function bsonSerialize() {}
-#endif
+    final public function bsonSerialize(): \stdClass {}
 
     final public function serialize(): string {}
 

--- a/src/MongoDB/ServerApi.stub.php
+++ b/src/MongoDB/ServerApi.stub.php
@@ -17,9 +17,9 @@ final class ServerApi implements \MongoDB\BSON\Serializable, \Serializable
     final public static function __set_state(array $properties): ServerApi {}
 
 #if PHP_VERSION_ID >= 80000
-    final public function bsonSerialize(): array|object {}
+    final public function bsonSerialize(): array|\stdClass {}
 #else
-    /** @return array|object */
+    /** @return array|\stdClass */
     final public function bsonSerialize() {}
 #endif
 

--- a/src/MongoDB/ServerApi_arginfo.h
+++ b/src/MongoDB/ServerApi_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 27db2a958d63eaf3ca813416bf0756c981dd013f */
+ * Stub hash: 50ac33dea8943336b9c562a90e189036c90f1479 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_ServerApi___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, version, IS_STRING, 0)
@@ -12,7 +12,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_ServerApi___
 ZEND_END_ARG_INFO()
 
 #if PHP_VERSION_ID >= 80000
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_MongoDB_Driver_ServerApi_bsonSerialize, 0, 0, MAY_BE_ARRAY|MAY_BE_OBJECT)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_MongoDB_Driver_ServerApi_bsonSerialize, 0, 0, stdClass, MAY_BE_ARRAY)
 ZEND_END_ARG_INFO()
 #endif
 

--- a/src/MongoDB/ServerApi_arginfo.h
+++ b/src/MongoDB/ServerApi_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 50ac33dea8943336b9c562a90e189036c90f1479 */
+ * Stub hash: 7678bfacdb398a3528feb4226a5ca1b8a21b9516 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_ServerApi___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, version, IS_STRING, 0)
@@ -11,15 +11,8 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_ServerApi___
 	ZEND_ARG_TYPE_INFO(0, properties, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
-#if PHP_VERSION_ID >= 80000
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_MongoDB_Driver_ServerApi_bsonSerialize, 0, 0, stdClass, MAY_BE_ARRAY)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_ServerApi_bsonSerialize, 0, 0, stdClass, 0)
 ZEND_END_ARG_INFO()
-#endif
-
-#if !(PHP_VERSION_ID >= 80000)
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_ServerApi_bsonSerialize, 0, 0, 0)
-ZEND_END_ARG_INFO()
-#endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_ServerApi_serialize, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -46,12 +39,7 @@ ZEND_END_ARG_INFO()
 
 static ZEND_METHOD(MongoDB_Driver_ServerApi, __construct);
 static ZEND_METHOD(MongoDB_Driver_ServerApi, __set_state);
-#if PHP_VERSION_ID >= 80000
 static ZEND_METHOD(MongoDB_Driver_ServerApi, bsonSerialize);
-#endif
-#if !(PHP_VERSION_ID >= 80000)
-static ZEND_METHOD(MongoDB_Driver_ServerApi, bsonSerialize);
-#endif
 static ZEND_METHOD(MongoDB_Driver_ServerApi, serialize);
 #if PHP_VERSION_ID >= 80000
 static ZEND_METHOD(MongoDB_Driver_ServerApi, unserialize);
@@ -66,12 +54,7 @@ static ZEND_METHOD(MongoDB_Driver_ServerApi, __serialize);
 static const zend_function_entry class_MongoDB_Driver_ServerApi_methods[] = {
 	ZEND_ME(MongoDB_Driver_ServerApi, __construct, arginfo_class_MongoDB_Driver_ServerApi___construct, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_ServerApi, __set_state, arginfo_class_MongoDB_Driver_ServerApi___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_FINAL)
-#if PHP_VERSION_ID >= 80000
 	ZEND_ME(MongoDB_Driver_ServerApi, bsonSerialize, arginfo_class_MongoDB_Driver_ServerApi_bsonSerialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
-#endif
-#if !(PHP_VERSION_ID >= 80000)
-	ZEND_ME(MongoDB_Driver_ServerApi, bsonSerialize, arginfo_class_MongoDB_Driver_ServerApi_bsonSerialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
-#endif
 	ZEND_ME(MongoDB_Driver_ServerApi, serialize, arginfo_class_MongoDB_Driver_ServerApi_serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 #if PHP_VERSION_ID >= 80000
 	ZEND_ME(MongoDB_Driver_ServerApi, unserialize, arginfo_class_MongoDB_Driver_ServerApi_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)

--- a/src/MongoDB/WriteConcern.stub.php
+++ b/src/MongoDB/WriteConcern.stub.php
@@ -37,12 +37,7 @@ final class WriteConcern implements \MongoDB\BSON\Serializable, \Serializable
 
     final public static function __set_state(array $properties): WriteConcern {}
 
-#if PHP_VERSION_ID >= 80000
-    final public function bsonSerialize(): array|\stdClass {}
-#else
-    /** @return array|\stdClass */
-    final public function bsonSerialize() {}
-#endif
+    final public function bsonSerialize(): \stdClass {}
 
     final public function serialize(): string {}
 

--- a/src/MongoDB/WriteConcern.stub.php
+++ b/src/MongoDB/WriteConcern.stub.php
@@ -38,9 +38,9 @@ final class WriteConcern implements \MongoDB\BSON\Serializable, \Serializable
     final public static function __set_state(array $properties): WriteConcern {}
 
 #if PHP_VERSION_ID >= 80000
-    final public function bsonSerialize(): array|object {}
+    final public function bsonSerialize(): array|\stdClass {}
 #else
-    /** @return array|object */
+    /** @return array|\stdClass */
     final public function bsonSerialize() {}
 #endif
 

--- a/src/MongoDB/WriteConcern_arginfo.h
+++ b/src/MongoDB/WriteConcern_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: bc052f233ec885eb7209a77d32fd9290a2a101e3 */
+ * Stub hash: 690913f0505161b1b2ca35495c4cdb06c263aacb */
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_WriteConcern___construct, 0, 0, 1)
@@ -40,14 +40,8 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_WriteConcern
 	ZEND_ARG_TYPE_INFO(0, properties, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
-#if PHP_VERSION_ID >= 80000
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_MongoDB_Driver_WriteConcern_bsonSerialize, 0, 0, stdClass, MAY_BE_ARRAY)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_WriteConcern_bsonSerialize, 0, 0, stdClass, 0)
 ZEND_END_ARG_INFO()
-#endif
-
-#if !(PHP_VERSION_ID >= 80000)
-#define arginfo_class_MongoDB_Driver_WriteConcern_bsonSerialize arginfo_class_MongoDB_Driver_WriteConcern_getW
-#endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_WriteConcern_serialize, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -88,12 +82,7 @@ static ZEND_METHOD(MongoDB_Driver_WriteConcern, getW);
 static ZEND_METHOD(MongoDB_Driver_WriteConcern, getWtimeout);
 static ZEND_METHOD(MongoDB_Driver_WriteConcern, isDefault);
 static ZEND_METHOD(MongoDB_Driver_WriteConcern, __set_state);
-#if PHP_VERSION_ID >= 80000
 static ZEND_METHOD(MongoDB_Driver_WriteConcern, bsonSerialize);
-#endif
-#if !(PHP_VERSION_ID >= 80000)
-static ZEND_METHOD(MongoDB_Driver_WriteConcern, bsonSerialize);
-#endif
 static ZEND_METHOD(MongoDB_Driver_WriteConcern, serialize);
 #if PHP_VERSION_ID >= 80000
 static ZEND_METHOD(MongoDB_Driver_WriteConcern, unserialize);
@@ -122,12 +111,7 @@ static const zend_function_entry class_MongoDB_Driver_WriteConcern_methods[] = {
 	ZEND_ME(MongoDB_Driver_WriteConcern, getWtimeout, arginfo_class_MongoDB_Driver_WriteConcern_getWtimeout, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_WriteConcern, isDefault, arginfo_class_MongoDB_Driver_WriteConcern_isDefault, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_WriteConcern, __set_state, arginfo_class_MongoDB_Driver_WriteConcern___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_FINAL)
-#if PHP_VERSION_ID >= 80000
 	ZEND_ME(MongoDB_Driver_WriteConcern, bsonSerialize, arginfo_class_MongoDB_Driver_WriteConcern_bsonSerialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
-#endif
-#if !(PHP_VERSION_ID >= 80000)
-	ZEND_ME(MongoDB_Driver_WriteConcern, bsonSerialize, arginfo_class_MongoDB_Driver_WriteConcern_bsonSerialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
-#endif
 	ZEND_ME(MongoDB_Driver_WriteConcern, serialize, arginfo_class_MongoDB_Driver_WriteConcern_serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 #if PHP_VERSION_ID >= 80000
 	ZEND_ME(MongoDB_Driver_WriteConcern, unserialize, arginfo_class_MongoDB_Driver_WriteConcern_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)

--- a/src/MongoDB/WriteConcern_arginfo.h
+++ b/src/MongoDB/WriteConcern_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 071d716b692ad1d3abdaf61bc96e9671f64f71e1 */
+ * Stub hash: bc052f233ec885eb7209a77d32fd9290a2a101e3 */
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_WriteConcern___construct, 0, 0, 1)
@@ -41,7 +41,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_WriteConcern
 ZEND_END_ARG_INFO()
 
 #if PHP_VERSION_ID >= 80000
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_MongoDB_Driver_WriteConcern_bsonSerialize, 0, 0, MAY_BE_ARRAY|MAY_BE_OBJECT)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_MongoDB_Driver_WriteConcern_bsonSerialize, 0, 0, stdClass, MAY_BE_ARRAY)
 ZEND_END_ARG_INFO()
 #endif
 

--- a/src/phongo_bson_encode.c
+++ b/src/phongo_bson_encode.c
@@ -104,14 +104,16 @@ static void php_phongo_bson_append_object(bson_t* bson, php_phongo_field_path* f
 	}
 
 	if (Z_TYPE_P(object) == IS_OBJECT && instanceof_function(Z_OBJCE_P(object), php_phongo_type_ce)) {
-		if (Z_TYPE_P(object) == IS_OBJECT && (instanceof_function(Z_OBJCE_P(object), php_phongo_document_ce) || instanceof_function(Z_OBJCE_P(object), php_phongo_packedarray_ce))) {
-			if (instanceof_function(Z_OBJCE_P(object), php_phongo_document_ce)) {
-				php_phongo_document_t* intern = Z_DOCUMENT_OBJ_P(object);
-				bson_append_document(bson, key, key_len, intern->bson);
-			} else {
-				php_phongo_packedarray_t* intern = Z_PACKEDARRAY_OBJ_P(object);
-				bson_append_array(bson, key, key_len, intern->bson);
-			}
+		if (instanceof_function(Z_OBJCE_P(object), php_phongo_document_ce)) {
+			php_phongo_document_t* intern = Z_DOCUMENT_OBJ_P(object);
+			bson_append_document(bson, key, key_len, intern->bson);
+
+			return;
+		}
+
+		if (instanceof_function(Z_OBJCE_P(object), php_phongo_packedarray_ce)) {
+			php_phongo_packedarray_t* intern = Z_PACKEDARRAY_OBJ_P(object);
+			bson_append_array(bson, key, key_len, intern->bson);
 
 			return;
 		}

--- a/src/phongo_bson_encode.c
+++ b/src/phongo_bson_encode.c
@@ -131,6 +131,7 @@ static void php_phongo_bson_append_object(bson_t* bson, php_phongo_field_path* f
 				return;
 			}
 
+			// TODO PHP_VERSION_ID < 80000: obsolete once the tentative return type of bsonSerialize() is enforced
 			if (
 				Z_TYPE(obj_data) != IS_ARRAY && !(Z_TYPE(obj_data) == IS_OBJECT && (instanceof_function(Z_OBJCE(obj_data), zend_standard_class_def) || instanceof_function(Z_OBJCE(obj_data), php_phongo_document_ce) || instanceof_function(Z_OBJCE(obj_data), php_phongo_packedarray_ce)))) {
 				phongo_throw_exception(PHONGO_ERROR_UNEXPECTED_VALUE,

--- a/src/phongo_bson_encode.c
+++ b/src/phongo_bson_encode.c
@@ -103,19 +103,19 @@ static void php_phongo_bson_append_object(bson_t* bson, php_phongo_field_path* f
 		return;
 	}
 
-	if (Z_TYPE_P(object) == IS_OBJECT && (instanceof_function(Z_OBJCE_P(object), php_phongo_document_ce) || instanceof_function(Z_OBJCE_P(object), php_phongo_packedarray_ce))) {
-		if (instanceof_function(Z_OBJCE_P(object), php_phongo_document_ce)) {
-			php_phongo_document_t* intern = Z_DOCUMENT_OBJ_P(object);
-			bson_append_document(bson, key, key_len, intern->bson);
-		} else {
-			php_phongo_packedarray_t* intern = Z_PACKEDARRAY_OBJ_P(object);
-			bson_append_array(bson, key, key_len, intern->bson);
+	if (Z_TYPE_P(object) == IS_OBJECT && instanceof_function(Z_OBJCE_P(object), php_phongo_type_ce)) {
+		if (Z_TYPE_P(object) == IS_OBJECT && (instanceof_function(Z_OBJCE_P(object), php_phongo_document_ce) || instanceof_function(Z_OBJCE_P(object), php_phongo_packedarray_ce))) {
+			if (instanceof_function(Z_OBJCE_P(object), php_phongo_document_ce)) {
+				php_phongo_document_t* intern = Z_DOCUMENT_OBJ_P(object);
+				bson_append_document(bson, key, key_len, intern->bson);
+			} else {
+				php_phongo_packedarray_t* intern = Z_PACKEDARRAY_OBJ_P(object);
+				bson_append_array(bson, key, key_len, intern->bson);
+			}
+
+			return;
 		}
 
-		return;
-	}
-
-	if (Z_TYPE_P(object) == IS_OBJECT && instanceof_function(Z_OBJCE_P(object), php_phongo_type_ce)) {
 		if (instanceof_function(Z_OBJCE_P(object), php_phongo_serializable_ce)) {
 			zval   obj_data;
 			bson_t child;

--- a/src/phongo_compat.h
+++ b/src/phongo_compat.h
@@ -285,15 +285,6 @@ static inline zend_bool zend_ini_parse_bool(zend_string* str)
 	Z_PARAM_ARRAY_OR_OBJECT(dest)
 #endif
 
-/* Per https://wiki.php.net/rfc/internal_method_return_types, "Non-final
- * internal method return types - when possible - are declared tentatively in
- * PHP 8.1, and they will become enforced in PHP 9.0." This can be revisited
- * when more general typing improvements are made in PHPC-1709. */
-#ifndef ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX
-#define ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(name, return_reference, required_num_args, type, allow_null) \
-	ZEND_BEGIN_ARG_INFO_EX(name, 0, return_reference, required_num_args)
-#endif
-
 /* ZEND_ABSTRACT_ME_WITH_FLAGS was introduced in PHP 8.0. */
 #ifndef ZEND_ABSTRACT_ME_WITH_FLAGS
 #define ZEND_ABSTRACT_ME_WITH_FLAGS(classname, name, arg_info, flags) ZEND_RAW_FENTRY(#name, NULL, arg_info, flags)
@@ -322,14 +313,20 @@ static inline zend_bool zend_ini_parse_bool(zend_string* str)
 #define ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(name, return_reference, required_num_args, type, allow_null) \
 	ZEND_BEGIN_ARG_INFO_EX(name, 0, return_reference, required_num_args)
 #endif
-
+#ifndef ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX
+#define ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(name, return_reference, required_num_args, type, allow_null) \
+	ZEND_BEGIN_ARG_INFO_EX(name, 0, return_reference, required_num_args)
+#endif
 #ifndef ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_MASK_EX
 #define ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_MASK_EX(name, return_reference, required_num_args, type) \
 	ZEND_BEGIN_ARG_INFO_EX(name, 0, return_reference, required_num_args)
 #endif
-
 #ifndef ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX
 #define ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(name, return_reference, required_num_args, class_name, allow_null) \
+	ZEND_BEGIN_ARG_INFO_EX(name, 0, return_reference, required_num_args)
+#endif
+#ifndef ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_TYPE_MASK_EX
+#define ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_TYPE_MASK_EX(name, return_reference, required_num_args, class_name, type) \
 	ZEND_BEGIN_ARG_INFO_EX(name, 0, return_reference, required_num_args)
 #endif
 

--- a/tests/bson/bson-document-fromPHP-003.phpt
+++ b/tests/bson/bson-document-fromPHP-003.phpt
@@ -10,7 +10,7 @@ class MyDocument implements MongoDB\BSON\Persistable {
     protected $bar = 2;
     public $baz = 3;
 
-    public function bsonSerialize(): object
+    public function bsonSerialize(): stdClass
     {
         return (object) [
             'foo' => $this->foo,

--- a/tests/bson/bson-fromPHP-001.phpt
+++ b/tests/bson/bson-fromPHP-001.phpt
@@ -1,5 +1,5 @@
 --TEST--
-MongoDB\BSON\fromPHP(): bsonSerialize() allows array and stdClass
+MongoDB\BSON\fromPHP(): bsonSerialize() allows arrays, stdClass instances, BSON arrays, and BSON documents
 --FILE--
 <?php
 
@@ -21,11 +21,21 @@ class MyDocument implements MongoDB\BSON\Serializable
     }
 }
 
+class MyPersistableDocument extends MyDocument implements MongoDB\BSON\Persistable
+{
+    public function bsonUnserialize(array $data): void
+    {
+        $this->data = $data;
+    }
+}
+
 $tests = array(
     array(1, 2, 3),
     array('foo' => 'bar'),
     (object) array(1, 2, 3),
     (object) array('foo' => 'bar'),
+    MongoDB\BSON\PackedArray::fromPHP([1, 2, 3]),
+    MongoDB\BSON\Document::fromPHP(['foo' => 'bar']),
 );
 
 echo "Testing top-level objects\n";
@@ -33,6 +43,7 @@ echo "Testing top-level objects\n";
 foreach ($tests as $test) {
     try {
         echo toJson(fromPHP(new MyDocument($test))), "\n";
+        echo toJson(fromPHP(new MyPersistableDocument($test))), "\n";
     } catch (MongoDB\Driver\Exception\UnexpectedValueException $e) {
         echo $e->getMessage(), "\n";
     }
@@ -43,6 +54,7 @@ echo "\nTesting nested objects\n";
 foreach ($tests as $test) {
     try {
         echo toJson(fromPHP(new MyDocument(array('nested' => new MyDocument($test))))), "\n";
+        echo toJson(fromPHP(new MyDocument(array('nested' => new MyPersistableDocument($test))))), "\n";
     } catch (MongoDB\Driver\Exception\UnexpectedValueException $e) {
         echo $e->getMessage(), "\n";
     }
@@ -54,13 +66,29 @@ foreach ($tests as $test) {
 --EXPECT--
 Testing top-level objects
 { "0" : 1, "1" : 2, "2" : 3 }
+{ "__pclass" : { "$binary" : "TXlQZXJzaXN0YWJsZURvY3VtZW50", "$type" : "80" }, "0" : 1, "1" : 2, "2" : 3 }
 { "foo" : "bar" }
+{ "__pclass" : { "$binary" : "TXlQZXJzaXN0YWJsZURvY3VtZW50", "$type" : "80" }, "foo" : "bar" }
 { "0" : 1, "1" : 2, "2" : 3 }
+{ "__pclass" : { "$binary" : "TXlQZXJzaXN0YWJsZURvY3VtZW50", "$type" : "80" }, "0" : 1, "1" : 2, "2" : 3 }
 { "foo" : "bar" }
+{ "__pclass" : { "$binary" : "TXlQZXJzaXN0YWJsZURvY3VtZW50", "$type" : "80" }, "foo" : "bar" }
+{ "0" : 1, "1" : 2, "2" : 3 }
+{ "__pclass" : { "$binary" : "TXlQZXJzaXN0YWJsZURvY3VtZW50", "$type" : "80" }, "0" : 1, "1" : 2, "2" : 3 }
+{ "foo" : "bar" }
+{ "__pclass" : { "$binary" : "TXlQZXJzaXN0YWJsZURvY3VtZW50", "$type" : "80" }, "foo" : "bar" }
 
 Testing nested objects
 { "nested" : [ 1, 2, 3 ] }
+{ "nested" : { "__pclass" : { "$binary" : "TXlQZXJzaXN0YWJsZURvY3VtZW50", "$type" : "80" }, "0" : 1, "1" : 2, "2" : 3 } }
 { "nested" : { "foo" : "bar" } }
+{ "nested" : { "__pclass" : { "$binary" : "TXlQZXJzaXN0YWJsZURvY3VtZW50", "$type" : "80" }, "foo" : "bar" } }
 { "nested" : { "0" : 1, "1" : 2, "2" : 3 } }
+{ "nested" : { "__pclass" : { "$binary" : "TXlQZXJzaXN0YWJsZURvY3VtZW50", "$type" : "80" }, "0" : 1, "1" : 2, "2" : 3 } }
 { "nested" : { "foo" : "bar" } }
+{ "nested" : { "__pclass" : { "$binary" : "TXlQZXJzaXN0YWJsZURvY3VtZW50", "$type" : "80" }, "foo" : "bar" } }
+{ "nested" : [ 1, 2, 3 ] }
+{ "nested" : { "__pclass" : { "$binary" : "TXlQZXJzaXN0YWJsZURvY3VtZW50", "$type" : "80" }, "0" : 1, "1" : 2, "2" : 3 } }
+{ "nested" : { "foo" : "bar" } }
+{ "nested" : { "__pclass" : { "$binary" : "TXlQZXJzaXN0YWJsZURvY3VtZW50", "$type" : "80" }, "foo" : "bar" } }
 ===DONE===

--- a/tests/bson/bson-fromPHP-001.phpt
+++ b/tests/bson/bson-fromPHP-001.phpt
@@ -34,6 +34,7 @@ $tests = array(
     array('foo' => 'bar'),
     (object) array(1, 2, 3),
     (object) array('foo' => 'bar'),
+    # The PackedArray check will fail for instances of Persistable
     MongoDB\BSON\PackedArray::fromPHP([1, 2, 3]),
     MongoDB\BSON\Document::fromPHP(['foo' => 'bar']),
 );
@@ -74,7 +75,7 @@ Testing top-level objects
 { "foo" : "bar" }
 { "__pclass" : { "$binary" : "TXlQZXJzaXN0YWJsZURvY3VtZW50", "$type" : "80" }, "foo" : "bar" }
 { "0" : 1, "1" : 2, "2" : 3 }
-{ "__pclass" : { "$binary" : "TXlQZXJzaXN0YWJsZURvY3VtZW50", "$type" : "80" }, "0" : 1, "1" : 2, "2" : 3 }
+Expected MyPersistableDocument::bsonSerialize() to return an array, stdClass, or MongoDB\BSON\Document, MongoDB\BSON\PackedArray given
 { "foo" : "bar" }
 { "__pclass" : { "$binary" : "TXlQZXJzaXN0YWJsZURvY3VtZW50", "$type" : "80" }, "foo" : "bar" }
 
@@ -88,7 +89,7 @@ Testing nested objects
 { "nested" : { "foo" : "bar" } }
 { "nested" : { "__pclass" : { "$binary" : "TXlQZXJzaXN0YWJsZURvY3VtZW50", "$type" : "80" }, "foo" : "bar" } }
 { "nested" : [ 1, 2, 3 ] }
-{ "nested" : { "__pclass" : { "$binary" : "TXlQZXJzaXN0YWJsZURvY3VtZW50", "$type" : "80" }, "0" : 1, "1" : 2, "2" : 3 } }
+Expected MyPersistableDocument::bsonSerialize() to return an array, stdClass, or MongoDB\BSON\Document, MongoDB\BSON\PackedArray given
 { "nested" : { "foo" : "bar" } }
 { "nested" : { "__pclass" : { "$binary" : "TXlQZXJzaXN0YWJsZURvY3VtZW50", "$type" : "80" }, "foo" : "bar" } }
 ===DONE===

--- a/tests/bson/bson-fromPHP_error-001.phpt
+++ b/tests/bson/bson-fromPHP_error-001.phpt
@@ -48,16 +48,16 @@ foreach ($invalidValues as $invalidValue) {
 <?php exit(0); ?>
 --EXPECTF--
 Testing top-level objects
-Expected MyDocument::bsonSerialize() to return an array or stdClass, %r(null|NULL)%r given
-Expected MyDocument::bsonSerialize() to return an array or stdClass, int%S given
-Expected MyDocument::bsonSerialize() to return an array or stdClass, string given
-Expected MyDocument::bsonSerialize() to return an array or stdClass, bool%S given
-Expected MyDocument::bsonSerialize() to return an array or stdClass, MyDocument given
+Expected MyDocument::bsonSerialize() to return an array, stdClass, MongoDB\BSON\Document, or MongoDB\BSON\PackedArray, %r(null|NULL)%r given
+Expected MyDocument::bsonSerialize() to return an array, stdClass, MongoDB\BSON\Document, or MongoDB\BSON\PackedArray, int%S given
+Expected MyDocument::bsonSerialize() to return an array, stdClass, MongoDB\BSON\Document, or MongoDB\BSON\PackedArray, string given
+Expected MyDocument::bsonSerialize() to return an array, stdClass, MongoDB\BSON\Document, or MongoDB\BSON\PackedArray, bool%S given
+Expected MyDocument::bsonSerialize() to return an array, stdClass, MongoDB\BSON\Document, or MongoDB\BSON\PackedArray, MyDocument given
 
 Testing nested objects
-Expected MyDocument::bsonSerialize() to return an array or stdClass, %r(null|NULL)%r given
-Expected MyDocument::bsonSerialize() to return an array or stdClass, int%S given
-Expected MyDocument::bsonSerialize() to return an array or stdClass, string given
-Expected MyDocument::bsonSerialize() to return an array or stdClass, bool%S given
-Expected MyDocument::bsonSerialize() to return an array or stdClass, MyDocument given
+Expected MyDocument::bsonSerialize() to return an array, stdClass, MongoDB\BSON\Document, or MongoDB\BSON\PackedArray, %r(null|NULL)%r given
+Expected MyDocument::bsonSerialize() to return an array, stdClass, MongoDB\BSON\Document, or MongoDB\BSON\PackedArray, int%S given
+Expected MyDocument::bsonSerialize() to return an array, stdClass, MongoDB\BSON\Document, or MongoDB\BSON\PackedArray, string given
+Expected MyDocument::bsonSerialize() to return an array, stdClass, MongoDB\BSON\Document, or MongoDB\BSON\PackedArray, bool%S given
+Expected MyDocument::bsonSerialize() to return an array, stdClass, MongoDB\BSON\Document, or MongoDB\BSON\PackedArray, MyDocument given
 ===DONE===

--- a/tests/bson/bson-fromPHP_error-005.phpt
+++ b/tests/bson/bson-fromPHP_error-005.phpt
@@ -43,7 +43,7 @@ echo throws(function() {
 --EXPECT--
 Testing Serializable with direct circular reference
 OK: Got MongoDB\Driver\Exception\UnexpectedValueException
-Expected MyRecursiveSerializable::bsonSerialize() to return an array or stdClass, MyRecursiveSerializable given
+Expected MyRecursiveSerializable::bsonSerialize() to return an array, stdClass, MongoDB\BSON\Document, or MongoDB\BSON\PackedArray, MyRecursiveSerializable given
 
 Testing Serializable with indirect circular reference
 OK: Got MongoDB\Driver\Exception\UnexpectedValueException


### PR DESCRIPTION
PHPC-1000

This PR allows implementations of `MongoDB\BSON\Serializable` to return instances of `MongoDB\BSON\Document` and `MongoDB\BSON\PackedArray`. This allows for an easier implementation of the `Serializable` in PHPLIB classes.

The first commit fixes the tentative return type for `Serializable::bsonSerialize`: while the original type was `array|object`, the code actually rejected any object that was not an instance of `stdClass`. I've also tested the impact on this change: on PHP < 8.1 there is no change as tentative return types are only reported in PHP 8.1+. In those versions, users that have a wider return type (e.g. the original `array|object` type or `object` in general), will see a deprecation message that the return types should be compatible. There is no hard break until we make the type non-tentative in PHPC 2.0, so I thought I'd preempt this and fix the return type. This then allows us to specify a return type of `array|stdClass|Document|PackedArray` in the last commit, which once again is consistent with the values the serializer accepts as return value.