### PR TITLE
Use full-report convenience action for SSDLC reports

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,32 +219,16 @@ jobs:
       - name: Download all release artifacts
         run: gh release download ${{ inputs.version }} --dir ${{ env.RELEASE_ASSETS }}
 
-      - name: "Generate authorized publication document"
-        uses: mongodb-labs/drivers-github-tools/authorized-pub@v2
+      - name: "Generate SSDLC Reports"
+        uses: mongodb-labs/drivers-github-tools/full-report@v2
         with:
           product_name: "MongoDB PHP Driver (extension)"
           release_version: ${{ inputs.version }}
-          filenames: "${{ env.RELEASE_ASSETS }}/*"
-          token: ${{ env.GH_TOKEN }}
-
-      - name: "Download SBOM file from Silk"
-        uses: mongodb-labs/drivers-github-tools/sbom@v2
-        with:
+          dist_filenames: "${{ env.RELEASE_ASSETS }}/*"
           silk_asset_group: mongodb-php-driver-extension
 
       - name: "Upload SBOM as release artifact"
         run: gh release upload ${{ inputs.version }} ${{ env.S3_ASSETS }}/cyclonedx.sbom.json
-
-      - name: "Generate SARIF report from code scanning alerts"
-        uses: mongodb-labs/drivers-github-tools/code-scanning-export@v2
-        with:
-          ref: ${{ inputs.version }}
-          output-file: ${{ env.S3_ASSETS }}/code-scanning-alerts.json
-
-      - name: "Generate compliance report"
-        uses: mongodb-labs/drivers-github-tools/compliance-report@v2
-        with:
-          token: ${{ env.GH_TOKEN }}
 
       - name: Upload S3 assets
         uses: mongodb-labs/drivers-github-tools/upload-s3-assets@v2


### PR DESCRIPTION
This PR leverages the new [full-report action](https://github.com/mongodb-labs/drivers-github-tools?tab=readme-ov-file#full-report) to generate all necessary SSDLC reports.