### PR TITLE
PHPC-2275: Always consult php-config for PHP version check in config.m4

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -15,18 +15,15 @@ if test "$PHP_MONGODB" != "no"; then
   dnl Check PHP version is compatible with this extension
   AC_MSG_CHECKING([PHP version])
 
-  PHP_MONGODB_PHP_VERSION=$PHP_VERSION
-  PHP_MONGODB_PHP_VERSION_ID=$PHP_VERSION_ID
-
-  if test -z "$PHP_MONGODB_PHP_VERSION"; then
-    if test -z "$PHP_CONFIG"; then
-      AC_MSG_ERROR([php-config not found])
-    fi
-    PHP_MONGODB_PHP_VERSION=`${PHP_CONFIG} --version`
-    PHP_MONGODB_PHP_VERSION_ID=`echo "${PHP_MONGODB_PHP_VERSION}" | $AWK 'BEGIN { FS = "."; } { printf "%d", ([$]1 * 100 + [$]2) * 100 + [$]3;}'`
+  if test -z "$PHP_CONFIG"; then
+    AC_MSG_ERROR([php-config not found])
   fi
 
+  PHP_MONGODB_PHP_VERSION=`${PHP_CONFIG} --version`
+  PHP_MONGODB_PHP_VERSION_ID=`${PHP_CONFIG} --vernum`
+
   AC_MSG_RESULT($PHP_MONGODB_PHP_VERSION)
+
   if test "$PHP_MONGODB_PHP_VERSION_ID" -lt "70400"; then
     AC_MSG_ERROR([not supported. Need a PHP version >= 7.4.0 (found $PHP_MONGODB_PHP_VERSION)])
   fi


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-2275

Typically, PHP_VERSION and PHP_VERSION_ID are only defined when building the extension statically with PHP, since those variables are defined in php-src's own configure.ac. The variables are not defined when using phpize for a shared build.

The PHP Docker images for Alpine happen to define PHP_VERSION in their shell, but not PHP_VERSION_ID, which resulted in an "sh: out of range" error attempting to check the version. The shell-defined PHP_VERSION is also not necessarily the value we'd get from php-config (edge case where someone installs a different PHP version on top of an existing image).

This changes the logic to always rely on php-config to derive these values, as is done in various other extensions (e.g. xdebug, parallel). The awk one-liner that calculates PHP_VERSION_ID is also replaced with a direct call to `php-config --vernum`, which has been available since PHP 5.4 (php/php-src@f0fe4e05b91b5a6815ee056dee204262810b862f).

----

Note: this has been manually tested on Alpine using [7.4.0-fpm-alpine](https://hub.docker.com/layers/library/php/7.4.0-fpm-alpine/images/sha256-35565c5edd4dd676a7ea7d7b566eab08b2ee6474263f6cd384d4d29d4590a199), which required manually installing additional packges to compile the driver:

```
$ apk add git autoconf build-base
```