### PR TITLE
Update submodule sources when building driver

### DIFF
--- a/.evergreen/compile-unix.sh
+++ b/.evergreen/compile-unix.sh
@@ -65,6 +65,11 @@ esac
 # Report the current PHP version
 echo "PHP: `php --version | head -n 1`"
 
+# If we're testing a specific version of libmongoc, update submodule sources
+if [ -n "$LIBMONGOC_VERSION" ]; then
+   php scripts/update-submodule-sources.php
+fi
+
 phpize
 ./configure --enable-mongodb-developer-flags
 

--- a/.evergreen/compile-unix.sh
+++ b/.evergreen/compile-unix.sh
@@ -73,9 +73,11 @@ fi
 phpize
 ./configure --enable-mongodb-developer-flags
 
-# If we're testing a specific version of libmongoc, regenerate the version file
+# configure relies on version information in libmongoc-version-current, but the target is not available until after calling configure
+# To work around this, run the make target, then run configure again
 if [ -n "$LIBMONGOC_VERSION" ]; then
    make libmongoc-version-current
+  ./configure --enable-mongodb-developer-flags
 fi
 
 make test TESTS="tests/smoketest.phpt"


### PR DESCRIPTION
This PR adds a call to update-submodule-sources.php when compiling against a different version of libmongoc than the bundled one. This helps avoid "symbol not found" errors when compiling with libmongoc latest with new files not included in the bundled stable release.