### PR TITLE
PHPC-2280: Prefer OpenSSL on MacOS over Secure Transport

### DIFF
--- a/scripts/autotools/libmongoc/CheckSSL.m4
+++ b/scripts/autotools/libmongoc/CheckSSL.m4
@@ -18,22 +18,6 @@ AS_IF([test "$PHP_MONGODB_SSL" = "yes"],[
   PHP_MONGODB_SSL="auto"
 ])
 
-AS_IF([test "$PHP_MONGODB_SSL" = "darwin" -o \( "$PHP_MONGODB_SSL" = "auto" -a "$os_darwin" = "yes" \)],[
-  AC_MSG_NOTICE([checking whether Darwin SSL is available])
-
-  if test "$os_darwin" = "no"; then
-    AC_MSG_ERROR([Darwin SSL is only supported on macOS])
-  fi
-  dnl PHP_FRAMEWORKS is only used for SAPI builds, so use MONGODB_SHARED_LIBADD for shared builds
-  if test "$ext_shared" = "yes"; then
-    MONGODB_SHARED_LIBADD="-framework Security -framework CoreFoundation $MONGODB_SHARED_LIBADD"
-  else
-    PHP_ADD_FRAMEWORK([Security])
-    PHP_ADD_FRAMEWORK([CoreFoundation])
-  fi
-  PHP_MONGODB_SSL="darwin"
-])
-
 AS_IF([test "$PHP_MONGODB_SSL" = "openssl" -o "$PHP_MONGODB_SSL" = "auto"],[
   AC_MSG_NOTICE([checking whether OpenSSL is available])
   found_openssl="no"
@@ -130,6 +114,22 @@ AS_IF([test "$PHP_MONGODB_SSL" = "openssl" -o "$PHP_MONGODB_SSL" = "auto"],[
   if test "$PHP_MONGODB_SSL" = "openssl" -a "$found_openssl" != "yes"; then
     AC_MSG_ERROR([OpenSSL libraries and development headers could not be found])
   fi
+])
+
+AS_IF([test "$PHP_MONGODB_SSL" = "darwin" -o \( "$PHP_MONGODB_SSL" = "auto" -a "$os_darwin" = "yes" \)],[
+  AC_MSG_NOTICE([checking whether Darwin SSL is available])
+
+  if test "$os_darwin" = "no"; then
+    AC_MSG_ERROR([Darwin SSL is only supported on macOS])
+  fi
+  dnl PHP_FRAMEWORKS is only used for SAPI builds, so use MONGODB_SHARED_LIBADD for shared builds
+  if test "$ext_shared" = "yes"; then
+    MONGODB_SHARED_LIBADD="-framework Security -framework CoreFoundation $MONGODB_SHARED_LIBADD"
+  else
+    PHP_ADD_FRAMEWORK([Security])
+    PHP_ADD_FRAMEWORK([CoreFoundation])
+  fi
+  PHP_MONGODB_SSL="darwin"
 ])
 
 AS_IF([test "$PHP_MONGODB_SSL" = "libressl" -o "$PHP_MONGODB_SSL" = "auto"],[


### PR DESCRIPTION
PHPC-2280

On MacOS, the driver is compiled using Secure Transport when the `--with-mongodb-ssl` switch is set to `auto`. While this works fine in a CLI context it causes segmentation faults when using the driver in php-fpm, which usually is compiled using OpenSSL. To work around this issue, we now prefer OpenSSL on all platforms, and only check for Secure Transport on MacOS if no OpenSSL installation was found. To continue using Secure Transport on MacOS, users should specify `--with-mongodb-ssl=darwin`.