### PR TITLE
Add tag checks aliases

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -25,14 +25,17 @@ post:
   - func: "stop load balancer"
   - func: "cleanup"
 
-# Define aliases for patch builds and PR builds. These only apply if no aliases are defined in project and repo settings
+# These aliases define the default variant/tasks to test for pull requests and merge queue
 github_pr_aliases: &github_pr_aliases
-  # Run all tasks in PR variants for PHP 8.3
-  - variant_tags: ["php8.3", "pr"]
-    task: ".*"
-  # Run PR tasks for PR variants
-  - variant_tags: ["pr"]
+  # Always test all builds for consistency
+  - variant_tags: ["pr build"]
     task_tags: ["pr"]
+  # Run all tasks in PR variants for PHP 8.3 (excluding MongoDB latest)
+  - variant_tags: ["pr php8.3"]
+    task_tags: ["!latest"]
+  # Run PR tasks for all PR variants (only MongoDB 7.0)
+  - variant_tags: ["pr"]
+    task_tags: ["pr 7.0"]
 
 commit_queue_aliases: *github_pr_aliases
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -39,6 +39,12 @@ github_pr_aliases: &github_pr_aliases
 
 commit_queue_aliases: *github_pr_aliases
 
+git_tag_aliases:
+  - git_tag: "^[0-9]+.[0-9]+.[0-9]+"
+    remote_path: ""
+    variant_tags: ["tag"]
+    task_tags: ["tag"]
+
 patch_aliases:
   - alias: pull-request
     variant_tags: ["pr"]

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -45,6 +45,10 @@ git_tag_aliases:
     variant_tags: ["tag"]
     task_tags: ["tag"]
 
+github_checks_aliases:
+  - variant: ".*"
+    task: ".*"
+
 patch_aliases:
   - alias: pull-request
     variant_tags: ["pr"]

--- a/.evergreen/config/generated/test/require-api-version-5.0.yml
+++ b/.evergreen/config/generated/test/require-api-version-5.0.yml
@@ -1,7 +1,7 @@
 # This file is generated automatically - please edit the "templates/test/require-api-version.yml" template file instead.
 tasks:
   - name: "test-requireApiVersion-5.0"
-    tags: [ "standalone", "local", "5.0", "versioned_api", "pr", "tag" ]
+    tags: [ "standalone", "local", "5.0", "versioned_api", "tag" ]
     commands:
       - func: "bootstrap mongo-orchestration"
         vars:

--- a/.evergreen/config/generated/test/require-api-version-6.0.yml
+++ b/.evergreen/config/generated/test/require-api-version-6.0.yml
@@ -1,7 +1,7 @@
 # This file is generated automatically - please edit the "templates/test/require-api-version.yml" template file instead.
 tasks:
   - name: "test-requireApiVersion-6.0"
-    tags: [ "standalone", "local", "6.0", "versioned_api", "pr", "tag" ]
+    tags: [ "standalone", "local", "6.0", "versioned_api", "tag" ]
     commands:
       - func: "bootstrap mongo-orchestration"
         vars:

--- a/.evergreen/config/generated/test/require-api-version-7.0.yml
+++ b/.evergreen/config/generated/test/require-api-version-7.0.yml
@@ -1,7 +1,7 @@
 # This file is generated automatically - please edit the "templates/test/require-api-version.yml" template file instead.
 tasks:
   - name: "test-requireApiVersion-7.0"
-    tags: [ "standalone", "local", "7.0", "versioned_api", "pr", "tag" ]
+    tags: [ "standalone", "local", "7.0", "versioned_api", "tag" ]
     commands:
       - func: "bootstrap mongo-orchestration"
         vars:

--- a/.evergreen/config/generated/test/require-api-version-latest.yml
+++ b/.evergreen/config/generated/test/require-api-version-latest.yml
@@ -1,7 +1,7 @@
 # This file is generated automatically - please edit the "templates/test/require-api-version.yml" template file instead.
 tasks:
   - name: "test-requireApiVersion-latest"
-    tags: [ "standalone", "local", "latest", "versioned_api", "pr", "tag" ]
+    tags: [ "standalone", "local", "latest", "versioned_api", "tag" ]
     commands:
       - func: "bootstrap mongo-orchestration"
         vars:

--- a/.evergreen/config/generated/test/require-api-version-rapid.yml
+++ b/.evergreen/config/generated/test/require-api-version-rapid.yml
@@ -1,7 +1,7 @@
 # This file is generated automatically - please edit the "templates/test/require-api-version.yml" template file instead.
 tasks:
   - name: "test-requireApiVersion-rapid"
-    tags: [ "standalone", "local", "rapid", "versioned_api", "pr", "tag" ]
+    tags: [ "standalone", "local", "rapid", "versioned_api", "tag" ]
     commands:
       - func: "bootstrap mongo-orchestration"
         vars:

--- a/.evergreen/config/templates/test/require-api-version.yml
+++ b/.evergreen/config/templates/test/require-api-version.yml
@@ -1,6 +1,6 @@
 tasks:
   - name: "test-requireApiVersion-%mongodbVersion%"
-    tags: [ "standalone", "local", "%mongodbVersion%", "versioned_api", "pr", "tag" ]
+    tags: [ "standalone", "local", "%mongodbVersion%", "versioned_api", "tag" ]
     commands:
       - func: "bootstrap mongo-orchestration"
         vars:


### PR DESCRIPTION
This PR adds evergreen aliases for GitHub commit checks and git tags. It also serves as a test to see if evergreen creates the correct patch definition for a pull request.