### PR TITLE
Manually merge up version bump commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,7 @@ jobs:
           app_id: ${{ vars.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
           submodules: true
+          fetch-depth: 0
 
       - name: "Set up drivers-github-tools"
         uses: mongodb-labs/drivers-github-tools/setup@v2
@@ -109,6 +110,8 @@ jobs:
         with:
           version: ${{ inputs.version }}
           tag_message_template: 'Release ${VERSION}'
+          # Don't push tag, we'll do that after merging up
+          push_tag: false
 
       - name: "Bump to next development release and commit"
         uses: mongodb-labs/drivers-github-tools/bump-version@v2
@@ -116,13 +119,34 @@ jobs:
           version: ${{ inputs.version }}
           version_bump_script: "./bin/update-release-version.php to-next-patch-dev"
           commit_template: 'Back to -dev'
+          # Don't push commit, we still need to merge up
+          push_commit: false
 
-      # TODO: Manually merge using ours strategy. This avoids merge-up pull requests being created
-      # Process is:
-      # 1. switch to next branch (according to merge-up action)
-      # 2. merge release branch using --strategy=ours
-      # 3. push next branch
-      # 4. switch back to release branch, then push
+      - name: "Determine branch to merge up to"
+        id: get-next-branch
+        uses: alcaeus/automatic-merge-up-action/get-next-branch@main
+        with:
+          ref: ${{ github.ref_name }}
+          branchNamePattern: 'v<major>.<minor>'
+          fallbackBranch: 'master'
+
+      - name: "Manually merge up changes"
+        if: ${{ steps.get-next-branch.outputs.hasNextBranch }}
+        run: |
+          git checkout ${NEXT_BRANCH}
+          git merge --strategy=ours ${RELEASE_BRANCH}
+          git push origin ${NEXT_BRANCH}
+          git checkout ${RELEASE_BRANCH}
+        env:
+          NEXT_BRANCH: ${{ steps.get-next-branch.outputs.branchName }}
+          RELEASE_BRANCH: ${{ github.ref_name }}
+
+      - name: "Push tag and release branch"
+        run: |
+          git push origin ${RELEASE_BRANCH}
+          git push origin ${{ inputs.version }}
+        env:
+          RELEASE_BRANCH: ${{ github.ref_name }}
 
       - name: "Prepare release message"
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,7 +144,7 @@ jobs:
       - name: "Push tag and release branch"
         run: |
           git push origin ${RELEASE_BRANCH}
-          git push origin ${{ inputs.version }}
+          git push origin tag ${{ inputs.version }}
         env:
           RELEASE_BRANCH: ${{ github.ref_name }}
 


### PR DESCRIPTION
This PR adds logic to automatically merge up changes to the next release branch. This is necessary as the pull request for the merge-up action will always have a conflict due to the version already having changed in the next branch.

If the branch detection logic finds a newer branch to merge to (which it always should as we're releasing from version branches), it runs a `git merge --strategy=ours` in this next branch, then pushes those changes before pushing the release branch. By pushing the next branch before the release branch, the merge-up action discovers that there are no commits to be merged from the release branch into the next branch and will not create a merge-up pull request.

Note that if the release branch contains changes that have not been merged up yet, those changes will be marked as merged without applying them. I can add logic to detect this and prevent a release, but this case shouldn't come up very often as we're quite diligent about merging the merge-up pull requests so I've decided against it for the time being.