### PR TITLE
Fix failing tests on x86 systems

### DIFF
--- a/tests/bson/bson-int64-001.phpt
+++ b/tests/bson/bson-int64-001.phpt
@@ -17,13 +17,15 @@ $tests = [
 ];
 
 foreach($tests as $test) {
-    $bson = fromPHP($test);
-    $testRoundtripped = toPHP($bson);
-    $bsonRoundtripped = fromPHP($testRoundtripped);
+    $bson = MongoDB\BSON\fromPHP($test);
+    $testRoundtripped = MongoDB\BSON\toPHP($bson);
+    $bsonRoundtripped = MongoDB\BSON\fromPHP($testRoundtripped);
+    $json = MongoDB\BSON\toJSON($bson);
+    $jsonRoundtripped = MongoDB\BSON\toJSON($bsonRoundtripped);
 
     var_dump($test->int64 instanceof MongoDB\BSON\Int64);
     var_dump($testRoundtripped->int64 instanceof MongoDB\BSON\Int64);
-    var_dump(toJSON($bson), toJSON($bsonRoundtripped));
+    var_dump($json, $jsonRoundtripped);
     var_dump($test == $testRoundtripped);
 
     echo "\n";
@@ -32,25 +34,64 @@ foreach($tests as $test) {
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function MongoDB\BSON\fromPHP() is deprecated in %s
+
+Deprecated: Function MongoDB\BSON\toPHP() is deprecated in %s
+
+Deprecated: Function MongoDB\BSON\fromPHP() is deprecated in %s
+
+Deprecated: Function MongoDB\BSON\toJSON() is deprecated in %s
+
+Deprecated: Function MongoDB\BSON\toJSON() is deprecated in %s
 bool(true)
 bool(true)
 string(33) "{ "int64" : 9223372036854775807 }"
 string(33) "{ "int64" : 9223372036854775807 }"
 bool(true)
 
+
+Deprecated: Function MongoDB\BSON\fromPHP() is deprecated in %s
+
+Deprecated: Function MongoDB\BSON\toPHP() is deprecated in %s
+
+Deprecated: Function MongoDB\BSON\fromPHP() is deprecated in %s
+
+Deprecated: Function MongoDB\BSON\toJSON() is deprecated in %s
+
+Deprecated: Function MongoDB\BSON\toJSON() is deprecated in %s
 bool(true)
 bool(true)
 string(34) "{ "int64" : -9223372036854775808 }"
 string(34) "{ "int64" : -9223372036854775808 }"
 bool(true)
 
+
+Deprecated: Function MongoDB\BSON\fromPHP() is deprecated in %s
+
+Deprecated: Function MongoDB\BSON\toPHP() is deprecated in %s
+
+Deprecated: Function MongoDB\BSON\fromPHP() is deprecated in %s
+
+Deprecated: Function MongoDB\BSON\toJSON() is deprecated in %s
+
+Deprecated: Function MongoDB\BSON\toJSON() is deprecated in %s
 bool(true)
 bool(true)
 string(24) "{ "int64" : 2147483648 }"
 string(24) "{ "int64" : 2147483648 }"
 bool(true)
 
+
+Deprecated: Function MongoDB\BSON\fromPHP() is deprecated in %s
+
+Deprecated: Function MongoDB\BSON\toPHP() is deprecated in %s
+
+Deprecated: Function MongoDB\BSON\fromPHP() is deprecated in %s
+
+Deprecated: Function MongoDB\BSON\toJSON() is deprecated in %s
+
+Deprecated: Function MongoDB\BSON\toJSON() is deprecated in %s
 bool(true)
 bool(true)
 string(25) "{ "int64" : -2147483649 }"

--- a/tests/bson/bson-int64-002.phpt
+++ b/tests/bson/bson-int64-002.phpt
@@ -8,25 +8,28 @@ MongoDB\BSON\Int64 wraps 64-bit integers on 32-bit platforms
 require_once __DIR__ . '/../utils/basic.inc';
 
 $tests = [
-    MongoDB\BSON\toPHP(MongoDB\BSON\fromJSON('{"max64": {"$numberLong": "9223372036854775807"}}')),
-    MongoDB\BSON\toPHP(MongoDB\BSON\fromJSON('{"min64": {"$numberLong": "-9223372036854775808"}}')),
-    MongoDB\BSON\toPHP(MongoDB\BSON\fromJSON('{"max32+1": {"$numberLong": "2147483648"}}')),
-    MongoDB\BSON\toPHP(MongoDB\BSON\fromJSON('{"min32-1": {"$numberLong": "-2147483649"}}')),
+    '{"max64": {"$numberLong": "9223372036854775807"}}',
+    '{"min64": {"$numberLong": "-9223372036854775808"}}',
+    '{"max32+1": {"$numberLong": "2147483648"}}',
+    '{"min32-1": {"$numberLong": "-2147483649"}}',
     // Numbers within the range of 32-bit integers will not be wrapped
-    MongoDB\BSON\toPHP(MongoDB\BSON\fromJSON('{"max32": {"$numberLong": "2147483647"}}')),
-    MongoDB\BSON\toPHP(MongoDB\BSON\fromJSON('{"min32": {"$numberLong": "-2147483648"}}')),
-    MongoDB\BSON\toPHP(MongoDB\BSON\fromJSON('{"zero": {"$numberLong": "0"}}')),
+    '{"max32": {"$numberLong": "2147483647"}}',
+    '{"min32": {"$numberLong": "-2147483648"}}',
+    '{"zero": {"$numberLong": "0"}}',
     
 ];
 
 foreach ($tests as $test) {
-    var_dump($test);
+    var_dump(MongoDB\BSON\toPHP(MongoDB\BSON\fromJSON($test)));
 }
 
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+Deprecated: Function MongoDB\BSON\fromJSON() is deprecated in %s
+
+Deprecated: Function MongoDB\BSON\toPHP() is deprecated in %s
 object(stdClass)#%d (%d) {
   ["max64"]=>
   object(MongoDB\BSON\Int64)#%d (%d) {
@@ -34,6 +37,10 @@ object(stdClass)#%d (%d) {
     string(19) "9223372036854775807"
   }
 }
