### PR TITLE
PHPC-2382: Allow static builds with php-src

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -529,6 +529,7 @@ mongodb was configured with the following options:
 Build configuration:
   CC                                               : $CC
   CFLAGS                                           : $CFLAGS
+  CPPFLAGS                                         : $CPPFLAGS
   Extra flags                                      : $PHP_MONGODB_STD_CFLAGS
   Developer flags (slow)                           : $PHP_MONGODB_DEV_CFLAGS
   Code Coverage flags (extra slow                  : $PHP_MONGODB_COVERAGE_CFLAGS

--- a/config.m4
+++ b/config.m4
@@ -532,7 +532,7 @@ Build configuration:
   CPPFLAGS                                         : $CPPFLAGS
   Extra flags                                      : $PHP_MONGODB_STD_CFLAGS
   Developer flags (slow)                           : $PHP_MONGODB_DEV_CFLAGS
-  Code Coverage flags (extra slow                  : $PHP_MONGODB_COVERAGE_CFLAGS
+  Code Coverage flags (extra slow)                 : $PHP_MONGODB_COVERAGE_CFLAGS
   libmongoc                                        : $PHP_MONGODB_BSON_VERSION_STRING
   libbson                                          : $PHP_MONGODB_MONGOC_VERSION_STRING
   libmongocrypt                                    : $PHP_MONGODB_MONGOCRYPT_VERSION_STRING

--- a/config.m4
+++ b/config.m4
@@ -521,7 +521,6 @@ if test "$PHP_MONGODB" != "no"; then
   dnl This must come after PHP_NEW_EXTENSION, otherwise the srcdir won't be set
   PHP_ADD_MAKEFILE_FRAGMENT
 
-  dnl The libmongocrypt line intentionally uses the PHP_LIBBSON flag as that decides whether to build against bundled or system libraries.
   AC_CONFIG_COMMANDS_POST([
     if test "$enable_static" = "no"; then
       echo "

--- a/config.m4
+++ b/config.m4
@@ -24,12 +24,17 @@ if test "$PHP_MONGODB" != "no"; then
   dnl Check PHP version is compatible with this extension
   AC_MSG_CHECKING([PHP version])
 
-  if test -z "$PHP_CONFIG"; then
-    AC_MSG_ERROR([php-config not found])
-  fi
+  if test -z "${PHP_VERSION_ID}"; then
+    if test -z "$PHP_CONFIG"; then
+      AC_MSG_ERROR([php-config not found])
+    fi
 
-  PHP_MONGODB_PHP_VERSION=`${PHP_CONFIG} --version`
-  PHP_MONGODB_PHP_VERSION_ID=`${PHP_CONFIG} --vernum`
+    PHP_MONGODB_PHP_VERSION=`${PHP_CONFIG} --version`
+    PHP_MONGODB_PHP_VERSION_ID=`${PHP_CONFIG} --vernum`
+  else
+    PHP_MONGODB_PHP_VERSION="${PHP_VERSION}"
+    PHP_MONGODB_PHP_VERSION_ID="${PHP_VERSION_ID}"
+  fi
 
   AC_MSG_RESULT($PHP_MONGODB_PHP_VERSION)
 

--- a/config.m4
+++ b/config.m4
@@ -323,6 +323,9 @@ if test "$PHP_MONGODB" != "no"; then
     dnl Endian.m4 will modify this when using bundled libmongocrypt
     PHP_MONGODB_LIBMONGOCRYPT_CFLAGS=""
 
+    dnl Save CPPFLAGS, which PlatformFlags.m4 modifies for subsequent M4 scripts
+    old_CPPFLAGS="$CPPFLAGS"
+
     dnl Avoid using AC_CONFIG_MACRO_DIR, which might conflict with PHP
     m4_include(PHP_MONGODB_BASEDIR/scripts/autotools/m4/ax_check_compile_flag.m4)
     m4_include(PHP_MONGODB_BASEDIR/scripts/autotools/m4/ax_prototype.m4)
@@ -354,6 +357,9 @@ if test "$PHP_MONGODB" != "no"; then
     m4_include(PHP_MONGODB_BASEDIR/scripts/autotools/libmongocrypt/CheckSSL.m4)
     m4_include(PHP_MONGODB_BASEDIR/scripts/autotools/libmongocrypt/Endian.m4)
     m4_include(PHP_MONGODB_BASEDIR/scripts/autotools/libmongocrypt/Version.m4)
+
+    dnl Restore CPPFLAGS once all M4 scripts have executed
+    CPPFLAGS="$old_CPPFLAGS"
 
     PHP_MONGODB_BSON_VERSION_STRING="Bundled ($libbson_VERSION_FULL)"
     PHP_MONGODB_MONGOC_VERSION_STRING="Bundled ($libmongoc_VERSION_FULL)"

--- a/config.m4
+++ b/config.m4
@@ -42,6 +42,10 @@ if test "$PHP_MONGODB" != "no"; then
     AC_MSG_ERROR([not supported. Need a PHP version >= 7.4.0 (found $PHP_MONGODB_PHP_VERSION)])
   fi
 
+  PHP_MONGODB_STD_CFLAGS=""
+  PHP_MONGODB_DEV_CFLAGS=""
+  PHP_MONGODB_COVERAGE_CFLAGS=""
+
   PHP_ARG_ENABLE([mongodb-developer-flags],
                  [whether to enable developer build flags],
                  [AS_HELP_STRING([--enable-mongodb-developer-flags],
@@ -51,54 +55,53 @@ if test "$PHP_MONGODB" != "no"; then
   PHP_MONGODB_VALIDATE_ARG([PHP_MONGODB_DEVELOPER_FLAGS], [yes no])
 
   if test "$PHP_MONGODB_DEVELOPER_FLAGS" = "yes"; then
+    PHP_MONGODB_STD_CFLAGS="-g -O0 -Wall"
+
     dnl Warn about functions which might be candidates for format attributes
-    AX_CHECK_COMPILE_FLAG(-Wmissing-format-attribute,       _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wmissing-format-attribute"     ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wmissing-format-attribute,       PHP_MONGODB_DEV_CFLAGS="$PHP_MONGODB_DEV_CFLAGS -Wmissing-format-attribute"     ,, -Werror)
     dnl Avoid duplicating values for an enum
-    AX_CHECK_COMPILE_FLAG(-Wduplicate-enum,                 _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wduplicate-enum"               ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wduplicate-enum,                 PHP_MONGODB_DEV_CFLAGS="$PHP_MONGODB_DEV_CFLAGS -Wduplicate-enum"               ,, -Werror)
     dnl Warns on mismatches between #ifndef and #define header guards
-    AX_CHECK_COMPILE_FLAG(-Wheader-guard,                   _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wheader-guard"                 ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wheader-guard,                   PHP_MONGODB_DEV_CFLAGS="$PHP_MONGODB_DEV_CFLAGS -Wheader-guard"                 ,, -Werror)
     dnl logical not of a non-boolean expression
-    AX_CHECK_COMPILE_FLAG(-Wlogical-not-parentheses,        _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wlogical-not-parentheses"      ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wlogical-not-parentheses,        PHP_MONGODB_DEV_CFLAGS="$PHP_MONGODB_DEV_CFLAGS -Wlogical-not-parentheses"      ,, -Werror)
     dnl Warn about suspicious uses of logical operators in expressions
-    AX_CHECK_COMPILE_FLAG(-Wlogical-op,                     _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wlogical-op"                   ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wlogical-op,                     PHP_MONGODB_DEV_CFLAGS="$PHP_MONGODB_DEV_CFLAGS -Wlogical-op"                   ,, -Werror)
     dnl memory error detector.
     dnl FIXME: -fsanitize=address,undefined for clang. The AX_CHECK_COMPILE_FLAG macro isn't happy about that string :(
-    AX_CHECK_COMPILE_FLAG(-fsanitize-address,               _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -fsanitize-address"             ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-fsanitize-address,               PHP_MONGODB_DEV_CFLAGS="$PHP_MONGODB_DEV_CFLAGS -fsanitize-address"             ,, -Werror)
     dnl Enable frame debugging
-    AX_CHECK_COMPILE_FLAG(-fno-omit-frame-pointer,          _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -fno-omit-frame-pointer"        ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-fno-omit-frame-pointer,          PHP_MONGODB_DEV_CFLAGS="$PHP_MONGODB_DEV_CFLAGS -fno-omit-frame-pointer"        ,, -Werror)
     dnl Make sure we don't optimize calls
-    AX_CHECK_COMPILE_FLAG(-fno-optimize-sibling-calls,      _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -fno-optimize-sibling-calls"    ,, -Werror)
-    AX_CHECK_COMPILE_FLAG(-Wlogical-op-parentheses,         _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wlogical-op-parentheses"       ,, -Werror)
-    AX_CHECK_COMPILE_FLAG(-Wpointer-bool-conversion,        _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wpointer-bool-conversion"      ,, -Werror)
-    AX_CHECK_COMPILE_FLAG(-Wbool-conversion,                _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wbool-conversion"              ,, -Werror)
-    AX_CHECK_COMPILE_FLAG(-Wloop-analysis,                  _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wloop-analysis"                ,, -Werror)
-    AX_CHECK_COMPILE_FLAG(-Wsizeof-array-argument,          _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wsizeof-array-argument"        ,, -Werror)
-    AX_CHECK_COMPILE_FLAG(-Wstring-conversion,              _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wstring-conversion"            ,, -Werror)
-    AX_CHECK_COMPILE_FLAG(-Wno-variadic-macros,             _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wno-variadic-macros"           ,, -Werror)
-    AX_CHECK_COMPILE_FLAG(-Wno-sign-compare,                _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wno-sign-compare"              ,, -Werror)
-    AX_CHECK_COMPILE_FLAG(-fstack-protector,                _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -fstack-protector"              ,, -Werror)
-    AX_CHECK_COMPILE_FLAG(-fno-exceptions,                  _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -fno-exceptions"                ,, -Werror)
-    AX_CHECK_COMPILE_FLAG(-Wformat-security,                _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wformat-security"              ,, -Werror)
-    AX_CHECK_COMPILE_FLAG(-Wformat-nonliteral,              _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wformat-nonliteral"            ,, -Werror)
-    AX_CHECK_COMPILE_FLAG(-Winit-self,                      _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Winit-self"                    ,, -Werror)
-    AX_CHECK_COMPILE_FLAG(-Wwrite-strings,                  _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wwrite-strings"                ,, -Werror)
-    AX_CHECK_COMPILE_FLAG(-Wenum-compare,                   _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wenum-compare"                 ,, -Werror)
-    AX_CHECK_COMPILE_FLAG(-Wempty-body,                     _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wempty-body"                   ,, -Werror)
-    AX_CHECK_COMPILE_FLAG(-Wparentheses,                    _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wparentheses"                  ,, -Werror)
-    AX_CHECK_COMPILE_FLAG(-Wmaybe-uninitialized,            _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wmaybe-uninitialized"          ,, -Werror)
-    AX_CHECK_COMPILE_FLAG(-Wimplicit-fallthrough,           _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wimplicit-fallthrough"         ,, -Werror)
-    AX_CHECK_COMPILE_FLAG(-Werror,                          _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Werror"                        ,, -Werror)
-    AX_CHECK_COMPILE_FLAG(-Wextra,                          _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wextra"                        ,, -Werror)
-    AX_CHECK_COMPILE_FLAG(-Wno-unused-parameter,            _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wno-unused-parameter"          ,, -Werror)
-    AX_CHECK_COMPILE_FLAG(-Wno-unused-but-set-variable,     _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wno-unused-but-set-variable"   ,, -Werror)
-    AX_CHECK_COMPILE_FLAG(-Wno-missing-field-initializers,  _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wno-missing-field-initializers",, -Werror)
+    AX_CHECK_COMPILE_FLAG(-fno-optimize-sibling-calls,      PHP_MONGODB_DEV_CFLAGS="$PHP_MONGODB_DEV_CFLAGS -fno-optimize-sibling-calls"    ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wlogical-op-parentheses,         PHP_MONGODB_DEV_CFLAGS="$PHP_MONGODB_DEV_CFLAGS -Wlogical-op-parentheses"       ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wpointer-bool-conversion,        PHP_MONGODB_DEV_CFLAGS="$PHP_MONGODB_DEV_CFLAGS -Wpointer-bool-conversion"      ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wbool-conversion,                PHP_MONGODB_DEV_CFLAGS="$PHP_MONGODB_DEV_CFLAGS -Wbool-conversion"              ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wloop-analysis,                  PHP_MONGODB_DEV_CFLAGS="$PHP_MONGODB_DEV_CFLAGS -Wloop-analysis"                ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wsizeof-array-argument,          PHP_MONGODB_DEV_CFLAGS="$PHP_MONGODB_DEV_CFLAGS -Wsizeof-array-argument"        ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wstring-conversion,              PHP_MONGODB_DEV_CFLAGS="$PHP_MONGODB_DEV_CFLAGS -Wstring-conversion"            ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wno-variadic-macros,             PHP_MONGODB_DEV_CFLAGS="$PHP_MONGODB_DEV_CFLAGS -Wno-variadic-macros"           ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wno-sign-compare,                PHP_MONGODB_DEV_CFLAGS="$PHP_MONGODB_DEV_CFLAGS -Wno-sign-compare"              ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-fstack-protector,                PHP_MONGODB_DEV_CFLAGS="$PHP_MONGODB_DEV_CFLAGS -fstack-protector"              ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-fno-exceptions,                  PHP_MONGODB_DEV_CFLAGS="$PHP_MONGODB_DEV_CFLAGS -fno-exceptions"                ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wformat-security,                PHP_MONGODB_DEV_CFLAGS="$PHP_MONGODB_DEV_CFLAGS -Wformat-security"              ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wformat-nonliteral,              PHP_MONGODB_DEV_CFLAGS="$PHP_MONGODB_DEV_CFLAGS -Wformat-nonliteral"            ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Winit-self,                      PHP_MONGODB_DEV_CFLAGS="$PHP_MONGODB_DEV_CFLAGS -Winit-self"                    ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wwrite-strings,                  PHP_MONGODB_DEV_CFLAGS="$PHP_MONGODB_DEV_CFLAGS -Wwrite-strings"                ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wenum-compare,                   PHP_MONGODB_DEV_CFLAGS="$PHP_MONGODB_DEV_CFLAGS -Wenum-compare"                 ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wempty-body,                     PHP_MONGODB_DEV_CFLAGS="$PHP_MONGODB_DEV_CFLAGS -Wempty-body"                   ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wparentheses,                    PHP_MONGODB_DEV_CFLAGS="$PHP_MONGODB_DEV_CFLAGS -Wparentheses"                  ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wmaybe-uninitialized,            PHP_MONGODB_DEV_CFLAGS="$PHP_MONGODB_DEV_CFLAGS -Wmaybe-uninitialized"          ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wimplicit-fallthrough,           PHP_MONGODB_DEV_CFLAGS="$PHP_MONGODB_DEV_CFLAGS -Wimplicit-fallthrough"         ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Werror,                          PHP_MONGODB_DEV_CFLAGS="$PHP_MONGODB_DEV_CFLAGS -Werror"                        ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wextra,                          PHP_MONGODB_DEV_CFLAGS="$PHP_MONGODB_DEV_CFLAGS -Wextra"                        ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wno-unused-parameter,            PHP_MONGODB_DEV_CFLAGS="$PHP_MONGODB_DEV_CFLAGS -Wno-unused-parameter"          ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wno-unused-but-set-variable,     PHP_MONGODB_DEV_CFLAGS="$PHP_MONGODB_DEV_CFLAGS -Wno-unused-but-set-variable"   ,, -Werror)
+    AX_CHECK_COMPILE_FLAG(-Wno-missing-field-initializers,  PHP_MONGODB_DEV_CFLAGS="$PHP_MONGODB_DEV_CFLAGS -Wno-missing-field-initializers",, -Werror)
 
     if test "$PHP_MONGODB_PHP_VERSION_ID" -ge "80108"; then
-      AX_CHECK_COMPILE_FLAG(-Wstrict-prototypes, _MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS -Wstrict-prototypes",, -Werror)
+      AX_CHECK_COMPILE_FLAG(-Wstrict-prototypes, PHP_MONGODB_DEV_CFLAGS="$PHP_MONGODB_DEV_CFLAGS -Wstrict-prototypes",, -Werror)
     fi
-
-    MAINTAINER_CFLAGS="$_MAINTAINER_CFLAGS"
-    STD_CFLAGS="-g -O0 -Wall"
   fi
 
 
@@ -115,13 +118,11 @@ if test "$PHP_MONGODB" != "no"; then
       AC_MSG_ERROR(code coverage is not supported for static builds)
     fi
 
-    COVERAGE_CFLAGS="--coverage -g"
-    COVERAGE_LDFLAGS="--coverage"
-
-    MONGODB_SHARED_LIBADD="$MONGODB_SHARED_LIBADD $COVERAGE_LDFLAGS"
+    PHP_MONGODB_COVERAGE_CFLAGS="--coverage -g"
+    MONGODB_SHARED_LIBADD="$MONGODB_SHARED_LIBADD --coverage"
   fi
 
-  PHP_MONGODB_CFLAGS="$STD_CFLAGS $MAINTAINER_CFLAGS $COVERAGE_CFLAGS"
+  PHP_MONGODB_CFLAGS="$PHP_MONGODB_STD_CFLAGS $PHP_MONGODB_DEV_CFLAGS $PHP_MONGODB_COVERAGE_CFLAGS"
 
   PHP_MONGODB_SOURCES="\
     php_phongo.c \
@@ -312,7 +313,7 @@ if test "$PHP_MONGODB" != "no"; then
   fi
 
   if test "$PHP_MONGODB_SYSTEM_LIBS" = "no"; then
-    PHP_MONGODB_BUNDLED_CFLAGS="$STD_CFLAGS -DBSON_COMPILATION -DMONGOC_COMPILATION"
+    PHP_MONGODB_BUNDLED_CFLAGS="$PHP_MONGODB_STD_CFLAGS -DBSON_COMPILATION -DMONGOC_COMPILATION"
 
     dnl CheckUtf8Proc.m4 will modify this when using bundled utf8proc
     PHP_MONGODB_UTF8PROC_CFLAGS=""
@@ -529,9 +530,9 @@ mongodb was configured with the following options:
 Build configuration:
   CC                                               : $CC
   CFLAGS                                           : $CFLAGS
-  Extra CFLAGS                                     : $STD_CFLAGS $EXTRA_CFLAGS
-  Developers flags (slow)                          : $MAINTAINER_CFLAGS
-  Code Coverage flags (extra slow)                 : $COVERAGE_CFLAGS
+  Extra flags                                      : $PHP_MONGODB_STD_CFLAGS
+  Developer flags (slow)                           : $PHP_MONGODB_DEV_CFLAGS
+  Code Coverage flags (extra slow                  : $PHP_MONGODB_COVERAGE_CFLAGS
   libmongoc                                        : $PHP_MONGODB_BSON_VERSION_STRING
   libbson                                          : $PHP_MONGODB_MONGOC_VERSION_STRING
   libmongocrypt                                    : $PHP_MONGODB_MONGOCRYPT_VERSION_STRING

--- a/scripts/autotools/CheckCompiler.m4
+++ b/scripts/autotools/CheckCompiler.m4
@@ -16,6 +16,7 @@ dnl so call it once more to ensure C99 remains enabled
 m4_version_prereq([2.70],,[AC_PROG_CC_C99])
 
 # Check that an appropriate C compiler is available.
+# Note: BEGIN_IGNORE_DEPRECATIONS macro requires GCC 4.6+.
 c_compiler="unknown"
 AC_LANG_PUSH([C])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
@@ -26,25 +27,11 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
 #define GCC_VERSION (__GNUC__ * 10000 \
                      + __GNUC_MINOR__ * 100 \
                      + __GNUC_PATCHLEVEL__)
-#if GCC_VERSION < 40100
+#if GCC_VERSION < 40600
 #error Not a supported GCC compiler
 #endif
 #endif
 ])], [c_compiler="gcc"], [])
-
-# If our BEGIN_IGNORE_DEPRECATIONS macro won't work, pass
-# -Wno-deprecated-declarations
-
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
-#if !defined(__clang__) && defined(__GNUC__)
-#define GCC_VERSION (__GNUC__ * 10000 \
-                     + __GNUC_MINOR__ * 100 \
-                     + __GNUC_PATCHLEVEL__)
-#if GCC_VERSION < 40600
-#error Does not support deprecation warning pragmas
-#endif
-#endif
-])], [], [STD_CFLAGS="$STD_CFLAGS -Wno-deprecated-declarations"])
 
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
 #if defined(__clang__)
@@ -65,7 +52,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
 AC_LANG_POP([C])
 
 if test "$c_compiler" = "unknown"; then
-    AC_MSG_ERROR([Compiler GCC >= 4.1 or Clang >= 3.3 is required for C compilation])
+    AC_MSG_ERROR([Compiler GCC >= 4.6 or Clang >= 3.3 is required for C compilation])
 fi
 
 AC_C_CONST

--- a/scripts/autotools/PlatformFlags.m4
+++ b/scripts/autotools/PlatformFlags.m4
@@ -18,12 +18,4 @@ AS_IF([test "$os_darwin" = "yes"],[
     dnl https://opensource.apple.com/source/Libc/Libc-1439.40.11/gen/compat.5.auto.html
     CPPFLAGS="$CPPFLAGS -D_DARWIN_C_SOURCE"
     PHP_MONGODB_BUNDLED_CFLAGS="$PHP_MONGODB_BUNDLED_CFLAGS -D_DARWIN_C_SOURCE"
-
-    dnl Ignore OpenSSL deprecation warnings on OSX
-    AX_CHECK_COMPILE_FLAG([-Wno-deprecated-declarations], [STD_CFLAGS="$STD_CFLAGS -Wno-deprecated-declarations"])
-
-    dnl We know there are some cast-align issues on OSX
-    AX_CHECK_COMPILE_FLAG([-Wno-cast-align], [STD_CFLAGS="$STD_CFLAGS -Wno-cast-align"])
-    AX_CHECK_COMPILE_FLAG([-Wno-unneeded-internal-declaration], [STD_CFLAGS="$STD_CFLAGS -Wno-unneeded-internal-declaration"])
-    AX_CHECK_COMPILE_FLAG([-Wno-error=unused-command-line-argument], [STD_CFLAGS="$STD_CFLAGS -Wno-error=unused-command-line-argument"])
 ])

--- a/src/libmongocrypt-compat/mongocrypt/mongocrypt.h
+++ b/src/libmongocrypt-compat/mongocrypt/mongocrypt.h
@@ -20,9 +20,7 @@
 /* This header forwards includes for "mongocrypt/mongocrypt.h" to the desired
  * header in the bundled libmongocrypt submodule. This is used when compiling
  * bundled versions of libmongoc and libmongocrypt and is necessary because
- * libmongocrypt's source directory is not named "mongocrypt/".
- *
- * This path is relative to the PHPC project directory to avoid ambiguity. */
-#include "src/libmongocrypt/src/mongocrypt.h"
+ * libmongocrypt's source directory is not named "mongocrypt/". */
+#include "libmongocrypt/src/mongocrypt.h"
 
 #endif /* PHONGO_COMPAT_MONGOCRYPT_H */


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-2382

Prefer PHP_VERSION_ID for static builds, and fall back to invoking php-config otherwise.

mongocrypt.h previously used a path relative to the PHPC project root, which is not compatible with static builds. The current path is relative to src/, which is explicitly defined as an include path in config.m4.

Related: https://github.com/mongodb/mongo-php-driver/issues/1549