### PR TITLE
PHPC-1489: Deprecate integer readPreference constants

### DIFF
--- a/src/MongoDB/ReadPreference.c
+++ b/src/MongoDB/ReadPreference.c
@@ -195,6 +195,8 @@ static PHP_METHOD(MongoDB_Driver_ReadPreference, __construct)
 	PHONGO_PARSE_PARAMETERS_END();
 
 	if (Z_TYPE_P(mode) == IS_LONG) {
+		php_error_docref(NULL, E_DEPRECATED, "Passing an integer mode to \"MongoDB\\Driver\\ReadPreference::__construct\" deprecated and will be removed in a future release.");
+
 		switch (Z_LVAL_P(mode)) {
 			case MONGOC_READ_PRIMARY:
 			case MONGOC_READ_SECONDARY:

--- a/src/MongoDB/ReadPreference.c
+++ b/src/MongoDB/ReadPreference.c
@@ -195,7 +195,7 @@ static PHP_METHOD(MongoDB_Driver_ReadPreference, __construct)
 	PHONGO_PARSE_PARAMETERS_END();
 
 	if (Z_TYPE_P(mode) == IS_LONG) {
-		php_error_docref(NULL, E_DEPRECATED, "Passing an integer mode to \"MongoDB\\Driver\\ReadPreference::__construct\" deprecated and will be removed in a future release.");
+		php_error_docref(NULL, E_DEPRECATED, "Passing an integer mode to \"MongoDB\\Driver\\ReadPreference::__construct\" is deprecated and will be removed in a future release.");
 
 		switch (Z_LVAL_P(mode)) {
 			case MONGOC_READ_PRIMARY:

--- a/src/MongoDB/ReadPreference.stub.php
+++ b/src/MongoDB/ReadPreference.stub.php
@@ -12,30 +12,35 @@ final class ReadPreference implements \MongoDB\BSON\Serializable, \Serializable
     /**
      * @var int
      * @cvalue MONGOC_READ_PRIMARY
+     * @deprecated
      */
     public const RP_PRIMARY = UNKNOWN;
 
     /**
      * @var int
      * @cvalue MONGOC_READ_PRIMARY_PREFERRED
+     * @deprecated
      */
     public const RP_PRIMARY_PREFERRED = UNKNOWN;
 
     /**
      * @var int
      * @cvalue MONGOC_READ_SECONDARY
+     * @deprecated
      */
     public const RP_SECONDARY = UNKNOWN;
 
     /**
      * @var int
      * @cvalue MONGOC_READ_SECONDARY_PREFERRED
+     * @deprecated
      */
     public const RP_SECONDARY_PREFERRED = UNKNOWN;
 
     /**
      * @var int
      * @cvalue MONGOC_READ_NEAREST
+     * @deprecated
      */
     public const RP_NEAREST = UNKNOWN;
 
@@ -92,6 +97,7 @@ final class ReadPreference implements \MongoDB\BSON\Serializable, \Serializable
 
     final public function getMaxStalenessSeconds(): int {}
 
+    /** @deprecated */
     final public function getMode(): int {}
 
     final public function getModeString(): string {}

--- a/src/MongoDB/ReadPreference_arginfo.h
+++ b/src/MongoDB/ReadPreference_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 1a1a31ef5910ddfbe66ba6c350df216ffe25b5dd */
+ * Stub hash: 5409119e964d14e52195c47daf14075fffb08926 */
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_ReadPreference___construct, 0, 0, 1)
@@ -92,7 +92,7 @@ static const zend_function_entry class_MongoDB_Driver_ReadPreference_methods[] =
 #endif
 	ZEND_ME(MongoDB_Driver_ReadPreference, getHedge, arginfo_class_MongoDB_Driver_ReadPreference_getHedge, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_ReadPreference, getMaxStalenessSeconds, arginfo_class_MongoDB_Driver_ReadPreference_getMaxStalenessSeconds, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
-	ZEND_ME(MongoDB_Driver_ReadPreference, getMode, arginfo_class_MongoDB_Driver_ReadPreference_getMode, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+	ZEND_ME(MongoDB_Driver_ReadPreference, getMode, arginfo_class_MongoDB_Driver_ReadPreference_getMode, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL|ZEND_ACC_DEPRECATED)
 	ZEND_ME(MongoDB_Driver_ReadPreference, getModeString, arginfo_class_MongoDB_Driver_ReadPreference_getModeString, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_ReadPreference, getTagSets, arginfo_class_MongoDB_Driver_ReadPreference_getTagSets, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_ReadPreference, __set_state, arginfo_class_MongoDB_Driver_ReadPreference___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_FINAL)
@@ -121,31 +121,31 @@ static zend_class_entry *register_class_MongoDB_Driver_ReadPreference(zend_class
 	zval const_RP_PRIMARY_value;
 	ZVAL_LONG(&const_RP_PRIMARY_value, MONGOC_READ_PRIMARY);
 	zend_string *const_RP_PRIMARY_name = zend_string_init_interned("RP_PRIMARY", sizeof("RP_PRIMARY") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_RP_PRIMARY_name, &const_RP_PRIMARY_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_class_constant_ex(class_entry, const_RP_PRIMARY_name, &const_RP_PRIMARY_value, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED, NULL);
 	zend_string_release(const_RP_PRIMARY_name);
 
 	zval const_RP_PRIMARY_PREFERRED_value;
 	ZVAL_LONG(&const_RP_PRIMARY_PREFERRED_value, MONGOC_READ_PRIMARY_PREFERRED);
 	zend_string *const_RP_PRIMARY_PREFERRED_name = zend_string_init_interned("RP_PRIMARY_PREFERRED", sizeof("RP_PRIMARY_PREFERRED") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_RP_PRIMARY_PREFERRED_name, &const_RP_PRIMARY_PREFERRED_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_class_constant_ex(class_entry, const_RP_PRIMARY_PREFERRED_name, &const_RP_PRIMARY_PREFERRED_value, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED, NULL);
 	zend_string_release(const_RP_PRIMARY_PREFERRED_name);
 
 	zval const_RP_SECONDARY_value;
 	ZVAL_LONG(&const_RP_SECONDARY_value, MONGOC_READ_SECONDARY);
 	zend_string *const_RP_SECONDARY_name = zend_string_init_interned("RP_SECONDARY", sizeof("RP_SECONDARY") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_RP_SECONDARY_name, &const_RP_SECONDARY_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_class_constant_ex(class_entry, const_RP_SECONDARY_name, &const_RP_SECONDARY_value, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED, NULL);
 	zend_string_release(const_RP_SECONDARY_name);
 
 	zval const_RP_SECONDARY_PREFERRED_value;
 	ZVAL_LONG(&const_RP_SECONDARY_PREFERRED_value, MONGOC_READ_SECONDARY_PREFERRED);
 	zend_string *const_RP_SECONDARY_PREFERRED_name = zend_string_init_interned("RP_SECONDARY_PREFERRED", sizeof("RP_SECONDARY_PREFERRED") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_RP_SECONDARY_PREFERRED_name, &const_RP_SECONDARY_PREFERRED_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_class_constant_ex(class_entry, const_RP_SECONDARY_PREFERRED_name, &const_RP_SECONDARY_PREFERRED_value, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED, NULL);
 	zend_string_release(const_RP_SECONDARY_PREFERRED_name);
 
 	zval const_RP_NEAREST_value;
 	ZVAL_LONG(&const_RP_NEAREST_value, MONGOC_READ_NEAREST);
 	zend_string *const_RP_NEAREST_name = zend_string_init_interned("RP_NEAREST", sizeof("RP_NEAREST") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_RP_NEAREST_name, &const_RP_NEAREST_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_class_constant_ex(class_entry, const_RP_NEAREST_name, &const_RP_NEAREST_value, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED, NULL);
 	zend_string_release(const_RP_NEAREST_name);
 
 	zval const_PRIMARY_value;

--- a/tests/connect/bug1015.phpt
+++ b/tests/connect/bug1015.phpt
@@ -17,7 +17,7 @@ PHPC-1015: Initial DNS Seedlist test
 require_once __DIR__ . "/../utils/basic.inc";
 
 $m = create_test_manager("mongodb+srv://test1.test.build.10gen.cc/");
-$s = $m->selectServer( new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_NEAREST ) );
+$s = $m->selectServer( new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::NEAREST ) );
 $servers = $m->getServers();
 
 foreach ( $servers as $server )

--- a/tests/manager/manager-ctor-duplicate-option-001.phpt
+++ b/tests/manager/manager-ctor-duplicate-option-001.phpt
@@ -5,11 +5,11 @@ MongoDB\Driver\Manager::__construct() with duplicate read preference option
 
 $manager = new MongoDB\Driver\Manager(null, ['readPreference' => 'primary', 'readpreference' => 'secondary']);
 
-echo $manager->getReadPreference()->getMode(), "\n";
+echo $manager->getReadPreference()->getModeString(), "\n";
 
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECT--
-2
+secondary
 ===DONE===

--- a/tests/manager/manager-executeCommand-002.phpt
+++ b/tests/manager/manager-executeCommand-002.phpt
@@ -11,8 +11,8 @@ require_once __DIR__ . "/../utils/basic.inc";
 
 $manager = create_test_manager();
 
-$primary   = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY);
-$secondary = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY);
+$primary   = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY);
+$secondary = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY);
 
 echo "Testing primary:\n";
 $command = new MongoDB\Driver\Command(['ping' => 1]);

--- a/tests/manager/manager-executeCommand-003.phpt
+++ b/tests/manager/manager-executeCommand-003.phpt
@@ -11,8 +11,8 @@ require_once __DIR__ . "/../utils/basic.inc";
 
 $manager = create_test_manager();
 
-$primary   = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY);
-$secondary = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY);
+$primary   = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY);
+$secondary = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY);
 
 echo "Testing primary:\n";
 $command = new MongoDB\Driver\Command(['ping' => 1]);

--- a/tests/manager/manager-executeCommand-004.phpt
+++ b/tests/manager/manager-executeCommand-004.phpt
@@ -24,7 +24,7 @@ $manager = create_test_manager();
                 DATABASE_NAME,
                 $command,
                 [
-                    'readPreference' => new \MongoDB\Driver\ReadPreference(\MongoDB\Driver\ReadPreference::RP_SECONDARY),
+                    'readPreference' => new \MongoDB\Driver\ReadPreference(\MongoDB\Driver\ReadPreference::SECONDARY),
                     'readConcern' => new \MongoDB\Driver\ReadConcern(\MongoDB\Driver\ReadConcern::LOCAL),
                     'writeConcern' => new \MongoDB\Driver\WriteConcern(\MongoDB\Driver\WriteConcern::MAJORITY),
                 ]

--- a/tests/manager/manager-executeQuery-003.phpt
+++ b/tests/manager/manager-executeQuery-003.phpt
@@ -16,8 +16,8 @@ $bulk = new MongoDB\Driver\BulkWrite();
 $bulk->insert(['_id' => 1, 'x' => 2, 'y' => 3]);
 $manager->executeBulkWrite(NS, $bulk);
 
-$primary   = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY);
-$secondary = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY);
+$primary   = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY);
+$secondary = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY);
 
 echo "Testing primary:\n";
 $query = new MongoDB\Driver\Query(['x' => 3], ['projection' => ['y' => 1]]);

