### PR TITLE
Update GitHub Actions job names

### DIFF
--- a/.github/workflows/arginfo-files.yml
+++ b/.github/workflows/arginfo-files.yml
@@ -12,15 +12,13 @@ on:
       - "master"
       - "feature/*"
 
+env:
+  PHP_VERSION: "8.2"
+
 jobs:
   check-arginfo:
     name: "Check generated arginfo files"
     runs-on: "ubuntu-20.04"
-
-    strategy:
-      matrix:
-        php-version:
-          - "8.2"
 
     steps:
       - name: "Checkout"
@@ -31,7 +29,7 @@ jobs:
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
-          php-version: "${{ matrix.php-version }}"
+          php-version: "${{ env.PHP_VERSION }}"
 
       - name: "Run phpize"
         run: phpize

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -12,15 +12,13 @@ on:
       - "master"
       - "feature/*"
 
+env:
+  PHP_VERSION: "7.4"
+
 jobs:
   coding-standards:
     name: "Coding Standards"
     runs-on: "ubuntu-20.04"
-
-    strategy:
-      matrix:
-        php-version:
-          - "7.4"
 
     steps:
       - name: "Checkout"
@@ -31,7 +29,7 @@ jobs:
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
-          php-version: "${{ matrix.php-version }}"
+          php-version: "${{ env.PHP_VERSION }}"
 
       - name: "Configure driver"
         run: .github/workflows/configure.sh


### PR DESCRIPTION
This PR removes the matrix strategy, as using it will include the PHP version in the name of the job, making it more difficult to have required check across branches. By setting it as an env var, we can avoid duplication as well have a consistent name for the checks after changing the PHP requirement in #1631.