### PR TITLE
PHPC-2337: Fix performance regression due to trace logging

### DIFF
--- a/php_phongo.c
+++ b/php_phongo.c
@@ -177,6 +177,10 @@ PHP_MINIT_FUNCTION(mongodb) /* {{{ */
 	 * a logger. */
 	mongoc_log_set_handler(NULL, NULL);
 
+	/* Disable trace logging. This will be enabled in phongo_log_sync_handlers()
+	 * if the "mongodb.debug" INI option is set. */
+	mongoc_log_trace_disable();
+
 	phongo_register_ini_entries(INIT_FUNC_ARGS_PASSTHRU);
 
 	/* Assign our custom vtable to libbson, so all memory allocation in libbson


### PR DESCRIPTION
PHPC-2337

Fixes #1501.

This adds a call to `mongoc_log_trace_disable()` in the extension's `MINIT` function. Since we always compile with trace-level logging (which is emitted when the `mongodb.debug` setting is enabled), libmongoc starts out with trace logging enabled. While we disable trace logging in `phongo_log_sync_handlers()`, this function is not called if `mongodb.debug` is not set, thus leaving trace logging enabled and causing significant overhead due to message preparation.

Now, trace logging starts out as disabled and will be enabled when `phongo_log_sync_handlers()` is called, either due to adding a log subscriber to a manager or due to the INI setting being enabled and us storing a file handle the debug log gets written to.

I've confirmed that the performance increases again - a bulk write that took 1.9 seconds without the change now completes in 0.02 seconds. However, due to the difficulty of measuring the performance in CI systems, I did not add the test. We will manually verify the improvements by observing the results of the performance test suite contained in PHPLIB.