### PR TITLE
Fix version computation for libmongoc development versions

### DIFF
--- a/.evergreen/compile-unix.sh
+++ b/.evergreen/compile-unix.sh
@@ -72,8 +72,11 @@ if [ -n "$LIBMONGOC_VERSION" ]; then
    echo "Finding Python3 binary... done."
 
    php scripts/update-submodule-sources.php
+
    # We invoke python manually as it may not be in the path
-   $PYTHON src/libmongoc/build/calc_release_version.py > src/LIBMONGOC_VERSION_CURRENT
+   pushd src/libmongoc/
+   $PYTHON build/calc_release_version.py > ../LIBMONGOC_VERSION_CURRENT
+   popd
 fi
 
 phpize


### PR DESCRIPTION
The `calc_release_version` script needs to be invoked from the libmongoc root directory, otherwise it will fail to compute a valid version, which in turn makes some of our tests fail.