### PR TITLE
PHPC-2505: Fix foreach after GC invocation

### DIFF
--- a/phongo.c
+++ b/phongo.c
@@ -155,13 +155,6 @@ static zend_class_entry* phongo_fetch_internal_class(const char* class_name, siz
 	return NULL;
 }
 
-static HashTable* phongo_std_get_gc(zend_object* object, zval** table, int* n)
-{
-	*table = NULL;
-	*n     = 0;
-	return zend_std_get_properties(object);
-}
-
 PHP_MINIT_FUNCTION(mongodb) /* {{{ */
 {
 	bson_mem_vtable_t bson_mem_vtable = {
@@ -197,9 +190,6 @@ PHP_MINIT_FUNCTION(mongodb) /* {{{ */
 	/* Disable cloning by default. Individual classes can opt in if they need to
 	 * support this (e.g. BSON objects). */
 	phongo_std_object_handlers.clone_obj = NULL;
-	/* Ensure that get_gc delegates to zend_std_get_properties directly in case
-	 * our class defines a get_properties handler for debugging purposes. */
-	phongo_std_object_handlers.get_gc = phongo_std_get_gc;
 
 	/* Initialize zend_class_entry dependencies.
 	 *

--- a/phongo.h
+++ b/phongo.h
@@ -77,8 +77,7 @@ zend_object_handlers* phongo_get_std_object_handlers(void);
 #define PHONGO_GET_PROPERTY_HASH_FREE_PROPS(is_temp, props) \
 	do {                                                    \
 		if (is_temp) {                                      \
-			zend_hash_destroy((props));                     \
-			FREE_HASHTABLE(props);                          \
+			zend_hash_release((props));                     \
 		}                                                   \
 	} while (0)
 

--- a/src/BSON/Document.c
+++ b/src/BSON/Document.c
@@ -425,8 +425,7 @@ static void phongo_document_free_object(zend_object* object)
 	}
 
 	if (intern->properties) {
-		zend_hash_destroy(intern->properties);
-		FREE_HASHTABLE(intern->properties);
+		zend_hash_release(intern->properties);
 	}
 }
 

--- a/src/MongoDB/Manager.c
+++ b/src/MongoDB/Manager.c
@@ -779,8 +779,7 @@ static void phongo_manager_free_object(zend_object* object)
 	}
 
 	if (intern->subscribers) {
-		zend_hash_destroy(intern->subscribers);
-		FREE_HASHTABLE(intern->subscribers);
+		zend_hash_release(intern->subscribers);
 	}
 }
 

--- a/tests/bson/bug2505-001.phpt
+++ b/tests/bson/bug2505-001.phpt
@@ -1,0 +1,71 @@
+--TEST--
+PHPC-2505: gc_collect_cycles() may interfere with using foreach to iterate objects
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+gc_disable();
+
+$tests = [
+    [ 'binary' => new MongoDB\BSON\Binary('foo', MongoDB\BSON\Binary::TYPE_GENERIC) ],
+    [ 'dbpointer' => createDBPointer() ],
+    [ 'decimal128' => new MongoDB\BSON\Decimal128('1234.5678') ],
+    [ 'int64' => new MongoDB\BSON\Int64('9223372036854775807') ],
+    // JavaScript w/ scope may not be necessary (same code path as w/o scope), but we'll test it anyway
+    [ 'javascript' => new MongoDB\BSON\Javascript('function() { return 1; }') ],
+
+    // The context is recreated every time with a different object ID
+    //[ 'javascript_ws' => new MongoDB\BSON\Javascript('function() { return a; }', ['a' => 1]) ],
+
+    // MaxKey and MinKey don't have get_properties or get_gc handlers, but we'll test them anyway
+    [ 'maxkey' => new MongoDB\BSON\MaxKey ],
+    [ 'minkey' => new MongoDB\BSON\MinKey ],
+    [ 'objectid' => new MongoDB\BSON\ObjectId ],
+    [ 'regex' => new MongoDB\BSON\Regex('pattern', 'i') ],
+    [ 'symbol' => createSymbol() ],
+    [ 'timestamp' => new MongoDB\BSON\Timestamp(1234, 5678) ],
+    [ 'utcdatetime' => new MongoDB\BSON\UTCDateTime ],
+];
+
+ob_start();
+foreach ($tests as $test) {
+    echo key($test), "\n";
+    $test = reset($test);
+
+    foreach ($test as $k => $v) {
+        var_dump($k, $v);
+    }
+}
+$buf1 = ob_get_clean();
+if ($buf1 === false) {
+    throw new \AssertionError("Could not flush buffer");
+}
+
+gc_enable();
+gc_collect_cycles();
+
+ob_start();
+foreach ($tests as $test) {
+    echo key($test), "\n";
+    $test = reset($test);
+
+    foreach ($test as $k => $v) {
+        var_dump($k, $v);
+    }
+}
+$buf2 = ob_get_clean();
+if ($buf2 === false) {
+    throw new \AssertionError("Could not flush buffer");
+}
+
+if ($buf1 === $buf2) {
+    echo "OK!\n";
+    exit(0);
+} else {
+    echo("buf1 != buf2: $buf1\n\n IS NOT EQUAL TO \n\n$buf2\n");
+    exit(1);
+}
+
+?>
+--EXPECT--
+OK!


### PR DESCRIPTION
## Summary

Fixes a GC/foreach inconsistency for BSON objects: iterating a BSON object with `foreach` after `gc_collect_cycles()` (or after setting/unsetting a dynamic property) could return an empty result set.

### Root cause

The shared `get_gc` handler in `phongo.c` was calling `zend_std_get_properties`, which populates the `zend_object`'s internal properties table as a side-effect. When the GC later collects that table, it corrupts the cached `intern->properties` HashTable used by `get_properties` — causing subsequent `foreach` iterations to yield no results.

### Fix

- Remove the custom `phongo_std_get_gc` handler (and its registration) from `phongo.c`
- Add a `php_properties` HashTable to each affected BSON struct to store dynamic PHP properties separately from the internal `properties` cache
- Add per-class property handlers (`PHONGO_DEFINE_PROPERTY_HANDLERS` / `PHONGO_ASSIGN_PROPERTY_HANDLERS`) so that `read_property`, `write_property`, `has_property`, `unset_property`, `get_property_ptr_ptr`, and `get_gc` all operate exclusively on `php_properties` — never on the internal BSON properties cache
- Replace `zend_hash_destroy` + `FREE_HASHTABLE` with `zend_hash_release` throughout

### Scope

All BSON types are treated uniformly: `Binary`, `DBPointer`, `Decimal128`, `Document`, `Int64`, `Iterator`, `Javascript`, `MaxKey`, `MinKey`, `ObjectId`, `PackedArray`, `Regex`, `Symbol`, `Timestamp`, `UTCDateTime`. `MaxKey` and `MinKey` are included because without custom property handlers, dynamic property assignment on them produces deprecation warnings on PHP 8.2+.

`Manager`, `ServerApi`, `ServerDescription`, and `TopologyDescription` are intentionally out of scope; they can be addressed separately (e.g. via the declared-properties approach from PHPC-2699).

## Test plan

- [x] `tests/bson/bug2505-001.phpt` — `gc_collect_cycles()` does not affect `foreach`
- [x] `tests/bson/bug2505-002.phpt` — set/unset a property does not affect `foreach`
- [x] `tests/bson/bug2505-003.phpt` — set/unset via reference does not affect `foreach`
- [x] `tests/bson/bug1598-002.phpt` — GC correctly collects cycles through BSON objects (PHP ≥ 8.2 skip removed)