--- a/tests/manager/manager-executeQuery-004.phpt
+++ b/tests/manager/manager-executeQuery-004.phpt
@@ -16,8 +16,8 @@ $bulk = new MongoDB\Driver\BulkWrite();
 $bulk->insert(['_id' => 1, 'x' => 2, 'y' => 3]);
 $manager->executeBulkWrite(NS, $bulk);
 
-$primary   = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY);
-$secondary = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY);
+$primary   = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY);
+$secondary = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY);
 
 echo "Testing primary:\n";
 $query = new MongoDB\Driver\Query(['x' => 3], ['projection' => ['y' => 1]]);

--- a/tests/manager/manager-executeReadCommand-001.phpt
+++ b/tests/manager/manager-executeReadCommand-001.phpt
@@ -25,7 +25,7 @@ $manager = create_test_manager();
             DATABASE_NAME,
             $command,
             [
-                'readPreference' => new \MongoDB\Driver\ReadPreference(\MongoDB\Driver\ReadPreference::RP_SECONDARY),
+                'readPreference' => new \MongoDB\Driver\ReadPreference(\MongoDB\Driver\ReadPreference::SECONDARY),
                 'readConcern' => new \MongoDB\Driver\ReadConcern(\MongoDB\Driver\ReadConcern::MAJORITY),
             ]
         );

--- a/tests/manager/manager-selectserver_error-001.phpt
+++ b/tests/manager/manager-selectserver_error-001.phpt
@@ -4,7 +4,7 @@ MongoDB\Driver\Manager::selectServer() should not issue warning before exception
 <?php
 require_once __DIR__ . "/../utils/basic.inc";
 
-$rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY);
+$rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY);
 
 // Invalid host cannot be resolved
 $manager = create_test_manager('mongodb://example.invalid:27017', ['serverSelectionTimeoutMS' => 1]);

