### PR TITLE
PHPLIB-2284: Force regeneration of arginfo files in workflow

### DIFF
--- a/.github/workflows/arginfo-files.yml
+++ b/.github/workflows/arginfo-files.yml
@@ -38,7 +38,7 @@ jobs:
         run: phpize
 
       - name: "Rebuild arginfo files from stubs"
-        run: "php ./build/gen_stub.php"
+        run: "php ./build/gen_stub.php --force-regeneration"
 
       - name: "Check arginfo file diff"
         run: git add . -N && git diff --exit-code


### PR DESCRIPTION
PHPLIB-2284

With this change, arginfo files will be regenerated using the latest version of the script. This helps identify changes to arginfo files as a result of the generation script changing, even when the underlying stub file hasn't changed.