### PR TITLE
Fix exception message expectation on MongoDB latest

### DIFF
--- a/tests/manager/manager-executeBulkWrite-011.phpt
+++ b/tests/manager/manager-executeBulkWrite-011.phpt
@@ -57,7 +57,7 @@ var_dump(iterator_to_array($cursor));
 OK: Got MongoDB\Driver\Exception\BulkWriteException
 Document failed validation
 OK: Got MongoDB\Driver\Exception\BulkWriteException
-Document failed validation
+%SDocument failed validation
 array(3) {
   [0]=>
   object(stdClass)#%d (2) {


### PR DESCRIPTION
On MongoDB latest, the error message is different as the validation is handled by the execution planner. The additional `%S` ensures that tests pass on upcoming versions of MongoDB as well.