--- a/tests/manager/manager-startSession_error-001.phpt
+++ b/tests/manager/manager-startSession_error-001.phpt
@@ -20,7 +20,7 @@ $options = [
     [ 'readPreference' => new \MongoDB\Driver\ReadConcern( \MongoDB\Driver\ReadConcern::LOCAL ) ],
     [ 'writeConcern' => 42 ],
     [ 'writeConcern' => new stdClass ],
-    [ 'writeConcern' => new \MongoDB\Driver\ReadPreference( \MongoDB\Driver\ReadPreference::RP_SECONDARY ) ],
+    [ 'writeConcern' => new \MongoDB\Driver\ReadPreference( \MongoDB\Driver\ReadPreference::SECONDARY ) ],
 
     [
         'readConcern' => new \MongoDB\Driver\ReadConcern( \MongoDB\Driver\ReadConcern::LOCAL ),
@@ -28,11 +28,11 @@ $options = [
     ],
     [
         'readConcern' => new \MongoDB\Driver\ReadConcern( \MongoDB\Driver\ReadConcern::LOCAL ),
-        'writeConcern' => new \MongoDB\Driver\ReadPreference( \MongoDB\Driver\ReadPreference::RP_SECONDARY ),
+        'writeConcern' => new \MongoDB\Driver\ReadPreference( \MongoDB\Driver\ReadPreference::SECONDARY ),
     ],
     [
-        'readPreference' => new \MongoDB\Driver\ReadPreference( \MongoDB\Driver\ReadPreference::RP_SECONDARY ),
-        'writeConcern' => new \MongoDB\Driver\ReadPreference( \MongoDB\Driver\ReadPreference::RP_SECONDARY ),
+        'readPreference' => new \MongoDB\Driver\ReadPreference( \MongoDB\Driver\ReadPreference::SECONDARY ),
+        'writeConcern' => new \MongoDB\Driver\ReadPreference( \MongoDB\Driver\ReadPreference::SECONDARY ),
     ],
 
     42,

--- a/tests/readPreference/bug0146-001.phpt
+++ b/tests/readPreference/bug0146-001.phpt
@@ -16,13 +16,13 @@ $bulk = new MongoDB\Driver\BulkWrite();
 $bulk->insert(array('my' => 'document'));
 $manager->executeBulkWrite(NS, $bulk);
 
-$rps = array(
-    MongoDB\Driver\ReadPreference::RP_PRIMARY,
-    MongoDB\Driver\ReadPreference::RP_PRIMARY_PREFERRED,
-    MongoDB\Driver\ReadPreference::RP_SECONDARY,
-    MongoDB\Driver\ReadPreference::RP_SECONDARY_PREFERRED,
-    MongoDB\Driver\ReadPreference::RP_NEAREST,
-);
+$rps = [
+    MongoDB\Driver\ReadPreference::PRIMARY,
+    MongoDB\Driver\ReadPreference::PRIMARY_PREFERRED,
+    MongoDB\Driver\ReadPreference::SECONDARY,
+    MongoDB\Driver\ReadPreference::SECONDARY_PREFERRED,
+    MongoDB\Driver\ReadPreference::NEAREST,
+];
 
 foreach($rps as $r) {
     $rp = new MongoDB\Driver\ReadPreference($r);

--- a/tests/readPreference/bug0851-001.phpt
+++ b/tests/readPreference/bug0851-001.phpt
@@ -8,7 +8,7 @@ $tagSets = [
     [],
 ];
 
-$rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY_PREFERRED, $tagSets);
+$rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY_PREFERRED, $tagSets);
 var_dump($tagSets);
 
 /* Dump the Manager's ReadPreference to ensure that each element in the $tagSets

--- a/tests/readPreference/readpreference-bsonserialize-001.phpt
+++ b/tests/readPreference/readpreference-bsonserialize-001.phpt
@@ -6,15 +6,15 @@ MongoDB\Driver\ReadPreference::bsonSerialize()
 require_once __DIR__ . '/../utils/basic.inc';
 
 $tests = [
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY_PREFERRED),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY_PREFERRED),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_NEAREST),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY, []),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, [['dc' => 'ny']]),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, [['dc' => 'ny'], ['dc' => 'sf', 'use' => 'reporting'], []]),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, null, ['maxStalenessSeconds' => 1000]),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY_PREFERRED),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY_PREFERRED),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::NEAREST),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY, []),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, [['dc' => 'ny']]),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, [['dc' => 'ny'], ['dc' => 'sf', 'use' => 'reporting'], []]),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['maxStalenessSeconds' => 1000]),
 ];
 
 foreach ($tests as $test) {

--- a/tests/readPreference/readpreference-bsonserialize-002.phpt
+++ b/tests/readPreference/readpreference-bsonserialize-002.phpt
@@ -6,15 +6,15 @@ MongoDB\Driver\ReadPreference::bsonSerialize() returns an object
 require_once __DIR__ . '/../utils/basic.inc';
 
 $tests = [
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY_PREFERRED),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY_PREFERRED),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_NEAREST),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY, []),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, [['dc' => 'ny']]),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, [['dc' => 'ny'], ['dc' => 'sf', 'use' => 'reporting'], []]),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, null, ['maxStalenessSeconds' => 1000]),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY_PREFERRED),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY_PREFERRED),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::NEAREST),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY, []),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, [['dc' => 'ny']]),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, [['dc' => 'ny'], ['dc' => 'sf', 'use' => 'reporting'], []]),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['maxStalenessSeconds' => 1000]),
 ];
 
 foreach ($tests as $test) {

--- a/tests/readPreference/readpreference-constants-001.phpt
+++ b/tests/readPreference/readpreference-constants-001.phpt
@@ -3,34 +3,24 @@ MongoDB\Driver\ReadPreference constants
 --FILE--
 <?php
 
-var_dump(MongoDB\Driver\ReadPreference::RP_PRIMARY);
-var_dump(MongoDB\Driver\ReadPreference::RP_PRIMARY_PREFERRED);
-var_dump(MongoDB\Driver\ReadPreference::RP_SECONDARY);
-var_dump(MongoDB\Driver\ReadPreference::RP_SECONDARY_PREFERRED);
-var_dump(MongoDB\Driver\ReadPreference::RP_NEAREST);
-var_dump(MongoDB\Driver\ReadPreference::NO_MAX_STALENESS);
-var_dump(MongoDB\Driver\ReadPreference::SMALLEST_MAX_STALENESS_SECONDS);
-
 var_dump(MongoDB\Driver\ReadPreference::PRIMARY);
 var_dump(MongoDB\Driver\ReadPreference::PRIMARY_PREFERRED);
 var_dump(MongoDB\Driver\ReadPreference::SECONDARY);
 var_dump(MongoDB\Driver\ReadPreference::SECONDARY_PREFERRED);
 var_dump(MongoDB\Driver\ReadPreference::NEAREST);
 
+var_dump(MongoDB\Driver\ReadPreference::NO_MAX_STALENESS);
+var_dump(MongoDB\Driver\ReadPreference::SMALLEST_MAX_STALENESS_SECONDS);
+
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-int(1)
-int(5)
-int(2)
-int(6)
-int(10)
-int(-1)
-int(90)
 string(7) "primary"
 string(16) "primaryPreferred"
 string(9) "secondary"
 string(18) "secondaryPreferred"
 string(7) "nearest"
+int(-1)
+int(90)
 ===DONE===

--- a/tests/readPreference/readpreference-constants-002.phpt
+++ b/tests/readPreference/readpreference-constants-002.phpt
@@ -1,0 +1,33 @@
+--TEST--
+MongoDB\Driver\ReadPreference deprecated constants
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_php_version('<', '8.3.0'); ?>
+--FILE--
+<?php
+
+var_dump(MongoDB\Driver\ReadPreference::RP_PRIMARY);
+var_dump(MongoDB\Driver\ReadPreference::RP_PRIMARY_PREFERRED);
+var_dump(MongoDB\Driver\ReadPreference::RP_SECONDARY);
+var_dump(MongoDB\Driver\ReadPreference::RP_SECONDARY_PREFERRED);
+var_dump(MongoDB\Driver\ReadPreference::RP_NEAREST);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+Deprecated: Constant MongoDB\Driver\ReadPreference::RP_PRIMARY is deprecated in %s
+int(1)
+
+Deprecated: Constant MongoDB\Driver\ReadPreference::RP_PRIMARY_PREFERRED is deprecated in %s
+int(5)
+
+Deprecated: Constant MongoDB\Driver\ReadPreference::RP_SECONDARY is deprecated in %s
+int(2)
+
+Deprecated: Constant MongoDB\Driver\ReadPreference::RP_SECONDARY_PREFERRED is deprecated in %s
+int(6)
+
+Deprecated: Constant MongoDB\Driver\ReadPreference::RP_NEAREST is deprecated in %s
+int(10)
+===DONE===

--- a/tests/readPreference/readpreference-ctor-001.phpt
+++ b/tests/readPreference/readpreference-ctor-001.phpt
@@ -3,12 +3,12 @@ MongoDB\Driver\ReadPreference construction
 --FILE--
 <?php
 
-var_dump(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY));
-var_dump(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, [['tag' => 'one']]));
-var_dump(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY, []));
-var_dump(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, null, ['maxStalenessSeconds' => 1000]));
-var_dump(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, null, ['hedge' => ['enabled' => true]]));
-var_dump(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, null, ['hedge' => []]));
+var_dump(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY));
+var_dump(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, [['tag' => 'one']]));
+var_dump(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY, []));
+var_dump(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['maxStalenessSeconds' => 1000]));
+var_dump(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['hedge' => ['enabled' => true]]));
+var_dump(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['hedge' => []]));
 
 ?>
 ===DONE===

--- a/tests/readPreference/readpreference-ctor-002.phpt
+++ b/tests/readPreference/readpreference-ctor-002.phpt
@@ -5,23 +5,23 @@ MongoDB\Driver\ReadPreference construction with strings
 $data = [
     "primary",
     "PrImAry",
-    MongoDB\Driver\ReadPreference::RP_PRIMARY,
+    MongoDB\Driver\ReadPreference::PRIMARY,
 
     "primaryPreferred",
     "primarypreferred",
-    MongoDB\Driver\ReadPreference::RP_PRIMARY_PREFERRED,
+    MongoDB\Driver\ReadPreference::PRIMARY_PREFERRED,
 
     "secondary",
     "SEcOndArY",
-    MongoDB\Driver\ReadPreference::RP_SECONDARY,
+    MongoDB\Driver\ReadPreference::SECONDARY,
 
     "secondaryPreferred",
     "secondarypreferred",
-    MongoDB\Driver\ReadPreference::RP_SECONDARY_PREFERRED,
+    MongoDB\Driver\ReadPreference::SECONDARY_PREFERRED,
 
     "nearest",
     "NeaRest",
-    MongoDB\Driver\ReadPreference::RP_NEAREST,
+    MongoDB\Driver\ReadPreference::NEAREST,
 ];
 
 foreach ($data as $item) {

--- a/tests/readPreference/readpreference-ctor-003.phpt
+++ b/tests/readPreference/readpreference-ctor-003.phpt
@@ -1,0 +1,70 @@
+--TEST--
+MongoDB\Driver\ReadPreference construction with integer constants (PHP < 8.3)
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_php_version('>=', '8.3.0'); ?>
+--FILE--
+<?php
+
+var_dump(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY));
+var_dump(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, [['tag' => 'one']]));
+var_dump(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY, []));
+var_dump(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, null, ['maxStalenessSeconds' => 1000]));
+var_dump(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, null, ['hedge' => ['enabled' => true]]));
+var_dump(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, null, ['hedge' => []]));
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+Deprecated: MongoDB\Driver\ReadPreference::__construct(): Passing an integer mode to "MongoDB\Driver\ReadPreference::__construct" is deprecated and will be removed in a future release. in %s
+object(MongoDB\Driver\ReadPreference)#%d (%d) {
+  ["mode"]=>
+  string(7) "primary"
+}
+
+Deprecated: MongoDB\Driver\ReadPreference::__construct(): Passing an integer mode to "MongoDB\Driver\ReadPreference::__construct" is deprecated and will be removed in a future release. in %s
+object(MongoDB\Driver\ReadPreference)#%d (%d) {
+  ["mode"]=>
+  string(9) "secondary"
+  ["tags"]=>
+  array(1) {
+    [0]=>
+    object(stdClass)#%d (%d) {
+      ["tag"]=>
+      string(3) "one"
+    }
+  }
+}
+
+Deprecated: MongoDB\Driver\ReadPreference::__construct(): Passing an integer mode to "MongoDB\Driver\ReadPreference::__construct" is deprecated and will be removed in a future release. in %s
+object(MongoDB\Driver\ReadPreference)#%d (%d) {
+  ["mode"]=>
+  string(7) "primary"
+}
+
+Deprecated: MongoDB\Driver\ReadPreference::__construct(): Passing an integer mode to "MongoDB\Driver\ReadPreference::__construct" is deprecated and will be removed in a future release. in %s
+object(MongoDB\Driver\ReadPreference)#%d (%d) {
+  ["mode"]=>
+  string(9) "secondary"
+  ["maxStalenessSeconds"]=>
+  int(1000)
+}
+
+Deprecated: MongoDB\Driver\ReadPreference::__construct(): Passing an integer mode to "MongoDB\Driver\ReadPreference::__construct" is deprecated and will be removed in a future release. in %s
+object(MongoDB\Driver\ReadPreference)#%d (%d) {
+  ["mode"]=>
+  string(9) "secondary"
+  ["hedge"]=>
+  object(stdClass)#%d (%d) {
+    ["enabled"]=>
+    bool(true)
+  }
+}
+
+Deprecated: MongoDB\Driver\ReadPreference::__construct(): Passing an integer mode to "MongoDB\Driver\ReadPreference::__construct" is deprecated and will be removed in a future release. in %s
+object(MongoDB\Driver\ReadPreference)#%d (%d) {
+  ["mode"]=>
+  string(9) "secondary"
+}
+===DONE===

--- a/tests/readPreference/readpreference-ctor-004.phpt
+++ b/tests/readPreference/readpreference-ctor-004.phpt
@@ -1,0 +1,82 @@
+--TEST--
+MongoDB\Driver\ReadPreference construction with integer constants (PHP 8.3+)
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_php_version('<', '8.3.0'); ?>
+--FILE--
+<?php
+
+var_dump(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY));
+var_dump(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, [['tag' => 'one']]));
+var_dump(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY, []));
+var_dump(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, null, ['maxStalenessSeconds' => 1000]));
+var_dump(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, null, ['hedge' => ['enabled' => true]]));
+var_dump(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, null, ['hedge' => []]));
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+Deprecated: Constant MongoDB\Driver\ReadPreference::RP_PRIMARY is deprecated in %s
+
+Deprecated: MongoDB\Driver\ReadPreference::__construct(): Passing an integer mode to "MongoDB\Driver\ReadPreference::__construct" is deprecated and will be removed in a future release. in %s
+object(MongoDB\Driver\ReadPreference)#%d (%d) {
+  ["mode"]=>
+  string(7) "primary"
+}
+
+Deprecated: Constant MongoDB\Driver\ReadPreference::RP_SECONDARY is deprecated in %s
+
+Deprecated: MongoDB\Driver\ReadPreference::__construct(): Passing an integer mode to "MongoDB\Driver\ReadPreference::__construct" is deprecated and will be removed in a future release. in %s
+object(MongoDB\Driver\ReadPreference)#%d (%d) {
+  ["mode"]=>
+  string(9) "secondary"
+  ["tags"]=>
+  array(1) {
+    [0]=>
+    object(stdClass)#%d (%d) {
+      ["tag"]=>
+      string(3) "one"
+    }
+  }
+}
+
+Deprecated: Constant MongoDB\Driver\ReadPreference::RP_PRIMARY is deprecated in %s
+
+Deprecated: MongoDB\Driver\ReadPreference::__construct(): Passing an integer mode to "MongoDB\Driver\ReadPreference::__construct" is deprecated and will be removed in a future release. in %s
+object(MongoDB\Driver\ReadPreference)#%d (%d) {
+  ["mode"]=>
+  string(7) "primary"
+}
+
+Deprecated: Constant MongoDB\Driver\ReadPreference::RP_SECONDARY is deprecated in %s
+
+Deprecated: MongoDB\Driver\ReadPreference::__construct(): Passing an integer mode to "MongoDB\Driver\ReadPreference::__construct" is deprecated and will be removed in a future release. in %s
+object(MongoDB\Driver\ReadPreference)#%d (%d) {
+  ["mode"]=>
+  string(9) "secondary"
+  ["maxStalenessSeconds"]=>
+  int(1000)
+}
+
+Deprecated: Constant MongoDB\Driver\ReadPreference::RP_SECONDARY is deprecated in %s
+
+Deprecated: MongoDB\Driver\ReadPreference::__construct(): Passing an integer mode to "MongoDB\Driver\ReadPreference::__construct" is deprecated and will be removed in a future release. in %s
+object(MongoDB\Driver\ReadPreference)#%d (%d) {
+  ["mode"]=>
+  string(9) "secondary"
+  ["hedge"]=>
+  object(stdClass)#%d (%d) {
+    ["enabled"]=>
+    bool(true)
+  }
+}
+
+Deprecated: Constant MongoDB\Driver\ReadPreference::RP_SECONDARY is deprecated in %s
+
+Deprecated: MongoDB\Driver\ReadPreference::__construct(): Passing an integer mode to "MongoDB\Driver\ReadPreference::__construct" is deprecated and will be removed in a future release. in %s
+object(MongoDB\Driver\ReadPreference)#%d (%d) {
+  ["mode"]=>
+  string(9) "secondary"
+}
+===DONE===

--- a/tests/readPreference/readpreference-ctor_error-001.phpt
+++ b/tests/readPreference/readpreference-ctor_error-001.phpt
@@ -6,7 +6,7 @@ MongoDB\Driver\ReadPreference construction (invalid mode)
 require_once __DIR__ . '/../utils/basic.inc';
 
 echo throws(function() {
-    new MongoDB\Driver\ReadPreference(42);
+    new MongoDB\Driver\ReadPreference('foo');
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
 ?>
@@ -14,5 +14,5 @@ echo throws(function() {
 <?php exit(0); ?>
 --EXPECT--
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
-Invalid mode: 42
+Invalid mode: 'foo'
 ===DONE===

--- a/tests/readPreference/readpreference-ctor_error-002.phpt
+++ b/tests/readPreference/readpreference-ctor_error-002.phpt
@@ -6,7 +6,7 @@ MongoDB\Driver\ReadPreference construction (invalid tagSets)
 require_once __DIR__ . '/../utils/basic.inc';
 
 echo throws(function() {
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY, [['tag' => 'one']]);
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY, [['tag' => 'one']]);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
 echo throws(function() {
@@ -14,16 +14,16 @@ echo throws(function() {
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
 echo throws(function() {
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY, ['invalid']);
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY, ['invalid']);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
 echo throws(function() {
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, ['invalid']);
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, ['invalid']);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
 // Ensure that tagSets is validated before maxStalenessSeconds option
 echo throws(function() {
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, ['invalid'], ['maxStalenessSeconds' => -2]);
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, ['invalid'], ['maxStalenessSeconds' => -2]);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
 ?>

--- a/tests/readPreference/readpreference-ctor_error-003.phpt
+++ b/tests/readPreference/readpreference-ctor_error-003.phpt
@@ -6,7 +6,7 @@ MongoDB\Driver\ReadPreference construction (invalid maxStalenessSeconds)
 require_once __DIR__ . '/../utils/basic.inc';
 
 echo throws(function() {
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY, null, ['maxStalenessSeconds' => 1000]);
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY, null, ['maxStalenessSeconds' => 1000]);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
 echo throws(function() {
@@ -14,15 +14,15 @@ echo throws(function() {
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
 echo throws(function() {
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, null, ['maxStalenessSeconds' => -2]);
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['maxStalenessSeconds' => -2]);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
 echo throws(function() {
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, null, ['maxStalenessSeconds' => 0]);
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['maxStalenessSeconds' => 0]);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
 echo throws(function() {
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, null, ['maxStalenessSeconds' => 42]);
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['maxStalenessSeconds' => 42]);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
 ?>

--- a/tests/readPreference/readpreference-ctor_error-004.phpt
+++ b/tests/readPreference/readpreference-ctor_error-004.phpt
@@ -8,7 +8,7 @@ MongoDB\Driver\ReadPreference construction (invalid maxStalenessSeconds range)
 require_once __DIR__ . '/../utils/basic.inc';
 
 echo throws(function() {
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, null, ['maxStalenessSeconds' => 2147483648]);
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['maxStalenessSeconds' => 2147483648]);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
 ?>

--- a/tests/readPreference/readpreference-ctor_error-007.phpt
+++ b/tests/readPreference/readpreference-ctor_error-007.phpt
@@ -6,7 +6,7 @@ MongoDB\Driver\ReadPreference construction (combining hedge with primary read pr
 require_once __DIR__ . '/../utils/basic.inc';
 
 echo throws(function() {
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY, null, ['hedge' => ['enabled' => true]]);
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY, null, ['hedge' => ['enabled' => true]]);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
 ?>

--- a/tests/readPreference/readpreference-debug-001.phpt
+++ b/tests/readPreference/readpreference-debug-001.phpt
@@ -6,16 +6,16 @@ MongoDB\Driver\ReadPreference debug output
 require_once __DIR__ . '/../utils/basic.inc';
 
 $tests = [
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY_PREFERRED),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY_PREFERRED),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_NEAREST),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY, []),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, [['dc' => 'ny']]),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, [['dc' => 'ny'], ['dc' => 'sf', 'use' => 'reporting'], []]),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, null, ['maxStalenessSeconds' => 1000]),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, null, ['hedge' => ['enabled' => true]]),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY_PREFERRED),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY_PREFERRED),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::NEAREST),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY, []),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, [['dc' => 'ny']]),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, [['dc' => 'ny'], ['dc' => 'sf', 'use' => 'reporting'], []]),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['maxStalenessSeconds' => 1000]),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['hedge' => ['enabled' => true]]),
 ];
 
 foreach ($tests as $test) {

--- a/tests/readPreference/readpreference-getHedge-001.phpt
+++ b/tests/readPreference/readpreference-getHedge-001.phpt
@@ -13,7 +13,7 @@ $tests = [
 ];
 
 foreach ($tests as $test) {
-    $rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, null, ['hedge' => $test]);
+    $rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['hedge' => $test]);
     var_dump($rp->getHedge());
 }
 

--- a/tests/readPreference/readpreference-getMaxStalenessMS-001.phpt
+++ b/tests/readPreference/readpreference-getMaxStalenessMS-001.phpt
@@ -14,7 +14,7 @@ $tests = [
 ];
 
 foreach ($tests as $test) {
-    $rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, null, ['maxStalenessSeconds' => $test]);
+    $rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['maxStalenessSeconds' => $test]);
     var_dump($rp->getMaxStalenessSeconds());
 }
 

--- a/tests/readPreference/readpreference-getMode-001.phpt
+++ b/tests/readPreference/readpreference-getMode-001.phpt
@@ -4,11 +4,11 @@ MongoDB\Driver\ReadPreference::getMode()
 <?php
 
 $tests = [
-    MongoDB\Driver\ReadPreference::RP_PRIMARY,
-    MongoDB\Driver\ReadPreference::RP_PRIMARY_PREFERRED,
-    MongoDB\Driver\ReadPreference::RP_SECONDARY,
-    MongoDB\Driver\ReadPreference::RP_SECONDARY_PREFERRED,
-    MongoDB\Driver\ReadPreference::RP_NEAREST,
+    MongoDB\Driver\ReadPreference::PRIMARY,
+    MongoDB\Driver\ReadPreference::PRIMARY_PREFERRED,
+    MongoDB\Driver\ReadPreference::SECONDARY,
+    MongoDB\Driver\ReadPreference::SECONDARY_PREFERRED,
+    MongoDB\Driver\ReadPreference::NEAREST,
 ];
 
 foreach ($tests as $test) {
@@ -19,10 +19,19 @@ foreach ($tests as $test) {
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECT--
+--EXPECTF--
+Deprecated: %s MongoDB\Driver\ReadPreference::getMode() is deprecated in %s
 int(1)
+
+Deprecated: %s MongoDB\Driver\ReadPreference::getMode() is deprecated in %s
 int(5)
+
+Deprecated: %s MongoDB\Driver\ReadPreference::getMode() is deprecated in %s
 int(2)
+
+Deprecated: %s MongoDB\Driver\ReadPreference::getMode() is deprecated in %s
 int(6)
+
+Deprecated: %s MongoDB\Driver\ReadPreference::getMode() is deprecated in %s
 int(10)
 ===DONE===

--- a/tests/readPreference/readpreference-getModeString-001.phpt
+++ b/tests/readPreference/readpreference-getModeString-001.phpt
@@ -4,11 +4,11 @@ MongoDB\Driver\ReadPreference::getModeString()
 <?php
 
 $tests = [
-    MongoDB\Driver\ReadPreference::RP_PRIMARY,
-    MongoDB\Driver\ReadPreference::RP_PRIMARY_PREFERRED,
-    MongoDB\Driver\ReadPreference::RP_SECONDARY,
-    MongoDB\Driver\ReadPreference::RP_SECONDARY_PREFERRED,
-    MongoDB\Driver\ReadPreference::RP_NEAREST,
+    MongoDB\Driver\ReadPreference::PRIMARY,
+    MongoDB\Driver\ReadPreference::PRIMARY_PREFERRED,
+    MongoDB\Driver\ReadPreference::SECONDARY,
+    MongoDB\Driver\ReadPreference::SECONDARY_PREFERRED,
+    MongoDB\Driver\ReadPreference::NEAREST,
 ];
 
 foreach ($tests as $test) {

--- a/tests/readPreference/readpreference-getTagSets-001.phpt
+++ b/tests/readPreference/readpreference-getTagSets-001.phpt
@@ -11,7 +11,7 @@ $tests = [
 ];
 
 foreach ($tests as $test) {
-    $rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY_PREFERRED, $test);
+    $rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY_PREFERRED, $test);
     var_dump($rp->getTagSets());
 }
 

--- a/tests/readPreference/readpreference-serialization-002.phpt
+++ b/tests/readPreference/readpreference-serialization-002.phpt
@@ -6,16 +6,16 @@ MongoDB\Driver\ReadPreference serialization (__serialize and __unserialize)
 require_once __DIR__ . '/../utils/basic.inc';
 
 $tests = [
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY_PREFERRED),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY_PREFERRED),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_NEAREST),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, []),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, [['dc' => 'ny']]),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, [['dc' => 'ny'], ['dc' => 'sf', 'use' => 'reporting'], []]),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, null, ['maxStalenessSeconds' => 1000]),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, null, ['hedge' => ['enabled' => true]]),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY_PREFERRED),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY_PREFERRED),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::NEAREST),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, []),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, [['dc' => 'ny']]),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, [['dc' => 'ny'], ['dc' => 'sf', 'use' => 'reporting'], []]),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['maxStalenessSeconds' => 1000]),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['hedge' => ['enabled' => true]]),
 ];
 
 foreach ($tests as $test) {

--- a/tests/readPreference/readpreference-var_export-001.phpt
+++ b/tests/readPreference/readpreference-var_export-001.phpt
@@ -6,15 +6,15 @@ MongoDB\Driver\ReadPreference: var_export()
 require_once __DIR__ . '/../utils/basic.inc';
 
 $tests = [
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY_PREFERRED),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY_PREFERRED),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_NEAREST),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY, []),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, [['dc' => 'ny']]),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, [['dc' => 'ny'], ['dc' => 'sf', 'use' => 'reporting'], []]),
-    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, null, ['maxStalenessSeconds' => 1000]),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY_PREFERRED),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY_PREFERRED),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::NEAREST),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY, []),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, [['dc' => 'ny']]),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, [['dc' => 'ny'], ['dc' => 'sf', 'use' => 'reporting'], []]),
+    new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['maxStalenessSeconds' => 1000]),
 ];
 
 foreach ($tests as $test) {

--- a/tests/replicaset/manager-selectserver-001.phpt
+++ b/tests/replicaset/manager-selectserver-001.phpt
@@ -13,9 +13,9 @@ require_once __DIR__ . "/../utils/basic.inc";
 // Explicitly use w:1 to work around MongoDB 5.0 applying w:majority (SERVER-61790)
 $manager = create_test_manager(URI, ['retryWrites' => false, 'w' => 1]);
 
-$rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY);
+$rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY);
 $server = $manager->selectServer($rp);
-$rp2 = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY);
+$rp2 = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY);
 $server2 = $manager->selectServer($rp2);
 
 // load fixtures for test

--- a/tests/replicaset/writeresult-getserver-001.phpt
+++ b/tests/replicaset/writeresult-getserver-001.phpt
@@ -28,7 +28,7 @@ $server2 = $server->executeBulkWrite(NS, $bulk)->getServer();
 var_dump($server == $server2);
 
 
-$rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY);
+$rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY);
 /* Fetch a secondary */
 $server3 = $manager->executeQuery(NS, new MongoDB\Driver\Query(array()), $rp)->getServer();
 

--- a/tests/replicaset/writeresult-getserver-002.phpt
+++ b/tests/replicaset/writeresult-getserver-002.phpt
@@ -31,7 +31,7 @@ $server2 = $server->executeBulkWrite(NS, $bulk)->getServer();
 var_dump($server == $server2);
 
 
-$rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY);
+$rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY);
 /* Fetch a secondary */
 $server3 = $manager->executeQuery(NS, new MongoDB\Driver\Query(array()), $rp)->getServer();
 

