### PR TITLE
WIP: Use forked setup-php-sdk

### DIFF
--- a/.github/actions/windows/prepare-build/action.yml
+++ b/.github/actions/windows/prepare-build/action.yml
@@ -31,7 +31,7 @@ runs:
 
     - name: Setup PHP SDK
       id: setup-php
-      uses: php/setup-php-sdk@v0.8
+      uses: alcaeus/setup-php-sdk@fix-old-php-install
       with:
         version: ${{ inputs.version }}
         arch: ${{ inputs.arch }}


### PR DESCRIPTION
Packages for old PHP versions are have moved to a different folder, causing download issues in the setup-php-sdk action. This PR switches to a forked version until the upstream action is fixed.