### PR TITLE
PHPC-2420: Compare Int64 instances without casting

### DIFF
--- a/src/BSON/Int64.c
+++ b/src/BSON/Int64.c
@@ -345,6 +345,15 @@ static int php_phongo_int64_compare_objects(zval* o1, zval* o2)
 	return 0;
 }
 
+#if PHP_VERSION_ID < 80000
+static int php_phongo_int64_compare_zvals(zval* result, zval* op1, zval* op2)
+{
+	ZVAL_LONG(result, php_phongo_int64_compare_objects(op1, op2));
+
+	return SUCCESS;
+}
+#endif
+
 static zend_result php_phongo_int64_cast_object(phongo_compat_object_handler_type* readobj, zval* retval, int type)
 {
 	php_phongo_int64_t* intern;
@@ -627,6 +636,12 @@ void php_phongo_int64_init_ce(INIT_FUNC_ARGS)
 	php_phongo_handler_int64.offset         = XtOffsetOf(php_phongo_int64_t, std);
 	php_phongo_handler_int64.cast_object    = php_phongo_int64_cast_object;
 	php_phongo_handler_int64.do_operation   = php_phongo_int64_do_operation;
+
+	/* On PHP 7.4, compare_objects is only used when comparing two objects.
+	 * Use the compare handler to compare an object with any other zval */
+#if PHP_VERSION_ID < 80000
+	php_phongo_handler_int64.compare = php_phongo_int64_compare_zvals;
+#endif
 }
 
 bool phongo_int64_new(zval* object, int64_t integer)

--- a/tests/bson/bson-int64-compare-005.phpt
+++ b/tests/bson/bson-int64-compare-005.phpt
@@ -1,5 +1,7 @@
 --TEST--
-MongoDB\BSON\Int64 comparisons with scalars (64-bit values, all platforms)
+MongoDB\BSON\Int64 comparisons with scalars (64-bit values, 64-bit platforms only)
+--SKIPIF--
+<?php if (8 !== PHP_INT_SIZE) { die('skip Only for 64-bit platform'); } ?>
 --FILE--
 <?php
 
@@ -7,21 +9,18 @@ MongoDB\BSON\Int64 comparisons with scalars (64-bit values, all platforms)
 $int64 = new MongoDB\BSON\Int64('8589934592');
 
 $tests = [
-    'matching float' => (float) 2**33,
-    'wrong int' => 0,
+    'matching int' => 8589934592,
+    'wrong int' => 8589934593,
 ];
 
 foreach ($tests as $name => $value) {
     printf('Testing %s: %s' . PHP_EOL, $name, var_export($int64 == $value, true));
 }
 
-var_dump($int64 > 123);
-
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECT--
-Testing matching float: true
+Testing matching int: true
 Testing wrong int: false
-bool(true)
 ===DONE===


### PR DESCRIPTION
PHPC-2420

Previously, we deferred to `zend_std_compare_objects` when comparing a single `Int64` instance with a long or double. By default, this will attempt to cast values to long or double, then comparing it. On 32-bit platforms, this cast truncates any value outside of the 32-bit range and yields a warning about this truncation. This means that we were not able to properly compare such values, even when we technically would easily be able to (as only the value of `ZEND_LONG` is limited to 32 bits, but `int64_t` is still available).

This PR changes this logic to specifically handle comparisons between to `Int64` instances as well as a single `Int64` instance with a long or double. Only if the instance is being compared with anything else will we attempt to cast the value. This removes warnings and fixes comparisons of 64-bit values on 32-bit platforms.