### PR TITLE
PHPC-2391: Update drivers tools to v2

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -8,10 +8,24 @@ on:
 
 jobs:
   build-pecl:
+    environment: release
     name: "Create PECL package"
     runs-on: "ubuntu-latest"
+    permissions:
+      id-token: write
 
     steps:
+      - name: "Create temporary app token"
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: "Store GitHub token in environment"
+        run: echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+        shell: bash
+
       - name: "Checkout"
         uses: "actions/checkout@v4"
         with:
@@ -19,6 +33,13 @@ jobs:
           # commit and specifically fetches this to the refs/tags/<tag> ref, which denies us access to the tag message
           ref: ${{ github.ref }}
           submodules: true
+
+      - name: "Set up drivers-github-tools"
+        uses: mongodb-labs/drivers-github-tools/setup@v2
+        with:
+          aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
+          aws_region_name: ${{ vars.AWS_REGION_NAME }}
+          aws_secret_id: ${{ secrets.AWS_SECRET_ID }}
 
       - name: "Build Driver"
         uses: ./.github/actions/linux/build
@@ -44,13 +65,9 @@ jobs:
           echo "PACKAGE_FILE=mongodb-${PACKAGE_VERSION}.tgz" >> "$GITHUB_ENV"
 
       - name: "Create detached signature for PECL package"
-        uses: mongodb-labs/drivers-github-tools/garasign/gpg-sign@v1
+        uses: mongodb-labs/drivers-github-tools/gpg-sign@v2
         with:
           filenames: ${{ env.PACKAGE_FILE }}
-          garasign_username: ${{ secrets.GRS_CONFIG_USER1_USERNAME }}
-          garasign_password: ${{ secrets.GRS_CONFIG_USER1_PASSWORD }}
-          artifactory_username: ${{ secrets.ARTIFACTORY_USER }}
-          artifactory_password: ${{ secrets.ARTIFACTORY_PASSWORD }}
 
       - name: "Install release archive to verify correctness"
         run: sudo pecl install ${{ env.PACKAGE_FILE }}
@@ -67,8 +84,6 @@ jobs:
       - name: "Upload release artifacts"
         run: gh release upload ${{ github.ref_name }} ${{ env.PACKAGE_FILE }} ${{ env.PACKAGE_FILE }}.sig
         continue-on-error: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build-windows:
     name: "Create Windows package"
@@ -117,11 +132,14 @@ jobs:
             php_mongodb.pdb
 
   sign-and-publish-windows:
+    environment: release
     name: "Sign and Publish Windows package"
     needs: [build-windows]
     # ubuntu-latest is required to use enableCrossOsArchive
     # See https://github.com/actions/cache/blob/main/tips-and-workarounds.md#cross-os-cache
     runs-on: "ubuntu-latest"
+    permissions:
+      id-token: write
 
     strategy:
       fail-fast: false
@@ -132,7 +150,25 @@ jobs:
         ts: [ ts, nts ]
 
     steps:
+      - name: "Create temporary app token"
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: "Store GitHub token in environment"
+        run: echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+        shell: bash
+
       - uses: actions/checkout@v4
+
+      - name: "Set up drivers-github-tools"
+        uses: mongodb-labs/drivers-github-tools/setup@v2
+        with:
+          aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
+          aws_region_name: ${{ vars.AWS_REGION_NAME }}
+          aws_secret_id: ${{ secrets.AWS_SECRET_ID }}
 
       - name: Restore cached build artifacts
         id: cache-build-artifacts
@@ -146,13 +182,9 @@ jobs:
             php_mongodb.pdb
 
       - name: "Create detached DLL signature"
-        uses: mongodb-labs/drivers-github-tools/garasign/gpg-sign@v1
+        uses: mongodb-labs/drivers-github-tools/gpg-sign@v2
         with:
           filenames: php_mongodb.dll
-          garasign_username: ${{ secrets.GRS_CONFIG_USER1_USERNAME }}
-          garasign_password: ${{ secrets.GRS_CONFIG_USER1_PASSWORD }}
-          artifactory_username: ${{ secrets.ARTIFACTORY_USER }}
-          artifactory_password: ${{ secrets.ARTIFACTORY_PASSWORD }}
 
       - name: "Upload DLL and PDB files as build artifacts"
         uses: actions/upload-artifact@v4
@@ -175,5 +207,3 @@ jobs:
           zip ${ARCHIVE} php_mongodb.dll php_mongodb.dll.sig php_mongodb.pdb CREDITS CONTRIBUTING.md LICENSE README.md THIRD_PARTY_NOTICES
           gh release upload ${{ github.ref_name }} ${ARCHIVE}
         continue-on-error: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -72,6 +72,11 @@ jobs:
       - name: "Install release archive to verify correctness"
         run: sudo pecl install ${{ env.PACKAGE_FILE }}
 
+      # Copy the signature file from the release asset directory to avoid directory issues in the ZIP file
+      # This can be removed once we're no longer uploading build artifacts
+      - name: "Copy signature file"
+        run: cp ${RELEASE_ASSETS}/${{ env.PACKAGE_FILE }}.sig .
+
       - name: "Upload artifacts"
         uses: actions/upload-artifact@v4
         with:
