### PR TITLE
PHPC-2287: Require PHP 8.1.8+ for -Wstrict-prototypes dev flag

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -80,7 +80,10 @@ if test "$PHP_MONGODB" != "no"; then
     AX_CHECK_COMPILE_FLAG(-Wno-unused-parameter,            _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wno-unused-parameter"          ,, -Werror)
     AX_CHECK_COMPILE_FLAG(-Wno-unused-but-set-variable,     _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wno-unused-but-set-variable"   ,, -Werror)
     AX_CHECK_COMPILE_FLAG(-Wno-missing-field-initializers,  _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wno-missing-field-initializers",, -Werror)
-    AX_CHECK_COMPILE_FLAG(-Wstrict-prototypes,              _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wstrict-prototypes"            ,, -Werror)
+
+    if test "$PHP_MONGODB_PHP_VERSION_ID" -ge "80108"; then
+      AX_CHECK_COMPILE_FLAG(-Wstrict-prototypes, _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wstrict-prototypes",, -Werror)
+    fi
 
     MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS"
     STD_CFLAGS="-g -O0 -Wall"


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-2287

This dev flag was originally introduced in b83ab98376c81c49c62098fc39af6b05be3c89ff, but did not account for conflicts within headers of earlier PHP versions.