### PR TITLE
PHPC-1957 Add tests for out-of-range `UTCDateTime` values

### DIFF
--- a/tests/bson/bson-utcdatetime-serialization_error-002.phpt
+++ b/tests/bson/bson-utcdatetime-serialization_error-002.phpt
@@ -9,7 +9,18 @@ echo throws(function() {
     unserialize('C:24:"MongoDB\BSON\UTCDateTime":42:{a:1:{s:12:"milliseconds";s:9:"1234.5678";}}');
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
-/* TODO: Add tests for out-of-range values once CDRIVER-1377 is resolved */
+// Out-of-range values
+echo throws(function() {
+    unserialize('C:24:"MongoDB\BSON\UTCDateTime":53:{a:1:{s:12:"milliseconds";s:19:"9223372036854775808";}}');
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() {
+    unserialize('C:24:"MongoDB\BSON\UTCDateTime":54:{a:1:{s:12:"milliseconds";s:20:"-9223372036854775809";}}');
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() {
+    unserialize('C:24:"MongoDB\BSON\UTCDateTime":54:{a:1:{s:12:"milliseconds";s:20:"18446744073709551615";}}');
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
 ?>
 ===DONE===
@@ -17,4 +28,10 @@ echo throws(function() {
 --EXPECT--
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Error parsing "1234.5678" as 64-bit integer for MongoDB\BSON\UTCDateTime initialization
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Error parsing "9223372036854775808" as 64-bit integer for MongoDB\BSON\UTCDateTime initialization
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Error parsing "-9223372036854775809" as 64-bit integer for MongoDB\BSON\UTCDateTime initialization
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Error parsing "18446744073709551615" as 64-bit integer for MongoDB\BSON\UTCDateTime initialization
 ===DONE===

--- a/tests/bson/bson-utcdatetime-serialization_error-004.phpt
+++ b/tests/bson/bson-utcdatetime-serialization_error-004.phpt
@@ -9,7 +9,18 @@ echo throws(function() {
     unserialize('O:24:"MongoDB\BSON\UTCDateTime":1:{s:12:"milliseconds";s:9:"1234.5678";}');
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
-/* TODO: Add tests for out-of-range values once CDRIVER-1377 is resolved */
+// Out-of-range values
+echo throws(function() {
+    unserialize('O:24:"MongoDB\BSON\UTCDateTime":1:{s:12:"milliseconds";s:19:"9223372036854775808";}');
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() {
+    unserialize('O:24:"MongoDB\BSON\UTCDateTime":1:{s:12:"milliseconds";s:20:"-9223372036854775809";}');
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() {
+    unserialize('O:24:"MongoDB\BSON\UTCDateTime":1:{s:12:"milliseconds";s:20:"18446744073709551615";}');
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
 ?>
 ===DONE===
@@ -17,4 +28,10 @@ echo throws(function() {
 --EXPECT--
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Error parsing "1234.5678" as 64-bit integer for MongoDB\BSON\UTCDateTime initialization
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Error parsing "9223372036854775808" as 64-bit integer for MongoDB\BSON\UTCDateTime initialization
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Error parsing "-9223372036854775809" as 64-bit integer for MongoDB\BSON\UTCDateTime initialization
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Error parsing "18446744073709551615" as 64-bit integer for MongoDB\BSON\UTCDateTime initialization
 ===DONE===

--- a/tests/bson/bson-utcdatetime-set_state_error-002.phpt
+++ b/tests/bson/bson-utcdatetime-set_state_error-002.phpt
@@ -9,7 +9,18 @@ echo throws(function() {
     MongoDB\BSON\UTCDateTime::__set_state(['milliseconds' => '1234.5678']);
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
-/* TODO: Add tests for out-of-range values once CDRIVER-1377 is resolved */
+// Out-of-range values
+echo throws(function() {
+    MongoDB\BSON\UTCDateTime::__set_state(['milliseconds' => '9223372036854775808']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() {
+    MongoDB\BSON\UTCDateTime::__set_state(['milliseconds' => '-9223372036854775809']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() {
+    MongoDB\BSON\UTCDateTime::__set_state(['milliseconds' => '18446744073709551615']);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
 ?>
 ===DONE===
@@ -17,4 +28,10 @@ echo throws(function() {
 --EXPECT--
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Error parsing "1234.5678" as 64-bit integer for MongoDB\BSON\UTCDateTime initialization
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Error parsing "9223372036854775808" as 64-bit integer for MongoDB\BSON\UTCDateTime initialization
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Error parsing "-9223372036854775809" as 64-bit integer for MongoDB\BSON\UTCDateTime initialization
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Error parsing "18446744073709551615" as 64-bit integer for MongoDB\BSON\UTCDateTime initialization
 ===DONE===

--- a/tests/bson/bson-utcdatetime_error-003.phpt
+++ b/tests/bson/bson-utcdatetime_error-003.phpt
@@ -9,7 +9,19 @@ echo throws(function() {
     new MongoDB\BSON\UTCDateTime('1234.5678');
 }, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
 
-/* TODO: Add tests for out-of-range values once CDRIVER-1377 is resolved */
+// Out-of-range values
+echo throws(function() {
+    new MongoDB\BSON\UTCDateTime('9223372036854775808');
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() {
+    new MongoDB\BSON\UTCDateTime('-9223372036854775809');
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() {
+    new MongoDB\BSON\UTCDateTime('18446744073709551615');
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
 
 ?>
 ===DONE===
@@ -17,4 +29,10 @@ echo throws(function() {
 --EXPECT--
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Error parsing "1234.5678" as 64-bit integer for MongoDB\BSON\UTCDateTime initialization
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Error parsing "9223372036854775808" as 64-bit integer for MongoDB\BSON\UTCDateTime initialization
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Error parsing "-9223372036854775809" as 64-bit integer for MongoDB\BSON\UTCDateTime initialization
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Error parsing "18446744073709551615" as 64-bit integer for MongoDB\BSON\UTCDateTime initialization
 ===DONE===


### PR DESCRIPTION
Fix [PHPC-1957](https://jira.mongodb.org/browse/PHPC-1957)

Test cases from @jmikola's [comment](https://jira.mongodb.org/browse/CDRIVER-1377?focusedCommentId=1323383&focusedId=1323383&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1323383).

I don't think we need to replicate all the tests for the C driver: https://github.com/mongodb/libbson/commit/877c4652bc032e960b712d7829fa1b8fe47c5552#diff-f659e15d1c412b12aedd35fd33872db3e54e03fa9e69927ba905924613c6c66dR211-R263