+
+Deprecated: Function MongoDB\BSON\fromJSON() is deprecated in %s
+
+Deprecated: Function MongoDB\BSON\toPHP() is deprecated in %s
 object(stdClass)#%d (%d) {
   ["min64"]=>
   object(MongoDB\BSON\Int64)#%d (%d) {
@@ -41,6 +48,10 @@ object(stdClass)#%d (%d) {
     string(20) "-9223372036854775808"
   }
 }
+
+Deprecated: Function MongoDB\BSON\fromJSON() is deprecated in %s
+
+Deprecated: Function MongoDB\BSON\toPHP() is deprecated in %s
 object(stdClass)#%d (%d) {
   ["max32+1"]=>
   object(MongoDB\BSON\Int64)#%d (%d) {
@@ -48,6 +59,10 @@ object(stdClass)#%d (%d) {
     string(10) "2147483648"
   }
 }
+
+Deprecated: Function MongoDB\BSON\fromJSON() is deprecated in %s
+
+Deprecated: Function MongoDB\BSON\toPHP() is deprecated in %s
 object(stdClass)#%d (%d) {
   ["min32-1"]=>
   object(MongoDB\BSON\Int64)#%d (%d) {
@@ -55,14 +70,26 @@ object(stdClass)#%d (%d) {
     string(11) "-2147483649"
   }
 }
+
+Deprecated: Function MongoDB\BSON\fromJSON() is deprecated in %s
+
+Deprecated: Function MongoDB\BSON\toPHP() is deprecated in %s
 object(stdClass)#%d (%d) {
   ["max32"]=>
   int(2147483647)
 }
+
+Deprecated: Function MongoDB\BSON\fromJSON() is deprecated in %s
+
+Deprecated: Function MongoDB\BSON\toPHP() is deprecated in %s
 object(stdClass)#%d (%d) {
   ["min32"]=>
   int(-2147483648)
 }
+
+Deprecated: Function MongoDB\BSON\fromJSON() is deprecated in %s
+
+Deprecated: Function MongoDB\BSON\toPHP() is deprecated in %s
 object(stdClass)#%d (%d) {
   ["zero"]=>
   int(0)

