### PR TITLE
Use drivers-evergreen-tools for Windows testing

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -97,7 +97,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Note: keep this in sync with the Windows matrix in windows-tests.yml
+        # Note: keep this in sync with the Windows matrix in tests.yml
         php: [ "7.4", "8.0", "8.1", "8.2", "8.3" ]
         arch: [ x64, x86 ]
         ts: [ ts, nts ]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -110,3 +110,19 @@ jobs:
 
       - name: "Install release archive to verify correctness"
         run: sudo pecl install ${{ env.PACKAGE_FILE }}
+
+  test-windows:
+    name: "Windows Tests"
+    uses: ./.github/workflows/windows-tests.yml
+    with:
+      php: ${{ matrix.php }}
+      arch: ${{ matrix.arch }}
+      ts: ${{ matrix.ts }}
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        # Note: keep this in sync with the Windows matrix in package-release.yml
+        php: [ "7.4", "8.0", "8.1", "8.2", "8.3" ]
+        arch: [ x64, x86 ]
+        ts: [ ts, nts ]

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -72,6 +72,12 @@ jobs:
         with:
           submodules: true
 
+      - id: setup-mongodb
+        uses: mongodb-labs/drivers-evergreen-tools@master
+        with:
+          version: "7.0"
+          topology: "server"
+
       - name: Prepare build environment
         id: prepare-build
         uses: ./.github/actions/windows/prepare-build
@@ -90,17 +96,11 @@ jobs:
             ${{ steps.prepare-build.outputs.build-dir }}\php_mongodb.dll
             ${{ steps.prepare-build.outputs.build-dir }}\php_mongodb.pdb
 
-      - name: Start MongoDB
-        run: |
-          sc config MongoDB start= auto
-          sc start MongoDB
-
-      - name: Wait until MongoDB is available
-        run: .github/workflows/wait-for-mongodb.bat
-
       - name: Run Tests
         run: nmake /nologo test
         env:
           NO_INTERACTION: 1
           REPORT_EXIT_STATUS: 1
           TESTS: --show-diff
+          MONGODB_URI: ${{ steps.setup-mongodb.outputs.cluster-uri }}
+          CRYPT_SHARED_LIB_PATH: ${{ steps.setup-mongodb.outputs.crypt-shared-lib-path }}

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -1,32 +1,33 @@
 name: "Windows Tests"
+run-name: "Windows Tests (PHP ${{ inputs.php }} ${{ inputs.arch }} ${{ inputs.ts }})"
 
 on:
-  pull_request:
-    branches:
-      - "v*.*"
-      - "master"
-      - "feature/*"
-  push:
-    branches:
-      - "v*.*"
-      - "master"
-      - "feature/*"
+  workflow_call:
+    inputs:
+      php:
+        description: "The PHP version to build for"
+        type: string
+        required: true
+      arch:
+        description: "The architecture to build for (x64 or x86)"
+        type: string
+        required: true
+      ts:
+        description: "Thread safety (ts or nts)"
+        type: string
+        required: true
+      upload_release_asset:
+        description: "Whether to upload a release asset"
+        type: boolean
+        default: false
 
 jobs:
   build:
-    name: "Build Windows DLLs"
+    name: "Build Driver"
     runs-on: windows-2022
     defaults:
       run:
         shell: cmd
-
-    strategy:
-      # This matrix intentionally uses fail-fast: false to ensure other builds are finished
-      fail-fast: false
-      matrix:
-        php: [ "7.4", "8.0", "8.1", "8.2", "8.3" ]
-        arch: [ x64, x86 ]
-        ts: [ ts, nts ]
 
     steps:
       - uses: actions/checkout@v4
@@ -37,35 +38,26 @@ jobs:
         id: build-driver
         uses: ./.github/actions/windows/build
         with:
-          version: ${{ matrix.php }}
-          arch: ${{ matrix.arch }}
-          ts: ${{ matrix.ts }}
+          version: ${{ inputs.php }}
+          arch: ${{ inputs.arch }}
+          ts: ${{ inputs.ts }}
 
       - name: Cache build artifacts for subsequent builds
         id: cache-build-artifacts
         uses: actions/cache/save@v4
         with:
-          key: ${{ github.sha }}-${{ matrix.php }}-${{ matrix.ts }}-${{ matrix.arch }}
+          key: ${{ github.sha }}-${{ inputs.php }}-${{ inputs.ts }}-${{ inputs.arch }}
           path: |
             ${{ steps.build-driver.outputs.build-dir }}\php_mongodb.dll
             ${{ steps.build-driver.outputs.build-dir }}\php_mongodb.pdb
 
   test:
