### PR TITLE
PHPC-2296: Test on PHP 8.3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,7 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.2"
+          - "8.3"
         mongodb-version:
           - "4.4"
         topology:

--- a/.github/workflows/windows-release-build.yml
+++ b/.github/workflows/windows-release-build.yml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Note: keep this in sync with the Windows matrix in tests.yml
-        php: [ "7.4", "8.0", "8.1", "8.2" ]
+        # Note: keep this in sync with the Windows matrix in windows-tests.yml
+        php: [ "7.4", "8.0", "8.1", "8.2", "8.3" ]
         arch: [ x64, x86 ]
         ts: [ ts, nts ]
     runs-on: ubuntu-latest

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -26,7 +26,7 @@ jobs:
       # This matrix intentionally uses fail-fast: false to ensure other builds are finished
       fail-fast: false
       matrix:
-        php: [ "7.4", "8.0", "8.1", "8.2" ]
+        php: [ "7.4", "8.0", "8.1", "8.2", "8.3" ]
         arch: [ x64, x86 ]
         ts: [ ts, nts ]
 
@@ -88,7 +88,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ "7.4", "8.0", "8.1", "8.2" ]
+        php: [ "7.4", "8.0", "8.1", "8.2", "8.3" ]
         arch: [ x64, x86 ]
         ts: [ ts, nts ]
 

--- a/.github/workflows/windows/prepare-build/action.yml
+++ b/.github/workflows/windows/prepare-build/action.yml
@@ -19,7 +19,7 @@ runs:
   steps:
     - name: Setup PHP SDK
       id: setup-php
-      uses: cmb69/setup-php-sdk@v0.7
+      uses: alcaeus/setup-php-sdk@php-8.3
       with:
         version: ${{ inputs.version }}
         arch: ${{ inputs.arch }}


### PR DESCRIPTION
PHPC-2296

Note: PHP version in arginfo-files was left at PHP 8.2 on purpose until PHP 8.3 is considered stable.