### PR TITLE
PHPC-2328: Use correct parameter name for classes implementing ArrayAccess

### DIFF
--- a/src/BSON/Document.stub.php
+++ b/src/BSON/Document.stub.php
@@ -45,37 +45,37 @@ final class Document implements \IteratorAggregate, \Serializable, \ArrayAccess,
     final public function toRelaxedExtendedJSON(): string {}
 
 #if PHP_VERSION_ID >= 80000
-    public function offsetExists(mixed $key): bool {}
+    public function offsetExists(mixed $offset): bool {}
 # else
-    /** @param mixed $key */
-    public function offsetExists($key): bool {}
+    /** @param mixed $offset */
+    public function offsetExists($offset): bool {}
 # endif
 
 #if PHP_VERSION_ID >= 80000
-    public function offsetGet(mixed $key): mixed {}
+    public function offsetGet(mixed $offset): mixed {}
 # else
     /**
-     * @param mixed $key
+     * @param mixed $offset
      * @return mixed
      */
-    public function offsetGet($key) {}
+    public function offsetGet($offset) {}
 # endif
 
 #if PHP_VERSION_ID >= 80000
-    public function offsetSet(mixed $key, mixed $value): void {}
+    public function offsetSet(mixed $offset, mixed $value): void {}
 # else
     /**
-     * @param mixed $key
+     * @param mixed $offset
      * @param mixed $value
      */
-    public function offsetSet($key, $value): void {}
+    public function offsetSet($offset, $value): void {}
 # endif
 
 #if PHP_VERSION_ID >= 80000
-    public function offsetUnset(mixed $key): void {}
+    public function offsetUnset(mixed $offset): void {}
 # else
-    /** @param mixed $key */
-    public function offsetUnset($key): void {}
+    /** @param mixed $offset */
+    public function offsetUnset($offset): void {}
 # endif
 
     final public function __toString(): string {}

--- a/src/BSON/Document_arginfo.h
+++ b/src/BSON/Document_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 10280ca319e69b9e6126002d7089ecaeb01650b1 */
+ * Stub hash: 54b11bb7d4058f4f279b2df828650b5eb1225882 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_Document___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -62,51 +62,51 @@ ZEND_END_ARG_INFO()
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Document_offsetExists, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, key, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO(0, offset, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if !(PHP_VERSION_ID >= 80000)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Document_offsetExists, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO(0, offset)
 ZEND_END_ARG_INFO()
 #endif
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Document_offsetGet, 0, 1, IS_MIXED, 0)
-	ZEND_ARG_TYPE_INFO(0, key, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO(0, offset, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if !(PHP_VERSION_ID >= 80000)
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_Document_offsetGet, 0, 0, 1)
-	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO(0, offset)
 ZEND_END_ARG_INFO()
 #endif
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Document_offsetSet, 0, 2, IS_VOID, 0)
-	ZEND_ARG_TYPE_INFO(0, key, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO(0, offset, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if !(PHP_VERSION_ID >= 80000)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Document_offsetSet, 0, 2, IS_VOID, 0)
-	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO(0, offset)
 	ZEND_ARG_INFO(0, value)
 ZEND_END_ARG_INFO()
 #endif
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Document_offsetUnset, 0, 1, IS_VOID, 0)
-	ZEND_ARG_TYPE_INFO(0, key, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO(0, offset, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if !(PHP_VERSION_ID >= 80000)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Document_offsetUnset, 0, 1, IS_VOID, 0)
-	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO(0, offset)
 ZEND_END_ARG_INFO()
 #endif
 

--- a/src/BSON/PackedArray.stub.php
+++ b/src/BSON/PackedArray.stub.php
@@ -32,37 +32,37 @@ final class PackedArray implements \IteratorAggregate, \Serializable, \ArrayAcce
 #endif
 
 #if PHP_VERSION_ID >= 80000
-    public function offsetExists(mixed $key): bool {}
+    public function offsetExists(mixed $offset): bool {}
 # else
-    /** @param mixed $key */
-    public function offsetExists($key): bool {}
+    /** @param mixed $offset */
+    public function offsetExists($offset): bool {}
 # endif
 
 #if PHP_VERSION_ID >= 80000
-    public function offsetGet(mixed $key): mixed {}
+    public function offsetGet(mixed $offset): mixed {}
 # else
     /**
-     * @param mixed $key
+     * @param mixed $offset
      * @return mixed
      */
-    public function offsetGet($key) {}
+    public function offsetGet($offset) {}
 # endif
 
 #if PHP_VERSION_ID >= 80000
-    public function offsetSet(mixed $key, mixed $value): void {}
+    public function offsetSet(mixed $offset, mixed $value): void {}
 # else
     /**
-     * @param mixed $key
+     * @param mixed $offset
      * @param mixed $value
      */
-    public function offsetSet($key, $value): void {}
+    public function offsetSet($offset, $value): void {}
 # endif
 
 #if PHP_VERSION_ID >= 80000
-    public function offsetUnset(mixed $key): void {}
+    public function offsetUnset(mixed $offset): void {}
 # else
-    /** @param mixed $key */
-    public function offsetUnset($key): void {}
+    /** @param mixed $offset */
+    public function offsetUnset($offset): void {}
 # endif
 
     final public function __toString(): string {}

--- a/src/BSON/PackedArray_arginfo.h
+++ b/src/BSON/PackedArray_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 0f153948c7083074dfeb4f6fafd7b561aa2fc37b */
+ * Stub hash: db49af73e3b8ef35fa6ed70fd8c097e0de69f17e */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_PackedArray___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -41,51 +41,51 @@ ZEND_END_ARG_INFO()
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_PackedArray_offsetExists, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, key, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO(0, offset, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if !(PHP_VERSION_ID >= 80000)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_PackedArray_offsetExists, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO(0, offset)
 ZEND_END_ARG_INFO()
 #endif
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_PackedArray_offsetGet, 0, 1, IS_MIXED, 0)
-	ZEND_ARG_TYPE_INFO(0, key, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO(0, offset, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if !(PHP_VERSION_ID >= 80000)
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_PackedArray_offsetGet, 0, 0, 1)
-	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO(0, offset)
 ZEND_END_ARG_INFO()
 #endif
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_PackedArray_offsetSet, 0, 2, IS_VOID, 0)
-	ZEND_ARG_TYPE_INFO(0, key, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO(0, offset, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if !(PHP_VERSION_ID >= 80000)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_PackedArray_offsetSet, 0, 2, IS_VOID, 0)
-	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO(0, offset)
 	ZEND_ARG_INFO(0, value)
 ZEND_END_ARG_INFO()
 #endif
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_PackedArray_offsetUnset, 0, 1, IS_VOID, 0)
-	ZEND_ARG_TYPE_INFO(0, key, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO(0, offset, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if !(PHP_VERSION_ID >= 80000)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_PackedArray_offsetUnset, 0, 1, IS_VOID, 0)
-	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO(0, offset)
 ZEND_END_ARG_INFO()
 #endif
 


### PR DESCRIPTION
PHPC-2328

I believe this change is safe enough to go in a patch release. Keeping parameter names consistent with the interface allows people to rely on named arguments, even though they are unlikely to do so for these classes. Also, static analysis tools like Psalm check parameter names and report errors if they mismatch.