-    name: "Windows Tests"
+    name: "Run Tests"
     runs-on: windows-2022
     needs: build
     defaults:
       run:
         shell: cmd
-
-    strategy:
-      # Timeouts starting the MongoDB service are common and should not
-      # interrupt the overall test matrix.
-      fail-fast: false
-      matrix:
-        php: [ "7.4", "8.0", "8.1", "8.2", "8.3" ]
-        arch: [ x64, x86 ]
-        ts: [ ts, nts ]
 
     steps:
       - uses: actions/checkout@v4
@@ -82,16 +74,16 @@ jobs:
         id: prepare-build
         uses: ./.github/actions/windows/prepare-build
         with:
-          version: ${{ matrix.php }}
-          arch: ${{ matrix.arch }}
-          ts: ${{ matrix.ts }}
+          version: ${{ inputs.php }}
+          arch: ${{ inputs.arch }}
+          ts: ${{ inputs.ts }}
 
       - name: Restore cached build artifacts
         id: cache-build-artifacts
         uses: actions/cache/restore@v4
         with:
           fail-on-cache-miss: true
-          key: ${{ github.sha }}-${{ matrix.php }}-${{ matrix.ts }}-${{ matrix.arch }}
+          key: ${{ github.sha }}-${{ inputs.php }}-${{ inputs.ts }}-${{ inputs.arch }}
           path: |
             ${{ steps.prepare-build.outputs.build-dir }}\php_mongodb.dll
             ${{ steps.prepare-build.outputs.build-dir }}\php_mongodb.pdb

--- a/src/MongoDB/Monitoring/ServerHeartbeatSucceededEvent.c
+++ b/src/MongoDB/Monitoring/ServerHeartbeatSucceededEvent.c
@@ -124,6 +124,7 @@ static HashTable* php_phongo_serverheartbeatsucceededevent_get_debug_info(phongo
 	ADD_ASSOC_STRING(&retval, "host", intern->host.host);
 	ADD_ASSOC_LONG_EX(&retval, "port", intern->host.port);
 	ADD_ASSOC_BOOL_EX(&retval, "awaited", intern->awaited);
+	ADD_ASSOC_INT64(&retval, "durationMicros", intern->duration_micros);
 
 	if (!php_phongo_bson_to_zval_ex(intern->reply, &reply_state)) {
 		zval_ptr_dtor(&reply_state.zchild);

--- a/src/phongo_structs.h
+++ b/src/phongo_structs.h
@@ -341,7 +341,7 @@ typedef struct {
 
 typedef struct {
 	bool               awaited;
-	uint64_t           duration_micros;
+	int64_t            duration_micros;
 	zval               z_error;
 	mongoc_host_list_t host;
 	zend_object        std;
@@ -355,7 +355,7 @@ typedef struct {
 
 typedef struct {
 	bool               awaited;
-	uint64_t           duration_micros;
+	int64_t            duration_micros;
 	mongoc_host_list_t host;
 	bson_t*            reply;
 	zend_object        std;

--- a/tests/apm/serverHeartbeatSucceededEvent-001.phpt
+++ b/tests/apm/serverHeartbeatSucceededEvent-001.phpt
@@ -68,6 +68,8 @@ object(MongoDB\Driver\Monitoring\ServerHeartbeatSucceededEvent)#%d (%d) {
   int(%d)
   ["awaited"]=>
   bool(%s)
+  ["durationMicros"]=>
+  int(%d)
   ["reply"]=>
   object(stdClass)#%d (%d) {%A
   }


### PR DESCRIPTION
This PR makes several changes, all related to how we start MongoDB on Windows. Since the previous method of starting MongoDB would often time out, the Windows workflow now uses drivers-evergreen-tools to start clusters. This should be more reliable and as a side effect uses the same configs we use for our Linux testing. As part of this change, I have also re-organised the windows workflows so that tests for a given variant (i.e. the combination of PHP version, architecture, and thread safety) start immediately after the corresponding build has completed, not only after all builds have completed. This yields faster test results.

During testing, I discovered an issue in the tests for `ServerHeartbeatFailedEvent`, where an expected integer return was actually returned as an `Int64` instance on 32-bit platforms. After some investigation I found that this was due to the type being wrong - libmongoc returns an `int64_t`, while we store a `uint64_t`. This caused issues when comparing the value to `INT32_MAX` and `INT32_MIN` on 32-bit platforms, erroneously returning an `Int64` instance which should only happen when the value exceeds the bounds of a 32-bit integer. During that investigation I also found that the same issue affects `ServerHeartbeatSucceededEvent`, but it didn't get exposed because the duration was not added to the `var_dump` output. All these issues have been fixed.