--- a/tests/server/bug0671-002.phpt
+++ b/tests/server/bug0671-002.phpt
@@ -9,7 +9,7 @@ PHPC-671: Segfault if Manager is already freed when using selected Server
 require_once __DIR__ . "/../utils/basic.inc";
 
 $manager = create_test_manager();
-$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY));
+$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY));
 
 unset($manager);
 

--- a/tests/server/server-executeBulkWrite-002.phpt
+++ b/tests/server/server-executeBulkWrite-002.phpt
@@ -9,7 +9,7 @@ MongoDB\Driver\Server::executeBulkWrite() with write concern (standalone)
 require_once __DIR__ . "/../utils/basic.inc";
 
 $manager = create_test_manager();
-$primary = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY));
+$primary = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY));
 
 $writeConcerns = array(0, 1);
 

--- a/tests/server/server-executeBulkWrite-003.phpt
+++ b/tests/server/server-executeBulkWrite-003.phpt
@@ -10,7 +10,7 @@ MongoDB\Driver\Server::executeBulkWrite() with legacy write concern (replica set
 require_once __DIR__ . "/../utils/basic.inc";
 
 $manager = create_test_manager();
-$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY));
+$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY));
 
 $writeConcerns = array(0, 1, 2, MongoDB\Driver\WriteConcern::MAJORITY);
 

