### PR TITLE
Revert "Bump mongodb-labs/drivers-github-tools from 1 to 2"

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -44,7 +44,7 @@ jobs:
           echo "PACKAGE_FILE=mongodb-${PACKAGE_VERSION}.tgz" >> "$GITHUB_ENV"
 
       - name: "Create detached signature for PECL package"
-        uses: mongodb-labs/drivers-github-tools/garasign/gpg-sign@v2
+        uses: mongodb-labs/drivers-github-tools/garasign/gpg-sign@v1
         with:
           filenames: ${{ env.PACKAGE_FILE }}
           garasign_username: ${{ secrets.GRS_CONFIG_USER1_USERNAME }}
@@ -146,7 +146,7 @@ jobs:
             php_mongodb.pdb
 
       - name: "Create detached DLL signature"
-        uses: mongodb-labs/drivers-github-tools/garasign/gpg-sign@v2
+        uses: mongodb-labs/drivers-github-tools/garasign/gpg-sign@v1
         with:
           filenames: php_mongodb.dll
           garasign_username: ${{ secrets.GRS_CONFIG_USER1_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
       # our tag and creates the release tag. This is run inside the container in
       # order to create signed git artifacts
       - name: "Create package commit and release tag"
-        uses: mongodb-labs/drivers-github-tools/garasign/git-sign@v2
+        uses: mongodb-labs/drivers-github-tools/garasign/git-sign@v1
         with:
           command: "$(pwd)/.github/workflows/commit-and-tag.sh ${{ env.PACKAGE_VERSION }} ${{ vars.GPG_KEY_ID }} tag-message"
           garasign_username: ${{ secrets.GRS_CONFIG_USER1_USERNAME }}
@@ -121,7 +121,7 @@ jobs:
 
       # Create a signed "back to -dev" commit, again inside the container
       - name: "Create dev commit"
-        uses: mongodb-labs/drivers-github-tools/garasign/git-sign@v2
+        uses: mongodb-labs/drivers-github-tools/garasign/git-sign@v1
         with:
           # Setup can be skipped as it was already done before
           skip_setup: true


### PR DESCRIPTION
Reverts mongodb/mongo-php-driver#1568. v2 uses a different setup process to fetch credentials which wouldn't work with our setup. I'll be migrating to v2 separately and have created PHPC-2391 to track this.