### PR TITLE
PHPC-2403: Remove optional sparsity and trimFactor options

### DIFF
--- a/tests/clientEncryption/clientEncryption-encryptExpression-001.phpt
+++ b/tests/clientEncryption/clientEncryption-encryptExpression-001.phpt
@@ -25,7 +25,7 @@ $encryptOpts = [
     'algorithm' => MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE,
     'queryType' => MongoDB\Driver\ClientEncryption::QUERY_TYPE_RANGE,
     'contentionFactor' => 0,
-    'rangeOpts' => ['min' => 0, 'max' => 200, 'sparsity' => 1, 'trimFactor' => 1],
+    'rangeOpts' => ['min' => 0, 'max' => 200],
 ];
 
 $expr = [

--- a/tests/clientEncryption/clientEncryption-encryptExpression_error-002.phpt
+++ b/tests/clientEncryption/clientEncryption-encryptExpression_error-002.phpt
@@ -25,7 +25,7 @@ $encryptOpts = [
     'algorithm' => MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE,
     'queryType' => MongoDB\Driver\ClientEncryption::QUERY_TYPE_RANGE,
     'contentionFactor' => 0,
-    'rangeOpts' => ['min' => 0, 'max' => 200, 'sparsity' => 1, 'trimFactor' => 1],
+    'rangeOpts' => ['min' => 0, 'max' => 200],
 ];
 
 echo throws(function() use ($clientEncryption, $encryptOpts) {


### PR DESCRIPTION
PHPC-2403

With `sparsity` and `trimFactor` now optional, we can remove them from the tests (see https://github.com/mongodb/mongo-php-driver/pull/1583#discussion_r1638671510 for context).