### PR TITLE
PHPC-2262: Add utf8proc directory to PECL package

### DIFF
--- a/bin/prep-release.php
+++ b/bin/prep-release.php
@@ -56,6 +56,7 @@ function get_files() {
         "src/libmongoc/src/libbson/VERSION*",
         "src/libmongoc/src/libmongoc/src/mongoc/*.{c,def,defs,h,h.in}",
         "src/libmongoc/src/zlib-1.*/*.{c,h,h.in}",
+        "src/libmongoc/src/utf8proc-2.*/*.{c,h}",
         "src/libmongoc/VERSION*",
 
         "src/libmongocrypt-compat/*.{c,h}",


### PR DESCRIPTION
Discovered while testing #1483 and building a PECL package.