--- a/tests/server/server-executeBulkWrite-004.phpt
+++ b/tests/server/server-executeBulkWrite-004.phpt
@@ -12,7 +12,7 @@ require_once __DIR__ . "/../utils/basic.inc";
 /* Disable retryWrites since the test expects to receive a "not primary" error,
  * which retryable writes would otherwise use to retry against the primary. */
 $manager = create_test_manager(URI, ['retryWrites' => false]);
-$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY));
+$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY));
 
 $writeConcerns = array(1, 2, MongoDB\Driver\WriteConcern::MAJORITY);
 

--- a/tests/server/server-executeBulkWrite-005.phpt
+++ b/tests/server/server-executeBulkWrite-005.phpt
@@ -13,7 +13,7 @@ require_once __DIR__ . "/../utils/basic.inc";
 // Disable retryWrites since the test writes to the unreplicated "local" database
 // Explicitly use w:1 to work around MongoDB 5.0 applying w:majority (SERVER-61790)
 $manager = create_test_manager(URI, ['retryWrites' => false, 'w' => 1]);
-$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY));
+$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY));
 
 /* The server ignores write concerns with w>2 for writes to the local database,
  * so we won't test behavior for w=2 and w=majority. */

--- a/tests/server/server-executeBulkWrite-006.phpt
+++ b/tests/server/server-executeBulkWrite-006.phpt
@@ -10,7 +10,7 @@ MongoDB\Driver\Server::executeBulkWrite() with legacy write concern (replica set
 require_once __DIR__ . "/../utils/basic.inc";
 
 $manager = create_test_manager();
-$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY));
+$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY));
 
 $writeConcerns = [0, 1, 2, MongoDB\Driver\WriteConcern::MAJORITY];
 

