### PR TITLE
PHPC-2254: Relax server selection timeout error message pattern

### DIFF
--- a/tests/ocsp-failure.phpt
+++ b/tests/ocsp-failure.phpt
@@ -29,5 +29,5 @@ $m->executeCommand('admin', $ping);
 <?php exit(0); ?>
 --EXPECTF--
 OK: Got MongoDB\Driver\Exception\ConnectionTimeoutException
-No suitable servers found (`serverSelectionTryOnce` set): [%s calling %s on '%s:%d']
+No suitable servers found (`serverSelectionTryOnce` set): %s
 ===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-2254

libmongoc 1.28 now includes the topology type in the server selection error message.

This makes the expected error message consistent with other tests.