### PR TITLE
PHPC-2380: Add SBOM file and tooling to update it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ mongodb-*tgz
 
 # Coverage files
 coverage*
+
+# temporary purls file
+/purls.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,7 +182,7 @@ a 1.23.1 tag also existed at the time. The bump to libmongoc 1.23.1 was left to
 another PHPC ticket in the 1.15.0 milestone, which actually depended on the
 libmongoc changes therein.
 
-### Update steps
+### Updating bundled libraries
 
 The following steps are the same for libmongoc and libmongocrypt. When updating
 libmongocrypt, follow the same steps but replace `libmongoc` with
@@ -205,7 +205,7 @@ be used to change the URL, and `git submodules set-branch` can be used to point
 the submodule to a development branch:
 
 ```shell
-git submodules set-url src/libmongoc https://github.com<owner>/<repo>.git
+git submodules set-url src/libmongoc https://github.com/<owner>/<repo>.git
 git submodules set-branch -b <branch> src/libmongoc
 ```
 
@@ -288,7 +288,7 @@ script to automate this process:
 
 This script will generate a purl file with our dependencies, then run the
 internal silkbomb tool to update the SBOM. Note that you need to have docker
-installed and have access to artifactory in order to run this.
+installed and have access to Artifactory in order to run this.
 
 #### Test and commit your changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -286,9 +286,9 @@ script to automate this process:
 ./scripts/update-sbom.sh
 ```
 
-This script will generate a purl file with our dependencies, then run the
-internal silkbomb tool to update the SBOM. Note that you need to have docker
-installed and have access to Artifactory in order to run this.
+This script will generate a temporary purl file with our dependencies, then run
+the internal silkbomb tool to update the SBOM. Note that you need to have docker
+installed in order to run this.
 
 #### Test and commit your changes
 

--- a/sbom.json
+++ b/sbom.json
@@ -1,0 +1,97 @@
+{
+  "components": [
+    {
+      "bom-ref": "pkg:github/mongodb/libmongocrypt@1.10.0",
+      "externalReferences": [
+        {
+          "type": "distribution",
+          "url": "https://github.com/mongodb/libmongocrypt/archive/refs/tags/1.10.0.tar.gz"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/mongodb/libmongocrypt/tree/1.10.0"
+        }
+      ],
+      "group": "mongodb",
+      "name": "libmongocrypt",
+      "purl": "pkg:github/mongodb/libmongocrypt@1.10.0",
+      "type": "library",
+      "version": "1.10.0"
+    },
+    {
+      "bom-ref": "pkg:github/mongodb/mongo-c-driver@1.27.2",
+      "externalReferences": [
+        {
+          "type": "distribution",
+          "url": "https://github.com/mongodb/mongo-c-driver/archive/refs/tags/1.27.2.tar.gz"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/mongodb/mongo-c-driver/tree/1.27.2"
+        }
+      ],
+      "group": "mongodb",
+      "name": "mongo-c-driver",
+      "purl": "pkg:github/mongodb/mongo-c-driver@1.27.2",
+      "type": "library",
+      "version": "1.27.2"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "pkg:github/mongodb/libmongocrypt@1.10.0"
+    },
+    {
+      "ref": "pkg:github/mongodb/mongo-c-driver@1.27.2"
+    }
+  ],
+  "metadata": {
+    "timestamp": "2024-06-06T07:13:52.679415+00:00",
+    "tools": [
+      {
+        "externalReferences": [
+          {
+            "type": "build-system",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/actions"
+          },
+          {
+            "type": "distribution",
+            "url": "https://pypi.org/project/cyclonedx-python-lib/"
+          },
+          {
+            "type": "documentation",
+            "url": "https://cyclonedx-python-library.readthedocs.io/"
+          },
+          {
+            "type": "issue-tracker",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/issues"
+          },
+          {
+            "type": "license",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/LICENSE"
+          },
+          {
+            "type": "release-notes",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/CHANGELOG.md"
+          },
+          {
+            "type": "vcs",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib"
+          },
+          {
+            "type": "website",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/#readme"
+          }
+        ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "6.4.4"
+      }
+    ]
+  },
+  "serialNumber": "urn:uuid:acb30d08-ee47-4ff0-b301-d66ef1f54082",
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/scripts/update-sbom.sh
+++ b/scripts/update-sbom.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+ROOT_DIR=$(realpath "${SCRIPT_DIR}/../")
+PURLS_FILE="${ROOT_DIR}/purls.txt"
+
+LIBMONGOC_VERSION=$(cat ${ROOT_DIR}/src/LIBMONGOC_VERSION_CURRENT | tr -d '[:space:]')
+LIBMONGOCRYPT_VERSION=$(cat ${ROOT_DIR}/src/LIBMONGOCRYPT_VERSION_CURRENT | tr -d '[:space:]')
+
+# Generate purls file from stored versions
+echo "pkg:github/mongodb/mongo-c-driver@${LIBMONGOC_VERSION}" > $PURLS_FILE
+echo "pkg:github/mongodb/libmongocrypt@${LIBMONGOCRYPT_VERSION}" >> $PURLS_FILE
+
+# Use silkbomb to update the sbom.json file
+docker run --platform="linux/amd64" -it --rm -v ${ROOT_DIR}:/pwd \
+  artifactory.corp.mongodb.com/release-tools-container-registry-public-local/silkbomb:1.0 \
+  update --sbom-in /pwd/sbom.json --purls /pwd/purls.txt --sbom-out /pwd/sbom.json
+
+rm $PURLS_FILE


### PR DESCRIPTION
PHPC-2380

This PR introduces the "SBOM lite" file necessary to generate a full SBOM when releasing a new version. The SBOM file is generated from a list of [purls](https://github.com/package-url/purl-spec) using the silkbomb tool. The script to update the tooling is added, along with updated instructions for updating submodules.