### PR TITLE
Add tag checks aliases

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -36,6 +36,16 @@ github_pr_aliases: &github_pr_aliases
 
 commit_queue_aliases: *github_pr_aliases
 
+github_checks_aliases:
+  - variant: ".*"
+    task: ".*"
+
+git_tag_aliases:
+  git_tag: "*"
+  remote_path: ""
+  variant_tags: ["tag"]
+  task_tags: ["tag"]
+
 patch_aliases:
   - alias: pull-request
     variant_tags: ["pr"]


### PR DESCRIPTION
This PR adds evergreen aliases for GitHub commit checks and git tags. It also serves as a test to see if evergreen creates the correct patch definition for a pull request.