### PR TITLE
PHPC-2230: Require PHP 7.4 in package.xml template

### DIFF
--- a/bin/package.xml.in
+++ b/bin/package.xml.in
@@ -58,7 +58,7 @@ necessary to build a fully-functional MongoDB driver.
  <dependencies>
   <required>
    <php>
-    <min>7.2.0</min>
+    <min>7.4.0</min>
     <max>8.99.99</max>
    </php>
    <pearinstaller>


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-2230

This was omitted in 2ab1e4ba2e6b3126e7acbd7025f3a2727aaa48d2