--- a/tests/server/server-executeBulkWrite-007.phpt
+++ b/tests/server/server-executeBulkWrite-007.phpt
@@ -12,7 +12,7 @@ require_once __DIR__ . "/../utils/basic.inc";
 /* Disable retryWrites since the test expects to receive a "not primary" error,
  * which retryable writes would otherwise use to retry against the primary. */
 $manager = create_test_manager(URI, ['retryWrites' => false]);
-$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY));
+$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY));
 
 $writeConcerns = [1, 2, MongoDB\Driver\WriteConcern::MAJORITY];
 

--- a/tests/server/server-executeBulkWrite_error-001.phpt
+++ b/tests/server/server-executeBulkWrite_error-001.phpt
@@ -9,7 +9,7 @@ MongoDB\Driver\Server::executeBulkWrite() with empty BulkWrite
 require_once __DIR__ . "/../utils/basic.inc";
 
 $manager = create_test_manager();
-$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY));
+$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY));
 
 echo throws(function() use ($server) {
     $server->executeBulkWrite(NS, new MongoDB\Driver\BulkWrite);

--- a/tests/server/server-executeBulkWrite_error-002.phpt
+++ b/tests/server/server-executeBulkWrite_error-002.phpt
@@ -8,7 +8,7 @@ MongoDB\Driver\Server::executeBulkWrite() with invalid options
 require_once __DIR__ . "/../utils/basic.inc";
 
 $manager = create_test_manager();
-$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY));
+$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY));
 
 echo throws(function() use ($server) {
     $bulk = new MongoDB\Driver\BulkWrite();

--- a/tests/server/server-executeCommand-002.phpt
+++ b/tests/server/server-executeCommand-002.phpt
@@ -11,7 +11,7 @@ require_once __DIR__ . "/../utils/basic.inc";
 
 $manager = create_test_manager();
 
-$rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY);
+$rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY);
 $secondary = $manager->selectServer($rp);
 
 $command = new MongoDB\Driver\Command(array('profile' => 2));

--- a/tests/server/server-executeCommand-003.phpt
+++ b/tests/server/server-executeCommand-003.phpt
@@ -10,13 +10,13 @@ require_once __DIR__ . "/../utils/basic.inc";
 
 $manager = create_test_manager();
 
-$secondaryRp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY);
+$secondaryRp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY);
 $secondary = $manager->selectServer($secondaryRp);
 
 /* Note: this is testing that the read preference (even a conflicting one) has
  * no effect when directly querying a server, since the secondaryOk flag is always
  * set for hinted commands. */
