### PR TITLE
PHPC-2245, PHPC-2246: Add array and property accessors to BSON types

### DIFF
--- a/src/BSON/Document.c
+++ b/src/BSON/Document.c
@@ -170,7 +170,7 @@ static bool php_phongo_document_get(php_phongo_document_t* intern, char* key, si
 	bson_iter_t iter;
 
 	if (!bson_iter_init(&iter, intern->bson)) {
-		phongo_throw_exception(PHONGO_ERROR_RUNTIME, "Could not initialize BSON iterator.");
+		phongo_throw_exception(PHONGO_ERROR_RUNTIME, "Could not initialize BSON iterator");
 		return false;
 	}
 
@@ -214,7 +214,7 @@ static bool php_phongo_document_has(php_phongo_document_t* intern, char* key, si
 	bson_iter_t iter;
 
 	if (!bson_iter_init(&iter, intern->bson)) {
-		phongo_throw_exception(PHONGO_ERROR_RUNTIME, "Could not initialize BSON iterator.");
+		phongo_throw_exception(PHONGO_ERROR_RUNTIME, "Could not initialize BSON iterator");
 		return false;
 	}
 

--- a/src/BSON/Document.c
+++ b/src/BSON/Document.c
@@ -175,7 +175,7 @@ static bool php_phongo_document_get(php_phongo_document_t* intern, char* key, si
 	}
 
 	if (!bson_iter_find_w_len(&iter, key, key_len)) {
-		phongo_throw_exception(PHONGO_ERROR_RUNTIME, "Could not find key \"%s\" in BSON data", key);
+		phongo_throw_exception(PHONGO_ERROR_RUNTIME, "Could not find key \"%s\" in BSON document", key);
 		return false;
 	}
 
@@ -320,7 +320,7 @@ static PHP_METHOD(MongoDB_BSON_Document, offsetGet)
 	intern = Z_DOCUMENT_OBJ_P(getThis());
 
 	if (Z_TYPE_P(offset) != IS_STRING) {
-		phongo_throw_exception(PHONGO_ERROR_RUNTIME, "Could not find key of type \"%s\" in BSON data", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(offset));
+		phongo_throw_exception(PHONGO_ERROR_RUNTIME, "Could not find key of type \"%s\" in BSON document", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(offset));
 		return;
 	}
 
@@ -589,7 +589,7 @@ zval* php_phongo_document_read_dimension(phongo_compat_object_handler_type* obje
 	intern = Z_OBJ_DOCUMENT(PHONGO_COMPAT_GET_OBJ(object));
 
 	if (Z_TYPE_P(offset) != IS_STRING) {
-		phongo_throw_exception(PHONGO_ERROR_RUNTIME, "Could not find key of type \"%s\" in BSON data", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(offset));
+		phongo_throw_exception(PHONGO_ERROR_RUNTIME, "Could not find key of type \"%s\" in BSON document", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(offset));
 		return &EG(uninitialized_zval);
 	}
 
@@ -613,7 +613,7 @@ int php_phongo_document_has_dimension(phongo_compat_object_handler_type* object,
 	intern = Z_OBJ_DOCUMENT(PHONGO_COMPAT_GET_OBJ(object));
 
 	if (Z_TYPE_P(member) != IS_STRING) {
-		phongo_throw_exception(PHONGO_ERROR_RUNTIME, "Could not find key of type \"%s\" in BSON data", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(member));
+		phongo_throw_exception(PHONGO_ERROR_RUNTIME, "Could not find key of type \"%s\" in BSON document", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(member));
 		return false;
 	}
 

--- a/src/BSON/Document.stub.php
+++ b/src/BSON/Document.stub.php
@@ -7,7 +7,7 @@
 
 namespace MongoDB\BSON;
 
-final class Document implements \IteratorAggregate, \Serializable, Type
+final class Document implements \IteratorAggregate, \Serializable, \ArrayAccess, Type
 {
     private function __construct() {}
 
@@ -43,6 +43,40 @@ final class Document implements \IteratorAggregate, \Serializable, Type
     final public function toCanonicalExtendedJSON(): string {}
 
     final public function toRelaxedExtendedJSON(): string {}
+
+#if PHP_VERSION_ID >= 80000
+    public function offsetExists(mixed $key): bool {}
+# else
+    /** @param mixed $key */
+    public function offsetExists($key): bool {}
+# endif
+
+#if PHP_VERSION_ID >= 80000
+    public function offsetGet(mixed $key): mixed {}
+# else
+    /**
+     * @param mixed $key
+     * @return mixed
+     */
+    public function offsetGet($key) {}
+# endif
+
+#if PHP_VERSION_ID >= 80000
+    public function offsetSet(mixed $key, mixed $value): void {}
+# else
+    /**
+     * @param mixed $key
+     * @param mixed $value
+     */
+    public function offsetSet($key, $value): void {}
+# endif
+
+#if PHP_VERSION_ID >= 80000
+    public function offsetUnset(mixed $key): void {}
+# else
+    /** @param mixed $key */
+    public function offsetUnset($key): void {}
+# endif
 
     final public function __toString(): string {}
 

--- a/src/BSON/Document_arginfo.h
+++ b/src/BSON/Document_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 703e15f17b01dd2b6f04cb89c080ba83a5a420d0 */
+ * Stub hash: 10280ca319e69b9e6126002d7089ecaeb01650b1 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_Document___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -60,6 +60,56 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_MongoDB_BSON_Document_toRelaxedExtendedJSON arginfo_class_MongoDB_BSON_Document_toCanonicalExtendedJSON
 
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Document_offsetExists, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, key, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if !(PHP_VERSION_ID >= 80000)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Document_offsetExists, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_INFO(0, key)
+ZEND_END_ARG_INFO()
+#endif
+
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Document_offsetGet, 0, 1, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO(0, key, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if !(PHP_VERSION_ID >= 80000)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_Document_offsetGet, 0, 0, 1)
+	ZEND_ARG_INFO(0, key)
+ZEND_END_ARG_INFO()
+#endif
+
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Document_offsetSet, 0, 2, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, key, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if !(PHP_VERSION_ID >= 80000)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Document_offsetSet, 0, 2, IS_VOID, 0)
+	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO(0, value)
+ZEND_END_ARG_INFO()
+#endif
+
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Document_offsetUnset, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, key, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if !(PHP_VERSION_ID >= 80000)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Document_offsetUnset, 0, 1, IS_VOID, 0)
+	ZEND_ARG_INFO(0, key)
+ZEND_END_ARG_INFO()
+#endif
+
 #define arginfo_class_MongoDB_BSON_Document___toString arginfo_class_MongoDB_BSON_Document_toCanonicalExtendedJSON
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_BSON_Document___set_state, 0, 1, MongoDB\\BSON\\Document, 0)
@@ -113,6 +163,30 @@ static ZEND_METHOD(MongoDB_BSON_Document, toPHP);
 #endif
 static ZEND_METHOD(MongoDB_BSON_Document, toCanonicalExtendedJSON);
 static ZEND_METHOD(MongoDB_BSON_Document, toRelaxedExtendedJSON);
+#if PHP_VERSION_ID >= 80000
+static ZEND_METHOD(MongoDB_BSON_Document, offsetExists);
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+static ZEND_METHOD(MongoDB_BSON_Document, offsetExists);
+#endif
+#if PHP_VERSION_ID >= 80000
+static ZEND_METHOD(MongoDB_BSON_Document, offsetGet);
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+static ZEND_METHOD(MongoDB_BSON_Document, offsetGet);
+#endif
+#if PHP_VERSION_ID >= 80000
+static ZEND_METHOD(MongoDB_BSON_Document, offsetSet);
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+static ZEND_METHOD(MongoDB_BSON_Document, offsetSet);
+#endif
+#if PHP_VERSION_ID >= 80000
+static ZEND_METHOD(MongoDB_BSON_Document, offsetUnset);
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+static ZEND_METHOD(MongoDB_BSON_Document, offsetUnset);
+#endif
 static ZEND_METHOD(MongoDB_BSON_Document, __toString);
 static ZEND_METHOD(MongoDB_BSON_Document, __set_state);
 static ZEND_METHOD(MongoDB_BSON_Document, serialize);
@@ -152,6 +226,30 @@ static const zend_function_entry class_MongoDB_BSON_Document_methods[] = {
 #endif
 	ZEND_ME(MongoDB_BSON_Document, toCanonicalExtendedJSON, arginfo_class_MongoDB_BSON_Document_toCanonicalExtendedJSON, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_Document, toRelaxedExtendedJSON, arginfo_class_MongoDB_BSON_Document_toRelaxedExtendedJSON, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+#if PHP_VERSION_ID >= 80000
+	ZEND_ME(MongoDB_BSON_Document, offsetExists, arginfo_class_MongoDB_BSON_Document_offsetExists, ZEND_ACC_PUBLIC)
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+	ZEND_ME(MongoDB_BSON_Document, offsetExists, arginfo_class_MongoDB_BSON_Document_offsetExists, ZEND_ACC_PUBLIC)
+#endif
+#if PHP_VERSION_ID >= 80000
+	ZEND_ME(MongoDB_BSON_Document, offsetGet, arginfo_class_MongoDB_BSON_Document_offsetGet, ZEND_ACC_PUBLIC)
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+	ZEND_ME(MongoDB_BSON_Document, offsetGet, arginfo_class_MongoDB_BSON_Document_offsetGet, ZEND_ACC_PUBLIC)
+#endif
+#if PHP_VERSION_ID >= 80000
+	ZEND_ME(MongoDB_BSON_Document, offsetSet, arginfo_class_MongoDB_BSON_Document_offsetSet, ZEND_ACC_PUBLIC)
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+	ZEND_ME(MongoDB_BSON_Document, offsetSet, arginfo_class_MongoDB_BSON_Document_offsetSet, ZEND_ACC_PUBLIC)
+#endif
+#if PHP_VERSION_ID >= 80000
+	ZEND_ME(MongoDB_BSON_Document, offsetUnset, arginfo_class_MongoDB_BSON_Document_offsetUnset, ZEND_ACC_PUBLIC)
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+	ZEND_ME(MongoDB_BSON_Document, offsetUnset, arginfo_class_MongoDB_BSON_Document_offsetUnset, ZEND_ACC_PUBLIC)
+#endif
 	ZEND_ME(MongoDB_BSON_Document, __toString, arginfo_class_MongoDB_BSON_Document___toString, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_Document, __set_state, arginfo_class_MongoDB_BSON_Document___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_Document, serialize, arginfo_class_MongoDB_BSON_Document_serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
@@ -166,14 +264,14 @@ static const zend_function_entry class_MongoDB_BSON_Document_methods[] = {
 	ZEND_FE_END
 };
 
-static zend_class_entry *register_class_MongoDB_BSON_Document(zend_class_entry *class_entry_IteratorAggregate, zend_class_entry *class_entry_Serializable, zend_class_entry *class_entry_MongoDB_BSON_Type)
+static zend_class_entry *register_class_MongoDB_BSON_Document(zend_class_entry *class_entry_IteratorAggregate, zend_class_entry *class_entry_Serializable, zend_class_entry *class_entry_ArrayAccess, zend_class_entry *class_entry_MongoDB_BSON_Type)
 {
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "Document", class_MongoDB_BSON_Document_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
-	zend_class_implements(class_entry, 3, class_entry_IteratorAggregate, class_entry_Serializable, class_entry_MongoDB_BSON_Type);
+	zend_class_implements(class_entry, 4, class_entry_IteratorAggregate, class_entry_Serializable, class_entry_ArrayAccess, class_entry_MongoDB_BSON_Type);
 
 	return class_entry;
 }

--- a/src/BSON/PackedArray.c
+++ b/src/BSON/PackedArray.c
@@ -127,7 +127,7 @@ static bool php_phongo_packedarray_get(php_phongo_packedarray_t* intern, zend_lo
 	}
 
 	if (!seek_iter_to_index(&iter, index)) {
-		phongo_throw_exception(PHONGO_ERROR_RUNTIME, "Could not find index \"%d\" in BSON data", index);
+		phongo_throw_exception(PHONGO_ERROR_RUNTIME, "Could not find index \"%d\" in BSON array", index);
 		return false;
 	}
 
@@ -249,7 +249,7 @@ static PHP_METHOD(MongoDB_BSON_PackedArray, offsetGet)
 	intern = Z_PACKEDARRAY_OBJ_P(getThis());
 
 	if (Z_TYPE_P(key) != IS_LONG) {
-		phongo_throw_exception(PHONGO_ERROR_RUNTIME, "Could not find index of type \"%s\" in BSON data", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(key));
+		phongo_throw_exception(PHONGO_ERROR_RUNTIME, "Could not find index of type \"%s\" in BSON array", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(key));
 		return;
 	}
 
@@ -477,7 +477,7 @@ zval* php_phongo_packedarray_read_dimension(phongo_compat_object_handler_type* o
 	intern = Z_OBJ_PACKEDARRAY(PHONGO_COMPAT_GET_OBJ(object));
 
 	if (Z_TYPE_P(offset) != IS_LONG) {
-		phongo_throw_exception(PHONGO_ERROR_RUNTIME, "Could not find index of type \"%s\" in BSON data", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(offset));
+		phongo_throw_exception(PHONGO_ERROR_RUNTIME, "Could not find index of type \"%s\" in BSON array", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(offset));
 		return &EG(uninitialized_zval);
 	}
 

--- a/src/BSON/PackedArray.c
+++ b/src/BSON/PackedArray.c
@@ -93,7 +93,7 @@ static PHP_METHOD(MongoDB_BSON_PackedArray, fromPHP)
 	PHONGO_PARSE_PARAMETERS_END();
 
 	if (!zend_array_is_list(Z_ARRVAL_P(data))) {
-		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected value to be a list, but given array is not.");
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected value to be a list, but given array is not");
 		return;
 	}
 
@@ -122,7 +122,7 @@ static bool php_phongo_packedarray_get(php_phongo_packedarray_t* intern, zend_lo
 	bson_iter_t iter;
 
 	if (!bson_iter_init(&iter, intern->bson)) {
-		phongo_throw_exception(PHONGO_ERROR_RUNTIME, "Could not initialize BSON iterator.");
+		phongo_throw_exception(PHONGO_ERROR_RUNTIME, "Could not initialize BSON iterator");
 		return false;
 	}
 
@@ -165,7 +165,7 @@ static bool php_phongo_packedarray_has(php_phongo_packedarray_t* intern, zend_lo
 	bson_iter_t iter;
 
 	if (!bson_iter_init(&iter, intern->bson)) {
-		phongo_throw_exception(PHONGO_ERROR_RUNTIME, "Could not initialize BSON iterator.");
+		phongo_throw_exception(PHONGO_ERROR_RUNTIME, "Could not initialize BSON iterator");
 		return false;
 	}
 

--- a/src/BSON/PackedArray.stub.php
+++ b/src/BSON/PackedArray.stub.php
@@ -7,7 +7,7 @@
 
 namespace MongoDB\BSON;
 
-final class PackedArray implements \IteratorAggregate, \Serializable, Type
+final class PackedArray implements \IteratorAggregate, \Serializable, \ArrayAccess, Type
 {
     private function __construct() {}
 
@@ -30,6 +30,40 @@ final class PackedArray implements \IteratorAggregate, \Serializable, Type
     /** @return array|object */
     final public function toPHP(?array $typeMap = null) {}
 #endif
+
+#if PHP_VERSION_ID >= 80000
+    public function offsetExists(mixed $key): bool {}
+# else
+    /** @param mixed $key */
+    public function offsetExists($key): bool {}
+# endif
+
+#if PHP_VERSION_ID >= 80000
+    public function offsetGet(mixed $key): mixed {}
+# else
+    /**
+     * @param mixed $key
+     * @return mixed
+     */
+    public function offsetGet($key) {}
+# endif
+
+#if PHP_VERSION_ID >= 80000
+    public function offsetSet(mixed $key, mixed $value): void {}
+# else
+    /**
+     * @param mixed $key
+     * @param mixed $value
+     */
+    public function offsetSet($key, $value): void {}
+# endif
+
+#if PHP_VERSION_ID >= 80000
+    public function offsetUnset(mixed $key): void {}
+# else
+    /** @param mixed $key */
+    public function offsetUnset($key): void {}
+# endif
 
     final public function __toString(): string {}
 

--- a/src/BSON/PackedArray_arginfo.h
+++ b/src/BSON/PackedArray_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: f9813432d7811e068f62a4b34d86919a52f63984 */
+ * Stub hash: 0f153948c7083074dfeb4f6fafd7b561aa2fc37b */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_PackedArray___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -36,6 +36,56 @@ ZEND_END_ARG_INFO()
 #if !(PHP_VERSION_ID >= 80000)
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_PackedArray_toPHP, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, typeMap, IS_ARRAY, 1, "null")
+ZEND_END_ARG_INFO()
+#endif
+
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_PackedArray_offsetExists, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, key, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if !(PHP_VERSION_ID >= 80000)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_PackedArray_offsetExists, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_INFO(0, key)
+ZEND_END_ARG_INFO()
+#endif
+
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_PackedArray_offsetGet, 0, 1, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO(0, key, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if !(PHP_VERSION_ID >= 80000)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_PackedArray_offsetGet, 0, 0, 1)
+	ZEND_ARG_INFO(0, key)
+ZEND_END_ARG_INFO()
+#endif
+
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_PackedArray_offsetSet, 0, 2, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, key, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if !(PHP_VERSION_ID >= 80000)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_PackedArray_offsetSet, 0, 2, IS_VOID, 0)
+	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO(0, value)
+ZEND_END_ARG_INFO()
+#endif
+
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_PackedArray_offsetUnset, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, key, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if !(PHP_VERSION_ID >= 80000)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_PackedArray_offsetUnset, 0, 1, IS_VOID, 0)
+	ZEND_ARG_INFO(0, key)
 ZEND_END_ARG_INFO()
 #endif
 
@@ -84,6 +134,30 @@ static ZEND_METHOD(MongoDB_BSON_PackedArray, toPHP);
 #if !(PHP_VERSION_ID >= 80000)
 static ZEND_METHOD(MongoDB_BSON_PackedArray, toPHP);
 #endif
+#if PHP_VERSION_ID >= 80000
+static ZEND_METHOD(MongoDB_BSON_PackedArray, offsetExists);
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+static ZEND_METHOD(MongoDB_BSON_PackedArray, offsetExists);
+#endif
+#if PHP_VERSION_ID >= 80000
+static ZEND_METHOD(MongoDB_BSON_PackedArray, offsetGet);
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+static ZEND_METHOD(MongoDB_BSON_PackedArray, offsetGet);
+#endif
+#if PHP_VERSION_ID >= 80000
+static ZEND_METHOD(MongoDB_BSON_PackedArray, offsetSet);
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+static ZEND_METHOD(MongoDB_BSON_PackedArray, offsetSet);
+#endif
+#if PHP_VERSION_ID >= 80000
+static ZEND_METHOD(MongoDB_BSON_PackedArray, offsetUnset);
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+static ZEND_METHOD(MongoDB_BSON_PackedArray, offsetUnset);
+#endif
 static ZEND_METHOD(MongoDB_BSON_PackedArray, __toString);
 static ZEND_METHOD(MongoDB_BSON_PackedArray, __set_state);
 static ZEND_METHOD(MongoDB_BSON_PackedArray, serialize);
@@ -114,6 +188,30 @@ static const zend_function_entry class_MongoDB_BSON_PackedArray_methods[] = {
 #if !(PHP_VERSION_ID >= 80000)
 	ZEND_ME(MongoDB_BSON_PackedArray, toPHP, arginfo_class_MongoDB_BSON_PackedArray_toPHP, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 #endif
+#if PHP_VERSION_ID >= 80000
+	ZEND_ME(MongoDB_BSON_PackedArray, offsetExists, arginfo_class_MongoDB_BSON_PackedArray_offsetExists, ZEND_ACC_PUBLIC)
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+	ZEND_ME(MongoDB_BSON_PackedArray, offsetExists, arginfo_class_MongoDB_BSON_PackedArray_offsetExists, ZEND_ACC_PUBLIC)
+#endif
+#if PHP_VERSION_ID >= 80000
+	ZEND_ME(MongoDB_BSON_PackedArray, offsetGet, arginfo_class_MongoDB_BSON_PackedArray_offsetGet, ZEND_ACC_PUBLIC)
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+	ZEND_ME(MongoDB_BSON_PackedArray, offsetGet, arginfo_class_MongoDB_BSON_PackedArray_offsetGet, ZEND_ACC_PUBLIC)
+#endif
+#if PHP_VERSION_ID >= 80000
+	ZEND_ME(MongoDB_BSON_PackedArray, offsetSet, arginfo_class_MongoDB_BSON_PackedArray_offsetSet, ZEND_ACC_PUBLIC)
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+	ZEND_ME(MongoDB_BSON_PackedArray, offsetSet, arginfo_class_MongoDB_BSON_PackedArray_offsetSet, ZEND_ACC_PUBLIC)
+#endif
+#if PHP_VERSION_ID >= 80000
+	ZEND_ME(MongoDB_BSON_PackedArray, offsetUnset, arginfo_class_MongoDB_BSON_PackedArray_offsetUnset, ZEND_ACC_PUBLIC)
+#endif
+#if !(PHP_VERSION_ID >= 80000)
+	ZEND_ME(MongoDB_BSON_PackedArray, offsetUnset, arginfo_class_MongoDB_BSON_PackedArray_offsetUnset, ZEND_ACC_PUBLIC)
+#endif
 	ZEND_ME(MongoDB_BSON_PackedArray, __toString, arginfo_class_MongoDB_BSON_PackedArray___toString, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_PackedArray, __set_state, arginfo_class_MongoDB_BSON_PackedArray___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_PackedArray, serialize, arginfo_class_MongoDB_BSON_PackedArray_serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
@@ -128,14 +226,14 @@ static const zend_function_entry class_MongoDB_BSON_PackedArray_methods[] = {
 	ZEND_FE_END
 };
 
-static zend_class_entry *register_class_MongoDB_BSON_PackedArray(zend_class_entry *class_entry_IteratorAggregate, zend_class_entry *class_entry_Serializable, zend_class_entry *class_entry_MongoDB_BSON_Type)
+static zend_class_entry *register_class_MongoDB_BSON_PackedArray(zend_class_entry *class_entry_IteratorAggregate, zend_class_entry *class_entry_Serializable, zend_class_entry *class_entry_ArrayAccess, zend_class_entry *class_entry_MongoDB_BSON_Type)
 {
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "PackedArray", class_MongoDB_BSON_PackedArray_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
-	zend_class_implements(class_entry, 3, class_entry_IteratorAggregate, class_entry_Serializable, class_entry_MongoDB_BSON_Type);
+	zend_class_implements(class_entry, 4, class_entry_IteratorAggregate, class_entry_Serializable, class_entry_ArrayAccess, class_entry_MongoDB_BSON_Type);
 
 	return class_entry;
 }

--- a/src/phongo_compat.h
+++ b/src/phongo_compat.h
@@ -70,12 +70,24 @@
 #define phongo_compat_object_handler_type zend_object
 #define PHONGO_COMPAT_GET_OBJ(val) val
 #define PHONGO_COMPAT_SET_COMPARE_OBJECTS_HANDLER(type) php_phongo_handler_##type.compare = php_phongo_##type##_compare_objects;
+#define phongo_compat_property_accessor_name_type zend_string
+#define PHONGO_COMPAT_PROPERTY_ACCESSOR_NAME_TO_STRING(value, key, len) \
+	do {                                                                \
+		(key) = ZSTR_VAL((value));                                      \
+		(len) = ZSTR_LEN((value));                                      \
+	} while (0)
 #else /* PHP_VERSION_ID < 80000 */
 #define PHONGO_COMPAT_OBJ_P(val) val
 #define phongo_compat_object_handler_type zval
 #define PHONGO_COMPAT_GET_OBJ(val) Z_OBJ_P(val)
 #define PHONGO_COMPAT_SET_COMPARE_OBJECTS_HANDLER(type) php_phongo_handler_##type.compare_objects = php_phongo_##type##_compare_objects;
 #define ZEND_COMPARE_OBJECTS_FALLBACK(o1, o2)
+#define phongo_compat_property_accessor_name_type zval
+#define PHONGO_COMPAT_PROPERTY_ACCESSOR_NAME_TO_STRING(value, key, len) \
+	do {                                                                \
+		(key) = Z_STRVAL_P((value));                                    \
+		(len) = Z_STRLEN_P((value));                                    \
+	} while (0)
 #endif /* PHP_VERSION_ID >= 80000 */
 
 #if SIZEOF_ZEND_LONG == 8

--- a/tests/bson/bson-document-array-access-001.phpt
+++ b/tests/bson/bson-document-array-access-001.phpt
@@ -1,0 +1,33 @@
+--TEST--
+MongoDB\BSON\Document array access (dimension object accessors)
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/basic.inc';
+
+$document = MongoDB\BSON\Document::fromPHP([
+    'foo' => 'bar',
+    'bar' => 'baz',
+    'int64' => new MongoDB\BSON\Int64(123),
+]);
+
+var_dump(isset($document['foo']));
+var_dump(isset($document['int64']));
+var_dump(isset($document['baz']));
+
+var_dump($document['foo']);
+var_dump($document['int64']);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+bool(true)
+bool(true)
+bool(false)
+string(3) "bar"
+object(MongoDB\BSON\Int64)#%d (%d) {
+  ["integer"]=>
+  string(3) "123"
+}
+===DONE===

--- a/tests/bson/bson-document-array-access-002.phpt
+++ b/tests/bson/bson-document-array-access-002.phpt
@@ -1,0 +1,35 @@
+--TEST--
+MongoDB\BSON\Document array access (ArrayAccess methods)
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/basic.inc';
+
+$document = MongoDB\BSON\Document::fromPHP([
+    'foo' => 'bar',
+    'bar' => 'baz',
+    'int64' => new MongoDB\BSON\Int64(123),
+]);
+
+var_dump($document->offsetExists('foo'));
+var_dump($document->offsetExists('int64'));
+var_dump($document->offsetExists('baz'));
+var_dump($document->offsetExists(0));
+
+var_dump($document->offsetGet('foo'));
+var_dump($document->offsetGet('int64'));
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+bool(true)
+bool(true)
+bool(false)
+bool(false)
+string(3) "bar"
+object(MongoDB\BSON\Int64)#%d (%d) {
+  ["integer"]=>
+  string(3) "123"
+}
+===DONE===

--- a/tests/bson/bson-document-array-access_error-001.phpt
+++ b/tests/bson/bson-document-array-access_error-001.phpt
@@ -1,0 +1,30 @@
+--TEST--
+MongoDB\BSON\Document array access does not allow writing (dimension object accessors)
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/basic.inc';
+
+$document = MongoDB\BSON\Document::fromPHP([
+    'foo' => 'bar',
+    'bar' => 'baz',
+    'int64' => new MongoDB\BSON\Int64(123),
+]);
+
+echo throws(function() use ($document) {
+    $document['foo'] = 'baz';
+}, MongoDB\Driver\Exception\LogicException::class), "\n";
+
+echo throws(function() use ($document) {
+    unset($document['foo']);
+}, MongoDB\Driver\Exception\LogicException::class), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\LogicException
+Cannot write to MongoDB\BSON\Document property
+OK: Got MongoDB\Driver\Exception\LogicException
+Cannot unset MongoDB\BSON\Document property
+===DONE===

--- a/tests/bson/bson-document-array-access_error-002.phpt
+++ b/tests/bson/bson-document-array-access_error-002.phpt
@@ -1,0 +1,30 @@
+--TEST--
+MongoDB\BSON\Document array access does not allow writing (ArrayAccess methods)
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/basic.inc';
+
+$document = MongoDB\BSON\Document::fromPHP([
+    'foo' => 'bar',
+    'bar' => 'baz',
+    'int64' => new MongoDB\BSON\Int64(123),
+]);
+
+echo throws(function() use ($document) {
+    $document->offsetSet('foo', 'baz');
+}, MongoDB\Driver\Exception\LogicException::class), "\n";
+
+echo throws(function() use ($document) {
+    $document->offsetUnset('foo');
+}, MongoDB\Driver\Exception\LogicException::class), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\LogicException
+Cannot write to MongoDB\BSON\Document property
+OK: Got MongoDB\Driver\Exception\LogicException
+Cannot unset MongoDB\BSON\Document property
+===DONE===

--- a/tests/bson/bson-document-array-access_error-003.phpt
+++ b/tests/bson/bson-document-array-access_error-003.phpt
@@ -1,0 +1,36 @@
+--TEST--
+MongoDB\BSON\Document array access checks types (dimension object handlers)
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/basic.inc';
+
+$document = MongoDB\BSON\Document::fromPHP([
+    'foo' => 'bar',
+    'bar' => 'baz',
+    'int64' => new MongoDB\BSON\Int64(123),
+]);
+
+echo throws(function() use ($document) {
+    $document[0];
+}, MongoDB\Driver\Exception\RuntimeException::class), "\n";
+
+echo throws(function() use ($document) {
+    $document[0.1];
+}, MongoDB\Driver\Exception\RuntimeException::class), "\n";
+
+echo throws(function() use ($document) {
+    $document[false];
+}, MongoDB\Driver\Exception\RuntimeException::class), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\RuntimeException
+Could not find key of type "int" in BSON data
+OK: Got MongoDB\Driver\Exception\RuntimeException
+Could not find key of type "float" in BSON data
+OK: Got MongoDB\Driver\Exception\RuntimeException
+Could not find key of type "bool" in BSON data
+===DONE===

--- a/tests/bson/bson-document-array-access_error-003.phpt
+++ b/tests/bson/bson-document-array-access_error-003.phpt
@@ -28,9 +28,9 @@ echo throws(function() use ($document) {
 <?php exit(0); ?>
 --EXPECT--
 OK: Got MongoDB\Driver\Exception\RuntimeException
-Could not find key of type "int" in BSON data
+Could not find key of type "int" in BSON document
 OK: Got MongoDB\Driver\Exception\RuntimeException
-Could not find key of type "float" in BSON data
+Could not find key of type "float" in BSON document
 OK: Got MongoDB\Driver\Exception\RuntimeException
-Could not find key of type "bool" in BSON data
+Could not find key of type "bool" in BSON document
 ===DONE===

--- a/tests/bson/bson-document-array-access_error-004.phpt
+++ b/tests/bson/bson-document-array-access_error-004.phpt
@@ -1,0 +1,36 @@
+--TEST--
+MongoDB\BSON\Document array access checks types (ArrayAccess methods)
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/basic.inc';
+
+$document = MongoDB\BSON\Document::fromPHP([
+    'foo' => 'bar',
+    'bar' => 'baz',
+    'int64' => new MongoDB\BSON\Int64(123),
+]);
+
+echo throws(function() use ($document) {
+    $document->offsetGet(0);
+}, MongoDB\Driver\Exception\RuntimeException::class), "\n";
+
+echo throws(function() use ($document) {
+    $document->offsetGet(0.1);
+}, MongoDB\Driver\Exception\RuntimeException::class), "\n";
+
+echo throws(function() use ($document) {
+    $document->offsetGet(false);
+}, MongoDB\Driver\Exception\RuntimeException::class), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\RuntimeException
+Could not find key of type "int" in BSON data
+OK: Got MongoDB\Driver\Exception\RuntimeException
+Could not find key of type "float" in BSON data
+OK: Got MongoDB\Driver\Exception\RuntimeException
+Could not find key of type "bool" in BSON data
+===DONE===

--- a/tests/bson/bson-document-array-access_error-004.phpt
+++ b/tests/bson/bson-document-array-access_error-004.phpt
@@ -28,9 +28,9 @@ echo throws(function() use ($document) {
 <?php exit(0); ?>
 --EXPECT--
 OK: Got MongoDB\Driver\Exception\RuntimeException
-Could not find key of type "int" in BSON data
+Could not find key of type "int" in BSON document
 OK: Got MongoDB\Driver\Exception\RuntimeException
-Could not find key of type "float" in BSON data
+Could not find key of type "float" in BSON document
 OK: Got MongoDB\Driver\Exception\RuntimeException
-Could not find key of type "bool" in BSON data
+Could not find key of type "bool" in BSON document
 ===DONE===

--- a/tests/bson/bson-document-get-001.phpt
+++ b/tests/bson/bson-document-get-001.phpt
@@ -29,5 +29,5 @@ object(MongoDB\BSON\Int64)#%d (%d) {
   string(3) "123"
 }
 OK: Got MongoDB\Driver\Exception\RuntimeException
-Could not find key "baz" in BSON data
+Could not find key "baz" in BSON document
 ===DONE===

--- a/tests/bson/bson-document-property-access-001.phpt
+++ b/tests/bson/bson-document-property-access-001.phpt
@@ -1,0 +1,39 @@
+--TEST--
+MongoDB\BSON\Document property access
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/basic.inc';
+
+$document = MongoDB\BSON\Document::fromPHP([
+    'foo' => 'bar',
+    'bar' => 'baz',
+    'int64' => new MongoDB\BSON\Int64(123),
+]);
+
+var_dump(isset($document->foo));
+var_dump(isset($document->int64));
+var_dump(isset($document->baz));
+
+var_dump($document->foo);
+var_dump($document->int64);
+
+echo throws(function() use ($document) {
+    var_dump($document->baz);
+}, MongoDB\Driver\Exception\RuntimeException::class), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+bool(true)
+bool(true)
+bool(false)
+string(3) "bar"
+object(MongoDB\BSON\Int64)#%d (%d) {
+  ["integer"]=>
+  string(3) "123"
+}
+OK: Got MongoDB\Driver\Exception\RuntimeException
+Could not find key "baz" in BSON data
+===DONE===

--- a/tests/bson/bson-document-property-access-001.phpt
+++ b/tests/bson/bson-document-property-access-001.phpt
@@ -35,5 +35,5 @@ object(MongoDB\BSON\Int64)#%d (%d) {
   string(3) "123"
 }
 OK: Got MongoDB\Driver\Exception\RuntimeException
-Could not find key "baz" in BSON data
+Could not find key "baz" in BSON document
 ===DONE===

--- a/tests/bson/bson-document-property-access_error-001.phpt
+++ b/tests/bson/bson-document-property-access_error-001.phpt
@@ -1,0 +1,30 @@
+--TEST--
+MongoDB\BSON\Document property access does not allow writing
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/basic.inc';
+
+$document = MongoDB\BSON\Document::fromPHP([
+    'foo' => 'bar',
+    'bar' => 'baz',
+    'int64' => new MongoDB\BSON\Int64(123),
+]);
+
+echo throws(function() use ($document) {
+    $document->foo = 'baz';
+}, MongoDB\Driver\Exception\LogicException::class), "\n";
+
+echo throws(function() use ($document) {
+    unset($document->foo);
+}, MongoDB\Driver\Exception\LogicException::class), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+OK: Got MongoDB\Driver\Exception\LogicException
+Cannot write to MongoDB\BSON\Document property
+OK: Got MongoDB\Driver\Exception\LogicException
+Cannot unset MongoDB\BSON\Document property
+===DONE===

--- a/tests/bson/bson-packedarray-array-access-001.phpt
+++ b/tests/bson/bson-packedarray-array-access-001.phpt
@@ -1,0 +1,31 @@
+--TEST--
+MongoDB\BSON\PackedArray array access (dimension object accessors)
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/basic.inc';
+
+$array = MongoDB\BSON\PackedArray::fromPHP(["foo", new MongoDB\BSON\Int64(123)]);
+
+var_dump(isset($array[0]));
+var_dump(isset($array[1]));
+var_dump(isset($array[2]));
+var_dump(isset($array['foo']));
+
+var_dump($array[0]);
+var_dump($array[1]);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+bool(true)
+bool(true)
+bool(false)
+bool(false)
+string(3) "foo"
+object(MongoDB\BSON\Int64)#%d (%d) {
+  ["integer"]=>
+  string(3) "123"
+}
+===DONE===

--- a/tests/bson/bson-packedarray-array-access-002.phpt
+++ b/tests/bson/bson-packedarray-array-access-002.phpt
@@ -1,0 +1,31 @@
+--TEST--
+MongoDB\BSON\PackedArray array access (ArrayAccess methods)
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/basic.inc';
+
+$array = MongoDB\BSON\PackedArray::fromPHP(["foo", new MongoDB\BSON\Int64(123)]);
+
+var_dump($array->offsetExists(0));
+var_dump($array->offsetExists(1));
+var_dump($array->offsetExists(2));
+var_dump($array->offsetExists('foo'));
+
+var_dump($array->offsetGet(0));
+var_dump($array->offsetGet(1));
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+bool(true)
+bool(true)
+bool(false)
+bool(false)
+string(3) "foo"
+object(MongoDB\BSON\Int64)#%d (%d) {
+  ["integer"]=>
+  string(3) "123"
+}
+===DONE===

--- a/tests/bson/bson-packedarray-array-access_error-001.phpt
+++ b/tests/bson/bson-packedarray-array-access_error-001.phpt
@@ -1,0 +1,28 @@
+--TEST--
+MongoDB\BSON\PackedArray array access does not allow writing (dimension object handlers)
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/basic.inc';
+
+$array = MongoDB\BSON\PackedArray::fromPHP(["foo", new MongoDB\BSON\Int64(123)]);
+
+// Writing causes exception
+echo throws(function() use ($array) {
+    $array[0] = 'bar';
+}, MongoDB\Driver\Exception\LogicException::class), "\n";
+
+// Unsetting causes exception
+echo throws(function() use ($array) {
+    unset($array[0]);
+}, MongoDB\Driver\Exception\LogicException::class), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\LogicException
+Cannot write to MongoDB\BSON\PackedArray offset
+OK: Got MongoDB\Driver\Exception\LogicException
+Cannot unset MongoDB\BSON\PackedArray offset
+===DONE===

--- a/tests/bson/bson-packedarray-array-access_error-002.phpt
+++ b/tests/bson/bson-packedarray-array-access_error-002.phpt
@@ -1,0 +1,28 @@
+--TEST--
+MongoDB\BSON\PackedArray array access does not allow writing (ArrayAccess methods)
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/basic.inc';
+
+$array = MongoDB\BSON\PackedArray::fromPHP(["foo", new MongoDB\BSON\Int64(123)]);
+
+// Writing causes exception
+echo throws(function() use ($array) {
+    $array->offsetSet(0, 'bar');
+}, MongoDB\Driver\Exception\LogicException::class), "\n";
+
+// Unsetting causes exception
+echo throws(function() use ($array) {
+    $array->offsetUnset(0);
+}, MongoDB\Driver\Exception\LogicException::class), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\LogicException
+Cannot write to MongoDB\BSON\PackedArray offset
+OK: Got MongoDB\Driver\Exception\LogicException
+Cannot unset MongoDB\BSON\PackedArray offset
+===DONE===

--- a/tests/bson/bson-packedarray-array-access_error-003.phpt
+++ b/tests/bson/bson-packedarray-array-access_error-003.phpt
@@ -28,11 +28,11 @@ echo throws(function() use ($array) {
 <?php exit(0); ?>
 --EXPECT--
 OK: Got MongoDB\Driver\Exception\RuntimeException
-Could not find index of type "string" in BSON data
+Could not find index of type "string" in BSON array
 OK: Got MongoDB\Driver\Exception\RuntimeException
-Could not find index of type "string" in BSON data
+Could not find index of type "string" in BSON array
 OK: Got MongoDB\Driver\Exception\RuntimeException
-Could not find index of type "float" in BSON data
+Could not find index of type "float" in BSON array
 OK: Got MongoDB\Driver\Exception\RuntimeException
-Could not find index of type "bool" in BSON data
+Could not find index of type "bool" in BSON array
 ===DONE===

--- a/tests/bson/bson-packedarray-array-access_error-003.phpt
+++ b/tests/bson/bson-packedarray-array-access_error-003.phpt
@@ -1,0 +1,38 @@
+--TEST--
+MongoDB\BSON\PackedArray array access checks types (dimension object handlers)
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/basic.inc';
+
+$array = MongoDB\BSON\PackedArray::fromPHP(["foo", new MongoDB\BSON\Int64(123)]);
+
+echo throws(function() use ($array) {
+    $array['foo'];
+}, MongoDB\Driver\Exception\RuntimeException::class), "\n";
+
+echo throws(function() use ($array) {
+    $array['0'];
+}, MongoDB\Driver\Exception\RuntimeException::class), "\n";
+
+echo throws(function() use ($array) {
+    $array[0.1];
+}, MongoDB\Driver\Exception\RuntimeException::class), "\n";
+
+echo throws(function() use ($array) {
+    $array[false];
+}, MongoDB\Driver\Exception\RuntimeException::class), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\RuntimeException
+Could not find index of type "string" in BSON data
+OK: Got MongoDB\Driver\Exception\RuntimeException
+Could not find index of type "string" in BSON data
+OK: Got MongoDB\Driver\Exception\RuntimeException
+Could not find index of type "float" in BSON data
+OK: Got MongoDB\Driver\Exception\RuntimeException
+Could not find index of type "bool" in BSON data
+===DONE===

--- a/tests/bson/bson-packedarray-array-access_error-004.phpt
+++ b/tests/bson/bson-packedarray-array-access_error-004.phpt
@@ -1,0 +1,38 @@
+--TEST--
+MongoDB\BSON\PackedArray array access checks types (ArrayAccess methods)
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/basic.inc';
+
+$array = MongoDB\BSON\PackedArray::fromPHP(["foo", new MongoDB\BSON\Int64(123)]);
+
+echo throws(function() use ($array) {
+    $array->offsetGet('foo');
+}, MongoDB\Driver\Exception\RuntimeException::class), "\n";
+
+echo throws(function() use ($array) {
+    $array->offsetGet('0');
+}, MongoDB\Driver\Exception\RuntimeException::class), "\n";
+
+echo throws(function() use ($array) {
+    $array->offsetGet(0.1);
+}, MongoDB\Driver\Exception\RuntimeException::class), "\n";
+
+echo throws(function() use ($array) {
+    $array->offsetGet(false);
+}, MongoDB\Driver\Exception\RuntimeException::class), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\RuntimeException
+Could not find index of type "string" in BSON data
+OK: Got MongoDB\Driver\Exception\RuntimeException
+Could not find index of type "string" in BSON data
+OK: Got MongoDB\Driver\Exception\RuntimeException
+Could not find index of type "float" in BSON data
+OK: Got MongoDB\Driver\Exception\RuntimeException
+Could not find index of type "bool" in BSON data
+===DONE===

--- a/tests/bson/bson-packedarray-array-access_error-004.phpt
+++ b/tests/bson/bson-packedarray-array-access_error-004.phpt
@@ -28,11 +28,11 @@ echo throws(function() use ($array) {
 <?php exit(0); ?>
 --EXPECT--
 OK: Got MongoDB\Driver\Exception\RuntimeException
-Could not find index of type "string" in BSON data
+Could not find index of type "string" in BSON array
 OK: Got MongoDB\Driver\Exception\RuntimeException
-Could not find index of type "string" in BSON data
+Could not find index of type "string" in BSON array
 OK: Got MongoDB\Driver\Exception\RuntimeException
-Could not find index of type "float" in BSON data
+Could not find index of type "float" in BSON array
 OK: Got MongoDB\Driver\Exception\RuntimeException
-Could not find index of type "bool" in BSON data
+Could not find index of type "bool" in BSON array
 ===DONE===

--- a/tests/bson/bson-packedarray-fromPHP_error-001.phpt
+++ b/tests/bson/bson-packedarray-fromPHP_error-001.phpt
@@ -22,9 +22,9 @@ foreach ($tests as $test) {
 <?php exit(0); ?>
 --EXPECT--
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected value to be a list, but given array is not.
+Expected value to be a list, but given array is not
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected value to be a list, but given array is not.
+Expected value to be a list, but given array is not
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Expected value to be a list, but given array is not.
+Expected value to be a list, but given array is not
 ===DONE===

--- a/tests/bson/bson-packedarray-get-001.phpt
+++ b/tests/bson/bson-packedarray-get-001.phpt
@@ -25,5 +25,5 @@ object(MongoDB\BSON\Int64)#%d (%d) {
   string(3) "123"
 }
 OK: Got MongoDB\Driver\Exception\RuntimeException
-Could not find index "4" in BSON data
+Could not find index "4" in BSON array
 ===DONE===


### PR DESCRIPTION
PHPC-2245, PHPC-2246

This adds array access for `MongoDB\BSON\PackedArray` instances, as well as array and property access to `MongoDB\BSON\Document` instances.

Note that the stubs currently don't implement the `ArrayAccess` interface, as the internal functionality does not require it and it would lead to us having to implement the various `offset...` methods defined in the interface. If implementing the interface is preferable to communicate the fact that such array access is possible, we can do so. The same applies to magic methods for property access in `MongoDB\BSON\Document`.