### PR TITLE
Use stable version of release tooling

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -44,7 +44,7 @@ jobs:
           echo "PACKAGE_FILE=mongodb-${PACKAGE_VERSION}.tgz" >> "$GITHUB_ENV"
 
       - name: "Create detached signature for PECL package"
-        uses: mongodb-labs/drivers-github-tools/garasign/gpg-sign@main
+        uses: mongodb-labs/drivers-github-tools/garasign/gpg-sign@v1
         with:
           filenames: ${{ env.PACKAGE_FILE }}
           garasign_username: ${{ secrets.GRS_CONFIG_USER1_USERNAME }}
@@ -146,7 +146,7 @@ jobs:
             php_mongodb.pdb
 
       - name: "Create detached DLL signature"
-        uses: mongodb-labs/drivers-github-tools/garasign/gpg-sign@main
+        uses: mongodb-labs/drivers-github-tools/garasign/gpg-sign@v1
         with:
           filenames: php_mongodb.dll
           garasign_username: ${{ secrets.GRS_CONFIG_USER1_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
       # our tag and creates the release tag. This is run inside the container in
       # order to create signed git artifacts
       - name: "Create package commit and release tag"
-        uses: mongodb-labs/drivers-github-tools/garasign/git-sign@main
+        uses: mongodb-labs/drivers-github-tools/garasign/git-sign@v1
         with:
           command: "$(pwd)/.github/workflows/commit-and-tag.sh ${{ env.PACKAGE_VERSION }} ${{ vars.GPG_KEY_ID }} tag-message"
           garasign_username: ${{ secrets.GRS_CONFIG_USER1_USERNAME }}
@@ -121,7 +121,7 @@ jobs:
 
       # Create a signed "back to -dev" commit, again inside the container
       - name: "Create dev commit"
-        uses: mongodb-labs/drivers-github-tools/garasign/git-sign@main
+        uses: mongodb-labs/drivers-github-tools/garasign/git-sign@v1
         with:
           # Setup can be skipped as it was already done before
           skip_setup: true


### PR DESCRIPTION
With significant changes being introduced to the release tooling in the shared repository, we should rely on a tagged version of those release tools.