-$primaryRp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY);
+$primaryRp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY);
 $cursor = $secondary->executeCommand(DATABASE_NAME, new MongoDB\Driver\Command(array('ping' => 1)), $primaryRp);
 
 var_dump($cursor->toArray());

--- a/tests/server/server-executeCommand-004.phpt
+++ b/tests/server/server-executeCommand-004.phpt
@@ -11,8 +11,8 @@ require_once __DIR__ . "/../utils/basic.inc";
 
 $manager = create_test_manager();
 
-$primaryRp   = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY);
-$secondaryRp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY);
+$primaryRp   = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY);
+$secondaryRp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY);
 
 $primary   = $manager->selectServer($primaryRp);
 $secondary = $manager->selectServer($secondaryRp);

--- a/tests/server/server-executeCommand-005.phpt
+++ b/tests/server/server-executeCommand-005.phpt
@@ -11,8 +11,8 @@ require_once __DIR__ . "/../utils/basic.inc";
 
 $manager = create_test_manager();
 
-$primaryRp   = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY);
-$secondaryRp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY);
+$primaryRp   = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY);
+$secondaryRp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY);
 
 $primary   = $manager->selectServer($primaryRp);
 $secondary = $manager->selectServer($secondaryRp);

--- a/tests/server/server-executeCommand-006.phpt
+++ b/tests/server/server-executeCommand-006.phpt
@@ -11,7 +11,7 @@ require_once __DIR__ . "/../utils/basic.inc";
 require_once __DIR__ . "/../utils/observer.php";
 
 $manager = create_test_manager();
-$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY));
+$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY));
 
 (new CommandObserver)->observe(
     function() use ($server) {
@@ -24,7 +24,7 @@ $server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Drive
                 DATABASE_NAME,
                 $command,
                 [
-                    'readPreference' => new \MongoDB\Driver\ReadPreference(\MongoDB\Driver\ReadPreference::RP_SECONDARY),
+                    'readPreference' => new \MongoDB\Driver\ReadPreference(\MongoDB\Driver\ReadPreference::SECONDARY),
                     'readConcern' => new \MongoDB\Driver\ReadConcern(\MongoDB\Driver\ReadConcern::LOCAL),
                     'writeConcern' => new \MongoDB\Driver\WriteConcern(\MongoDB\Driver\WriteConcern::MAJORITY),
                 ]

--- a/tests/server/server-executeCommand-007.phpt
+++ b/tests/server/server-executeCommand-007.phpt
@@ -9,7 +9,7 @@ require_once __DIR__ . "/../utils/basic.inc";
 require_once __DIR__ . "/../utils/observer.php";
 
 $manager = create_test_manager();
-$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY));
+$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY));
 
 (new CommandObserver)->observe(
     function() use ($server) {
@@ -17,7 +17,7 @@ $server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Drive
             DATABASE_NAME,
             new MongoDB\Driver\Command(['ping' => true]),
             [
-                'readPreference' => new \MongoDB\Driver\ReadPreference(\MongoDB\Driver\ReadPreference::RP_NEAREST),
+                'readPreference' => new \MongoDB\Driver\ReadPreference(\MongoDB\Driver\ReadPreference::NEAREST),
             ]
         );
     },

--- a/tests/server/server-executeCommand-008.phpt
+++ b/tests/server/server-executeCommand-008.phpt
@@ -11,7 +11,7 @@ require_once __DIR__ . "/../utils/basic.inc";
 require_once __DIR__ . "/../utils/observer.php";
 
 $manager = create_test_manager();
-$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY));
+$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY));
 
 (new CommandObserver)->observe(
     function() use ($server) {
@@ -24,7 +24,7 @@ $server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Drive
                 DATABASE_NAME,
                 $command,
                 [
-                    'readPreference' => new \MongoDB\Driver\ReadPreference(\MongoDB\Driver\ReadPreference::RP_SECONDARY),
+                    'readPreference' => new \MongoDB\Driver\ReadPreference(\MongoDB\Driver\ReadPreference::SECONDARY),
                     'readConcern' => new \MongoDB\Driver\ReadConcern(\MongoDB\Driver\ReadConcern::LOCAL),
                     'writeConcern' => new \MongoDB\Driver\WriteConcern(\MongoDB\Driver\WriteConcern::MAJORITY),
                 ]

--- a/tests/server/server-executeCommand_error-001.phpt
+++ b/tests/server/server-executeCommand_error-001.phpt
@@ -8,7 +8,7 @@ MongoDB\Driver\Server::executeCommand() with invalid options (MONGOC_CMD_RAW)
 require_once __DIR__ . "/../utils/basic.inc";
 
 $manager = create_test_manager();
-$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY));
+$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY));
 
 $command = new MongoDB\Driver\Command(['ping' => 1]);
 

--- a/tests/server/server-executeQuery-006.phpt
+++ b/tests/server/server-executeQuery-006.phpt
@@ -11,7 +11,7 @@ require_once __DIR__ . "/../utils/basic.inc";
 
 $manager = create_test_manager();
 
-$rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY);
+$rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY);
 $secondary = $manager->selectServer($rp);
 
 $command = new MongoDB\Driver\Command(array('profile' => 2));

--- a/tests/server/server-executeQuery-008.phpt
+++ b/tests/server/server-executeQuery-008.phpt
@@ -11,7 +11,7 @@ require_once __DIR__ . "/../utils/basic.inc";
 
 $manager = create_test_manager();
 
-$primaryRp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY);
+$primaryRp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY);
 $primary = $manager->selectServer($primaryRp);
 
 // Count all data-bearing members to use for the write concern
@@ -23,7 +23,7 @@ $bulk = new \MongoDB\Driver\BulkWrite;
 $bulk->insert(['_id' => 1, 'x' => 1]);
 $primary->executeBulkWrite(NS, $bulk, new MongoDB\Driver\WriteConcern($dataBearingNodes));
 
