### PR TITLE
Disable fail-fast for Windows Tests

### DIFF
--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -86,6 +86,8 @@ jobs:
         shell: cmd
 
     strategy:
+      # Timeouts starting the MongoDB service are common and should not
+      # interrupt the overall test matrix.
       fail-fast: false
       matrix:
         php: [ "7.4", "8.0", "8.1", "8.2", "8.3" ]

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -86,7 +86,7 @@ jobs:
         shell: cmd
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         php: [ "7.4", "8.0", "8.1", "8.2", "8.3" ]
         arch: [ x64, x86 ]


### PR DESCRIPTION
Since Windows tests often suffer from long startup times of the MongoDB daemon, the failure of a single job cancels the entire workflow. Disabling `fail-fast` will prevent this and help get at least some test coverage without restarting all builds.