@@ -185,6 +190,10 @@ jobs:
         uses: mongodb-labs/drivers-github-tools/gpg-sign@v2
         with:
           filenames: php_mongodb.dll
+
+      # Copy the signature file from the release asset directory to avoid directory issues in the ZIP file
+      - name: "Copy signature file"
+        run: cp ${RELEASE_ASSETS}/php_mongodb.dll.sig .
 
       - name: "Upload DLL and PDB files as build artifacts"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,6 @@ on:
         type: "string"
 
 env:
-  # TODO: Use different token
-  GH_TOKEN: ${{ secrets.MERGE_UP_TOKEN }}
-  GIT_AUTHOR_NAME: "DBX PHP Release Bot"
-  GIT_AUTHOR_EMAIL: "dbx-php@mongodb.com"
   default-release-message: |
     The PHP team is happy to announce that version {0} of the [mongodb](https://pecl.php.net/package/mongodb) PHP extension is now available on PECL.
 
@@ -49,17 +45,39 @@ env:
 
 jobs:
   prepare-release:
+    environment: release
     name: "Prepare release"
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
 
     steps:
       - name: "Create release output"
         run: echo '🎬 Release process for version ${{ inputs.version }} started by @${{ github.triggering_actor }}' >> $GITHUB_STEP_SUMMARY
 
+      - name: "Create temporary app token"
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: "Store GitHub token in environment"
+        run: echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+        shell: bash
+
       - uses: actions/checkout@v4
         with:
           submodules: true
           token: ${{ env.GH_TOKEN }}
+
+      - name: "Set up drivers-github-tools"
+        uses: mongodb-labs/drivers-github-tools/setup@v2
+        with:
+          aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
+          aws_region_name: ${{ vars.AWS_REGION_NAME }}
+          aws_secret_id: ${{ secrets.AWS_SECRET_ID }}
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
@@ -84,11 +102,6 @@ jobs:
       # Preliminary checks done - commence the release process
       #
 
-      - name: "Set git author information"
-        run: |
-          git config user.name "${GIT_AUTHOR_NAME}"
-          git config user.email "${GIT_AUTHOR_EMAIL}"
-
       # Create a draft release with a changelog
       # TODO: Consider using the API to generate changelog
       - name: "Create draft release with generated changelog"
@@ -106,13 +119,9 @@ jobs:
       # our tag and creates the release tag. This is run inside the container in
       # order to create signed git artifacts
       - name: "Create package commit and release tag"
-        uses: mongodb-labs/drivers-github-tools/garasign/git-sign@v1
+        uses: mongodb-labs/drivers-github-tools/git-sign@v2
         with:
-          command: "$(pwd)/.github/workflows/commit-and-tag.sh ${{ env.PACKAGE_VERSION }} ${{ vars.GPG_KEY_ID }} tag-message"
-          garasign_username: ${{ secrets.GRS_CONFIG_USER1_USERNAME }}
-          garasign_password: ${{ secrets.GRS_CONFIG_USER1_PASSWORD }}
-          artifactory_username: ${{ secrets.ARTIFACTORY_USER }}
-          artifactory_password: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          command: "$(pwd)/.github/workflows/commit-and-tag.sh ${{ env.PACKAGE_VERSION }} ${{ env.GPG_KEY_ID }} tag-message"
 
       # This step needs to happen outside of the container, as PHP is not
       # available within.
@@ -121,15 +130,9 @@ jobs:
 
       # Create a signed "back to -dev" commit, again inside the container
       - name: "Create dev commit"
-        uses: mongodb-labs/drivers-github-tools/garasign/git-sign@v1
+        uses: mongodb-labs/drivers-github-tools/git-sign@v2
         with:
-          # Setup can be skipped as it was already done before
-          skip_setup: true
-          command: "git commit -m 'Back to -dev' -s --gpg-sign=${{ vars.GPG_KEY_ID }} phongo_version.h"
-          garasign_username: ${{ secrets.GRS_CONFIG_USER1_USERNAME }}
-          garasign_password: ${{ secrets.GRS_CONFIG_USER1_PASSWORD }}
-          artifactory_username: ${{ secrets.ARTIFACTORY_USER }}
-          artifactory_password: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          command: "git commit -m 'Back to -dev' -s --gpg-sign=${{ env.GPG_KEY_ID }} phongo_version.h"
 
       # TODO: Manually merge using ours strategy. This avoids merge-up pull requests being created
       # Process is:


### PR DESCRIPTION
PHPC-2391

This PR updates drivers-github-tools to v2 and makes the necessary adjustments. Alongside with those changes, this now removes the old fixed token in favour of generating a temporary token for the mongodb-dbx-release-bot app. The release commit and tags will be attributed to this bot in future, as it will be for other drivers.

I've tested these changes in my fork and applied the same configuration here. Note that once this PR is merged and we remove the old configuration, releases for 1.18 **will no longer work**!