-$secondaryRp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY);
+$secondaryRp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY);
 $secondary = $manager->selectServer($secondaryRp);
 
 /* Note: this is testing that the read preference (even a conflicting one) has

--- a/tests/server/server-executeQuery-009.phpt
+++ b/tests/server/server-executeQuery-009.phpt
@@ -16,8 +16,8 @@ $bulk = new MongoDB\Driver\BulkWrite();
 $bulk->insert(['_id' => 1, 'x' => 2, 'y' => 3]);
 $manager->executeBulkWrite(NS, $bulk);
 
-$primaryRp   = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY);
-$secondaryRp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY);
+$primaryRp   = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY);
+$secondaryRp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY);
 
 $primary   = $manager->selectServer($primaryRp);
 $secondary = $manager->selectServer($secondaryRp);

--- a/tests/server/server-executeQuery-010.phpt
+++ b/tests/server/server-executeQuery-010.phpt
@@ -16,8 +16,8 @@ $bulk = new MongoDB\Driver\BulkWrite();
 $bulk->insert(['_id' => 1, 'x' => 2, 'y' => 3]);
 $manager->executeBulkWrite(NS, $bulk);
 
-$primaryRp   = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY);
-$secondaryRp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY);
+$primaryRp   = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY);
+$secondaryRp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY);
 
 $primary   = $manager->selectServer($primaryRp);
 $secondary = $manager->selectServer($secondaryRp);

--- a/tests/server/server-executeQuery-011.phpt
+++ b/tests/server/server-executeQuery-011.phpt
@@ -9,7 +9,7 @@ require_once __DIR__ . "/../utils/basic.inc";
 require_once __DIR__ . "/../utils/observer.php";
 
 $manager = create_test_manager();
-$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY));
+$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY));
 
 (new CommandObserver)->observe(
     function() use ($server) {
@@ -17,7 +17,7 @@ $server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Drive
             NS,
             new MongoDB\Driver\Query(['x' => 1]),
             [
-                'readPreference' => new \MongoDB\Driver\ReadPreference(\MongoDB\Driver\ReadPreference::RP_NEAREST),
+                'readPreference' => new \MongoDB\Driver\ReadPreference(\MongoDB\Driver\ReadPreference::NEAREST),
             ]
         );
     },

--- a/tests/server/server-executeQuery_error-001.phpt
+++ b/tests/server/server-executeQuery_error-001.phpt
@@ -8,7 +8,7 @@ MongoDB\Driver\Server::executeQuery() with invalid options
 require_once __DIR__ . "/../utils/basic.inc";
 
 $manager = create_test_manager();
-$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY));
+$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY));
 
 $query = new MongoDB\Driver\Query(['x' => 3], ['projection' => ['y' => 1]]);
 

--- a/tests/server/server-executeReadCommand-001.phpt
+++ b/tests/server/server-executeReadCommand-001.phpt
@@ -13,7 +13,7 @@ require_once __DIR__ . "/../utils/basic.inc";
 require_once __DIR__ . "/../utils/observer.php";
 
 $manager = create_test_manager();
-$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY));
+$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY));
 
 (new CommandObserver)->observe(
     function() use ($server) {
@@ -26,7 +26,7 @@ $server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Drive
             DATABASE_NAME,
             $command,
             [
-                'readPreference' => new \MongoDB\Driver\ReadPreference(\MongoDB\Driver\ReadPreference::RP_SECONDARY),
+                'readPreference' => new \MongoDB\Driver\ReadPreference(\MongoDB\Driver\ReadPreference::SECONDARY),
                 'readConcern' => new \MongoDB\Driver\ReadConcern(\MongoDB\Driver\ReadConcern::MAJORITY),
             ]
         );

--- a/tests/server/server-executeReadCommand_error-001.phpt
+++ b/tests/server/server-executeReadCommand_error-001.phpt
@@ -11,7 +11,7 @@ MongoDB\Driver\Server::executeReadCommand() with invalid options
 require_once __DIR__ . "/../utils/basic.inc";
 
 $manager = create_test_manager();
-$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY));
+$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY));
 
 $command = new MongoDB\Driver\Command(['ping' => 1]);
 

--- a/tests/server/server-executeReadWriteCommand-001.phpt
+++ b/tests/server/server-executeReadWriteCommand-001.phpt
@@ -10,7 +10,7 @@ require_once __DIR__ . "/../utils/basic.inc";
 require_once __DIR__ . "/../utils/observer.php";
 
 $manager = create_test_manager();
-$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY));
+$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY));
 
 (new CommandObserver)->observe(
     function() use ($server) {

--- a/tests/server/server-executeReadWriteCommand_error-001.phpt
+++ b/tests/server/server-executeReadWriteCommand_error-001.phpt
@@ -11,7 +11,7 @@ MongoDB\Driver\Server::executeReadWriteCommand() with invalid options
 require_once __DIR__ . "/../utils/basic.inc";
 
 $manager = create_test_manager();
-$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY));
+$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY));
 
 $command = new MongoDB\Driver\Command(['ping' => 1]);
 

--- a/tests/server/server-executeWriteCommand-001.phpt
+++ b/tests/server/server-executeWriteCommand-001.phpt
@@ -10,7 +10,7 @@ require_once __DIR__ . "/../utils/basic.inc";
 require_once __DIR__ . "/../utils/observer.php";
 
 $manager = create_test_manager();
-$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY));
+$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY));
 
 $bw = new MongoDB\Driver\BulkWrite();
 $bw->insert(['a' => 1]);

--- a/tests/server/server-executeWriteCommand_error-001.phpt
+++ b/tests/server/server-executeWriteCommand_error-001.phpt
@@ -12,7 +12,7 @@ require_once __DIR__ . "/../utils/basic.inc";
 require_once __DIR__ . "/../utils/observer.php";
 
 $manager = create_test_manager();
-$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY));
+$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY));
 
 $command = new MongoDB\Driver\Command([]);
 

--- a/tests/server/server-getInfo-001.phpt
+++ b/tests/server/server-getInfo-001.phpt
@@ -10,7 +10,7 @@ require_once __DIR__ . "/../utils/basic.inc";
 $manager = create_test_manager();
 
 try{
-var_dump($manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY))->getInfo());
+var_dump($manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY))->getInfo());
 } catch (Exception $e) {}
 ?>
 ===DONE===

--- a/tests/server/server-getTags-001.phpt
+++ b/tests/server/server-getTags-001.phpt
@@ -11,7 +11,7 @@ require_once __DIR__ . "/../utils/basic.inc";
 
 $manager = create_test_manager();
 
-var_dump($manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY))->getTags());
+var_dump($manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY))->getTags());
 
 ?>
 ===DONE===

--- a/tests/session/session-startTransaction_error-002.phpt
+++ b/tests/session/session-startTransaction_error-002.phpt
@@ -21,7 +21,7 @@ $options = [
     [ 'readPreference' => new \MongoDB\Driver\ReadConcern( \MongoDB\Driver\ReadConcern::LOCAL ) ],
     [ 'writeConcern' => 42 ],
     [ 'writeConcern' => new stdClass ],
-    [ 'writeConcern' => new \MongoDB\Driver\ReadPreference( \MongoDB\Driver\ReadPreference::RP_SECONDARY ) ],
+    [ 'writeConcern' => new \MongoDB\Driver\ReadPreference( \MongoDB\Driver\ReadPreference::SECONDARY ) ],
 
     [
         'readConcern' => new \MongoDB\Driver\ReadConcern( \MongoDB\Driver\ReadConcern::LOCAL ),
@@ -29,11 +29,11 @@ $options = [
     ],
     [
         'readConcern' => new \MongoDB\Driver\ReadConcern( \MongoDB\Driver\ReadConcern::LOCAL ),
-        'writeConcern' => new \MongoDB\Driver\ReadPreference( \MongoDB\Driver\ReadPreference::RP_SECONDARY ),
+        'writeConcern' => new \MongoDB\Driver\ReadPreference( \MongoDB\Driver\ReadPreference::SECONDARY ),
     ],
     [
-        'readPreference' => new \MongoDB\Driver\ReadPreference( \MongoDB\Driver\ReadPreference::RP_SECONDARY ),
-        'writeConcern' => new \MongoDB\Driver\ReadPreference( \MongoDB\Driver\ReadPreference::RP_SECONDARY ),
+        'readPreference' => new \MongoDB\Driver\ReadPreference( \MongoDB\Driver\ReadPreference::SECONDARY ),
+        'writeConcern' => new \MongoDB\Driver\ReadPreference( \MongoDB\Driver\ReadPreference::SECONDARY ),
     ],
 ];
 

--- a/tests/standalone/manager-as-singleton.phpt
+++ b/tests/standalone/manager-as-singleton.phpt
@@ -30,7 +30,7 @@ class Database {
     }
  
     public function query($scheme, $query) {
-        return $this->Database->executeQuery($scheme, $query, new ReadPreference(ReadPreference::RP_PRIMARY));
+        return $this->Database->executeQuery($scheme, $query, new ReadPreference(ReadPreference::PRIMARY));
     }
 }
  

--- a/tests/utils/tools.php
+++ b/tests/utils/tools.php
@@ -517,7 +517,7 @@ function loadFixtures(Manager $manager, $dbname = DATABASE_NAME, $collname = COL
 
     $bulk = new BulkWrite(['ordered' => false]);
 
-    $server = $manager->selectServer(new ReadPreference(ReadPreference::RP_PRIMARY));
+    $server = $manager->selectServer(new ReadPreference(ReadPreference::PRIMARY));
 
     $data = file_get_contents($filename);
     $array = json_decode($data);

--- a/tests/writeResult/writeresult-getserver-001.phpt
+++ b/tests/writeResult/writeresult-getserver-001.phpt
@@ -9,7 +9,7 @@ MongoDB\Driver\WriteResult::getUpsertedIds()
 require_once __DIR__ . "/../utils/basic.inc";
 
 $manager = create_test_manager();
-$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY));
+$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY));
 
 $bulk = new MongoDB\Driver\BulkWrite;
 $bulk->insert(['x' => 1]);


### PR DESCRIPTION
PHPC-1489

This deprecates the `RP_*` constants in `MongoDB\Driver\ReadPreference` constants, along with passing an int in the constructor and using `getMode`.

Note that PHP 8.3 and newer automagically triggers warnings when using deprecated warnings. Calling deprecated methods results in a warning starting in PHP 7.4 (albeit with a wrong message in PHP 7.4).