--- a/tests/bson/bug0592.phpt
+++ b/tests/bson/bug0592.phpt
@@ -23,7 +23,7 @@ $tests = [
 foreach ($tests as $json) {
     printf("Test %s\n", $json);
     try {
-        $encoded = toPHP(fromJSON($json));
+        $encoded = MongoDB\BSON\toPHP(MongoDB\BSON\fromJSON($json));
         var_dump( $encoded );
     } catch ( MongoDB\Driver\Exception\InvalidArgumentException $e ) {
         echo "MongoDB\Driver\Exception\InvalidArgumentException: ", $e->getMessage(), "\n";
@@ -36,18 +36,30 @@ foreach ($tests as $json) {
 <?php exit(0); ?>
 --EXPECTF--
 Test { "x": { "$numberLong": "-2147483648" }}
+
+Deprecated: Function MongoDB\BSON\fromJSON() is deprecated in %s
+
+Deprecated: Function MongoDB\BSON\toPHP() is deprecated in %s
 object(stdClass)#%d (%d) {
   ["x"]=>
   int(-2147483648)
 }
 
 Test { "x": { "$numberLong": "2147483647" }}
+
+Deprecated: Function MongoDB\BSON\fromJSON() is deprecated in %s
+
+Deprecated: Function MongoDB\BSON\toPHP() is deprecated in %s
 object(stdClass)#%d (%d) {
   ["x"]=>
   int(2147483647)
 }
 
 Test { "x": { "$numberLong": "4294967294" }}
+
+Deprecated: Function MongoDB\BSON\fromJSON() is deprecated in %s
+
+Deprecated: Function MongoDB\BSON\toPHP() is deprecated in %s
 object(stdClass)#%d (%d) {
   ["x"]=>
   object(MongoDB\BSON\Int64)#%d (%d) {
@@ -57,6 +69,10 @@ object(stdClass)#%d (%d) {
 }
 
 Test { "x": { "$numberLong": "4294967295" }}
+
+Deprecated: Function MongoDB\BSON\fromJSON() is deprecated in %s
+
+Deprecated: Function MongoDB\BSON\toPHP() is deprecated in %s
 object(stdClass)#%d (%d) {
   ["x"]=>
   object(MongoDB\BSON\Int64)#%d (%d) {
@@ -66,6 +82,10 @@ object(stdClass)#%d (%d) {
 }
 
 Test { "x": { "$numberLong": "9223372036854775807" }}
+
+Deprecated: Function MongoDB\BSON\fromJSON() is deprecated in %s
+
+Deprecated: Function MongoDB\BSON\toPHP() is deprecated in %s
 object(stdClass)#%d (%d) {
   ["x"]=>
   object(MongoDB\BSON\Int64)#%d (%d) {
@@ -75,18 +95,30 @@ object(stdClass)#%d (%d) {
 }
 
 Test { "longFieldName": { "$numberLong": "-2147483648" }}
+
+Deprecated: Function MongoDB\BSON\fromJSON() is deprecated in %s
+
+Deprecated: Function MongoDB\BSON\toPHP() is deprecated in %s
 object(stdClass)#%d (%d) {
   ["longFieldName"]=>
   int(-2147483648)
 }
 
 Test { "longFieldName": { "$numberLong": "2147483647" }}
+
+Deprecated: Function MongoDB\BSON\fromJSON() is deprecated in %s
+
+Deprecated: Function MongoDB\BSON\toPHP() is deprecated in %s
 object(stdClass)#%d (%d) {
   ["longFieldName"]=>
   int(2147483647)
 }
 
 Test { "longFieldName": { "$numberLong": "4294967294" }}
+
+Deprecated: Function MongoDB\BSON\fromJSON() is deprecated in %s
+
+Deprecated: Function MongoDB\BSON\toPHP() is deprecated in %s
 object(stdClass)#%d (%d) {
   ["longFieldName"]=>
   object(MongoDB\BSON\Int64)#%d (%d) {
@@ -96,6 +128,10 @@ object(stdClass)#%d (%d) {
 }
 
 Test { "longFieldName": { "$numberLong": "4294967295" }}
+
+Deprecated: Function MongoDB\BSON\fromJSON() is deprecated in %s
+
+Deprecated: Function MongoDB\BSON\toPHP() is deprecated in %s
 object(stdClass)#%d (%d) {
   ["longFieldName"]=>
   object(MongoDB\BSON\Int64)#%d (%d) {
@@ -105,6 +141,10 @@ object(stdClass)#%d (%d) {
 }
 
 Test { "longFieldName": { "$numberLong": "9223372036854775807" }}
+
+Deprecated: Function MongoDB\BSON\fromJSON() is deprecated in %s
+
+Deprecated: Function MongoDB\BSON\toPHP() is deprecated in %s
 object(stdClass)#%d (%d) {
   ["longFieldName"]=>
   object(MongoDB\BSON\Int64)#%d (%d) {


### PR DESCRIPTION
I missed these failures in #1607

These tests specifically test roundtripping 64-bit integers, which are returned as `Int64` instances on 32-bit systems only. Since the `MongoDB\BSON\Document` API always returns `Int64` instances, I changed the tests to use the deprecated BSON API as the entire behaviour will be removed in 2.0.