### PR TITLE
PHPC-2269: Add internal iterator logic for MongoDB\BSON\Iterator

### DIFF
--- a/src/BSON/Iterator.c
+++ b/src/BSON/Iterator.c
@@ -358,7 +358,7 @@ static const zend_object_iterator_funcs php_phongo_iterator_it_funcs = PHONGO_IT
 	php_phongo_iterator_it_get_current_key,
 	php_phongo_iterator_it_move_forward,
 	php_phongo_iterator_it_rewind,
-	NULL,
+	NULL, /* invalidate_current */
 	php_phongo_iterator_it_get_gc);
 
 static zend_object_iterator* php_phongo_iterator_get_iterator(zend_class_entry* ce, zval* object, int by_ref)

--- a/src/BSON/Iterator.c
+++ b/src/BSON/Iterator.c
@@ -342,14 +342,16 @@ static void php_phongo_iterator_it_rewind(zend_object_iterator* iter)
 	php_phongo_iterator_rewind(intern);
 }
 
+#if PHP_VERSION_ID >= 80000
 static HashTable* php_phongo_iterator_it_get_gc(zend_object_iterator* iter, zval** table, int* n)
 {
 	*n     = 1;
 	*table = &iter->data;
 	return NULL;
 }
+#endif
 
-static const zend_object_iterator_funcs php_phongo_iterator_it_funcs = {
+static const zend_object_iterator_funcs php_phongo_iterator_it_funcs = PHONGO_ITERATOR_FUNCS(
 	php_phongo_iterator_it_dtor,
 	php_phongo_iterator_it_valid,
 	php_phongo_iterator_it_get_current_data,
@@ -357,8 +359,7 @@ static const zend_object_iterator_funcs php_phongo_iterator_it_funcs = {
 	php_phongo_iterator_it_move_forward,
 	php_phongo_iterator_it_rewind,
 	NULL,
-	php_phongo_iterator_it_get_gc,
-};
+	php_phongo_iterator_it_get_gc);
 
 static zend_object_iterator* php_phongo_iterator_get_iterator(zend_class_entry* ce, zval* object, int by_ref)
 {

--- a/src/phongo_compat.h
+++ b/src/phongo_compat.h
@@ -303,4 +303,42 @@ zend_bool zend_array_is_list(zend_array* array);
 typedef ZEND_RESULT_CODE zend_result;
 #endif
 
+/* get_gc iterator handler was added in PHP 8.0 */
+#if PHP_VERSION_ID >= 80000
+#define PHONGO_ITERATOR_FUNCS(dtor, valid, get_current_data, get_current_key, move_forward, rewind, invalidate_current, get_gc) \
+	{                                                                                                                           \
+		(dtor),                                                                                                                 \
+			(valid),                                                                                                            \
+			(get_current_data),                                                                                                 \
+			(get_current_key),                                                                                                  \
+			(move_forward),                                                                                                     \
+			(rewind),                                                                                                           \
+			(invalidate_current),                                                                                               \
+			(get_gc),                                                                                                           \
+	}
+#else
+#define PHONGO_ITERATOR_FUNCS(dtor, valid, get_current_data, get_current_key, move_forward, rewind, invalidate_current, get_gc) \
+	{                                                                                                                           \
+		(dtor),                                                                                                                 \
+			(valid),                                                                                                            \
+			(get_current_data),                                                                                                 \
+			(get_current_key),                                                                                                  \
+			(move_forward),                                                                                                     \
+			(rewind),                                                                                                           \
+			(invalidate_current),                                                                                               \
+	}
+#endif
+
+/* ZVAL_OBJ_COPY was added in PHP 8.0 */
+#ifndef ZVAL_OBJ_COPY
+#define ZVAL_OBJ_COPY(z, o)                \
+	do {                                   \
+		zval*        __z = (z);            \
+		zend_object* __o = (o);            \
+		GC_ADDREF(__o);                    \
+		Z_OBJ_P(__z)       = __o;          \
+		Z_TYPE_INFO_P(__z) = IS_OBJECT_EX; \
+	} while (0)
+#endif
+
 #endif /* PHONGO_COMPAT_H */

--- a/src/phongo_compat.h
+++ b/src/phongo_compat.h
@@ -316,7 +316,7 @@ typedef ZEND_RESULT_CODE zend_result;
 			(invalidate_current),                                                                                               \
 			(get_gc),                                                                                                           \
 	}
-#else
+#else /* PHP_VERSION_ID < 80000 */
 #define PHONGO_ITERATOR_FUNCS(dtor, valid, get_current_data, get_current_key, move_forward, rewind, invalidate_current, get_gc) \
 	{                                                                                                                           \
 		(dtor),                                                                                                                 \
@@ -327,7 +327,7 @@ typedef ZEND_RESULT_CODE zend_result;
 			(rewind),                                                                                                           \
 			(invalidate_current),                                                                                               \
 	}
-#endif
+#endif /* PHP_VERSION_ID >= 80000 */
 
 /* ZVAL_OBJ_COPY was added in PHP 8.0 */
 #ifndef ZVAL_OBJ_COPY


### PR DESCRIPTION
PHPC-2269

Adding to v1.17 only as we'd be backporting a number of compat macros from PHP itself, in addition to `ZVAL_OBJ_COPY`. Waiting on #1450 to be merged so I don't have to bother fixing the PHP 7.2 build.