### PR TITLE
PHPC-2745: Reject null bytes in namespaces and periods in database names [v2.4]

### DIFF
--- a/src/MongoDB/ClientEncryption.c
+++ b/src/MongoDB/ClientEncryption.c
@@ -567,6 +567,14 @@ static mongoc_client_encryption_opts_t* phongo_clientencryption_opts_from_zval(z
 
 		key_vault_namespace = php_array_fetchc_string(options, "keyVaultNamespace", &plen, &pfree);
 
+		if (!phongo_validate_namespace(key_vault_namespace, plen)) {
+			if (pfree) {
+				efree(key_vault_namespace);
+			}
+
+			goto cleanup;
+		}
+
 		if (!phongo_split_namespace(key_vault_namespace, &db_name, &coll_name)) {
 			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"keyVaultNamespace\" option to contain a full collection namespace");
 

--- a/src/MongoDB/Manager.c
+++ b/src/MongoDB/Manager.c
@@ -310,7 +310,7 @@ static PHP_METHOD(MongoDB_Driver_Manager, executeCommand)
 	 * session pool is cleared. */
 	PHONGO_RESET_CLIENT_IF_PID_DIFFERS(intern, intern);
 
-	phongo_execute_command(getThis(), PHONGO_COMMAND_RAW, db, command, options, server_id, return_value);
+	phongo_execute_command(getThis(), PHONGO_COMMAND_RAW, db, db_len, command, options, server_id, return_value);
 }
 
 /* Execute a ReadCommand */
@@ -353,7 +353,7 @@ static PHP_METHOD(MongoDB_Driver_Manager, executeReadCommand)
 	 * session pool is cleared. */
 	PHONGO_RESET_CLIENT_IF_PID_DIFFERS(intern, intern);
 
-	phongo_execute_command(getThis(), PHONGO_COMMAND_READ, db, command, options, server_id, return_value);
+	phongo_execute_command(getThis(), PHONGO_COMMAND_READ, db, db_len, command, options, server_id, return_value);
 }
 
 /* Execute a WriteCommand */
@@ -390,7 +390,7 @@ static PHP_METHOD(MongoDB_Driver_Manager, executeWriteCommand)
 	 * session pool is cleared. */
 	PHONGO_RESET_CLIENT_IF_PID_DIFFERS(intern, intern);
 
-	phongo_execute_command(getThis(), PHONGO_COMMAND_WRITE, db, command, options, server_id, return_value);
+	phongo_execute_command(getThis(), PHONGO_COMMAND_WRITE, db, db_len, command, options, server_id, return_value);
 }
 
 /* Execute a ReadWriteCommand */
@@ -427,7 +427,7 @@ static PHP_METHOD(MongoDB_Driver_Manager, executeReadWriteCommand)
 	 * session pool is cleared. */
 	PHONGO_RESET_CLIENT_IF_PID_DIFFERS(intern, intern);
 
-	phongo_execute_command(getThis(), PHONGO_COMMAND_READ_WRITE, db, command, options, server_id, return_value);
+	phongo_execute_command(getThis(), PHONGO_COMMAND_READ_WRITE, db, db_len, command, options, server_id, return_value);
 }
 
 /* Execute a Query */
@@ -470,7 +470,7 @@ static PHP_METHOD(MongoDB_Driver_Manager, executeQuery)
 	 * session pool is cleared. */
 	PHONGO_RESET_CLIENT_IF_PID_DIFFERS(intern, intern);
 
-	phongo_execute_query(getThis(), namespace, query, options, server_id, return_value);
+	phongo_execute_query(getThis(), namespace, namespace_len, query, options, server_id, return_value);
 }
 
 /* Executes a BulkWrite (i.e. any number of insert, update, and delete ops) */
@@ -509,7 +509,7 @@ static PHP_METHOD(MongoDB_Driver_Manager, executeBulkWrite)
 	 * that its session pool is cleared. */
 	PHONGO_RESET_CLIENT_IF_PID_DIFFERS(intern, intern);
 
-	phongo_execute_bulk_write(getThis(), namespace, bulk, options, server_id, return_value);
+	phongo_execute_bulk_write(getThis(), namespace, namespace_len, bulk, options, server_id, return_value);
 }
 
 /* Executes a BulkWriteCommand (i.e. bulkWrite command for MongoDB 8.0+) */

--- a/src/MongoDB/Server.c
+++ b/src/MongoDB/Server.c
@@ -57,7 +57,7 @@ static PHP_METHOD(MongoDB_Driver_Server, executeCommand)
 	 * session pool is cleared. */
 	PHONGO_RESET_CLIENT_IF_PID_DIFFERS(intern, Z_MANAGER_OBJ_P(&intern->manager));
 
-	phongo_execute_command(&intern->manager, PHONGO_COMMAND_RAW, db, command, options, intern->server_id, return_value);
+	phongo_execute_command(&intern->manager, PHONGO_COMMAND_RAW, db, db_len, command, options, intern->server_id, return_value);
 }
 
 /* Executes a ReadCommand on this Server */
@@ -82,7 +82,7 @@ static PHP_METHOD(MongoDB_Driver_Server, executeReadCommand)
 	 * session pool is cleared. */
 	PHONGO_RESET_CLIENT_IF_PID_DIFFERS(intern, Z_MANAGER_OBJ_P(&intern->manager));
 
-	phongo_execute_command(&intern->manager, PHONGO_COMMAND_READ, db, command, options, intern->server_id, return_value);
+	phongo_execute_command(&intern->manager, PHONGO_COMMAND_READ, db, db_len, command, options, intern->server_id, return_value);
 }
 
 /* Executes a WriteCommand on this Server */
@@ -107,7 +107,7 @@ static PHP_METHOD(MongoDB_Driver_Server, executeWriteCommand)
 	 * session pool is cleared. */
 	PHONGO_RESET_CLIENT_IF_PID_DIFFERS(intern, Z_MANAGER_OBJ_P(&intern->manager));
 
-	phongo_execute_command(&intern->manager, PHONGO_COMMAND_WRITE, db, command, options, intern->server_id, return_value);
+	phongo_execute_command(&intern->manager, PHONGO_COMMAND_WRITE, db, db_len, command, options, intern->server_id, return_value);
 }
 
 /* Executes a ReadWriteCommand on this Server */
@@ -132,7 +132,7 @@ static PHP_METHOD(MongoDB_Driver_Server, executeReadWriteCommand)
 	 * session pool is cleared. */
 	PHONGO_RESET_CLIENT_IF_PID_DIFFERS(intern, Z_MANAGER_OBJ_P(&intern->manager));
 
-	phongo_execute_command(&intern->manager, PHONGO_COMMAND_READ_WRITE, db, command, options, intern->server_id, return_value);
+	phongo_execute_command(&intern->manager, PHONGO_COMMAND_READ_WRITE, db, db_len, command, options, intern->server_id, return_value);
 }
 
 /* Executes a Query on this Server */
@@ -157,7 +157,7 @@ static PHP_METHOD(MongoDB_Driver_Server, executeQuery)
 	 * session pool is cleared. */
 	PHONGO_RESET_CLIENT_IF_PID_DIFFERS(intern, Z_MANAGER_OBJ_P(&intern->manager));
 
-	phongo_execute_query(&intern->manager, namespace, query, options, intern->server_id, return_value);
+	phongo_execute_query(&intern->manager, namespace, namespace_len, query, options, intern->server_id, return_value);
 }
 
 /* Executes a BulkWrite (i.e. any number of insert, update, and delete ops) on
@@ -185,7 +185,7 @@ static PHP_METHOD(MongoDB_Driver_Server, executeBulkWrite)
 	 * that its session pool is cleared. */
 	PHONGO_RESET_CLIENT_IF_PID_DIFFERS(intern, Z_MANAGER_OBJ_P(&intern->manager));
 
-	phongo_execute_bulk_write(&intern->manager, namespace, bulk, options, intern->server_id, return_value);
+	phongo_execute_bulk_write(&intern->manager, namespace, namespace_len, bulk, options, intern->server_id, return_value);
 }
 
 /* Executes a BulkWriteCommand (i.e. bulkWrite command for MongoDB 8.0+) */

--- a/src/phongo_client.c
+++ b/src/phongo_client.c
@@ -1225,6 +1225,14 @@ static bool phongo_manager_set_auto_encryption_opts(phongo_manager_t* manager, z
 
 		key_vault_ns = php_array_fetchc_string(zAutoEncryptionOpts, "keyVaultNamespace", &plen, &pfree);
 
+		if (!phongo_validate_namespace(key_vault_ns, plen)) {
+			if (pfree) {
+				efree(key_vault_ns);
+			}
+
+			goto cleanup;
+		}
+
 		if (!phongo_split_namespace(key_vault_ns, &db_name, &coll_name)) {
 			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"keyVaultNamespace\" autoEncryption option to contain a full collection namespace");
 

--- a/src/phongo_execute.c
+++ b/src/phongo_execute.c
@@ -231,7 +231,7 @@ static bool phongo_parse_write_concern(zval* options, bson_t* mongoc_opts, zval*
 	return true;
 }
 
-bool phongo_execute_bulk_write(zval* manager, const char* namespace, phongo_bulkwrite_t* bulk_write, zval* options, uint32_t server_id, zval* return_value)
+bool phongo_execute_bulk_write(zval* manager, const char* namespace, size_t namespace_len, phongo_bulkwrite_t* bulk_write, zval* options, uint32_t server_id, zval* return_value)
 {
 	mongoc_client_t*              client = NULL;
 	bson_error_t                  error  = { 0 };
@@ -246,6 +246,10 @@ bool phongo_execute_bulk_write(zval* manager, const char* namespace, phongo_bulk
 
 	if (bulk_write->executed) {
 		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "BulkWrite objects may only be executed once and this instance has already been executed");
+		return false;
+	}
+
+	if (!phongo_validate_namespace(namespace, namespace_len)) {
 		return false;
 	}
 
@@ -461,7 +465,7 @@ cleanup:
 	return success;
 }
 
-bool phongo_execute_command(zval* manager, phongo_command_type_t type, const char* db, zval* zcommand, zval* options, uint32_t server_id, zval* return_value)
+bool phongo_execute_command(zval* manager, phongo_command_type_t type, const char* db, size_t db_len, zval* zcommand, zval* options, uint32_t server_id, zval* return_value)
 {
 	mongoc_client_t*        client;
 	const phongo_command_t* command;
@@ -479,6 +483,10 @@ bool phongo_execute_command(zval* manager, phongo_command_type_t type, const cha
 
 	client  = Z_MANAGER_OBJ_P(manager)->client;
 	command = Z_COMMAND_OBJ_P(zcommand);
+
+	if (!phongo_validate_dbname(db, db_len)) {
+		goto cleanup;
+	}
 
 	if ((type & PHONGO_OPTION_READ_CONCERN) && !phongo_parse_read_concern(options, &opts)) {
 		/* Exception should already have been thrown */
@@ -631,7 +639,7 @@ cleanup:
 	return result;
 }
 
-bool phongo_execute_query(zval* manager, const char* namespace, zval* zquery, zval* options, uint32_t server_id, zval* return_value)
+bool phongo_execute_query(zval* manager, const char* namespace, size_t namespace_len, zval* zquery, zval* options, uint32_t server_id, zval* return_value)
 {
 	mongoc_client_t*      client;
 	const phongo_query_t* query;
@@ -644,6 +652,10 @@ bool phongo_execute_query(zval* manager, const char* namespace, zval* zquery, zv
 	zval*                 zsession        = NULL;
 
 	client = Z_MANAGER_OBJ_P(manager)->client;
+
+	if (!phongo_validate_namespace(namespace, namespace_len)) {
+		return false;
+	}
 
 	if (!phongo_split_namespace(namespace, &dbname, &collname)) {
 		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "%s: %s", "Invalid namespace provided", namespace);

--- a/src/phongo_execute.h
+++ b/src/phongo_execute.h
@@ -38,10 +38,10 @@ typedef enum {
 	PHONGO_COMMAND_READ_WRITE     = 0x05,
 } phongo_command_type_t;
 
-bool phongo_execute_bulk_write(zval* manager, const char* namespace, phongo_bulkwrite_t* bulk_write, zval* zwriteConcern, uint32_t server_id, zval* return_value);
+bool phongo_execute_bulk_write(zval* manager, const char* namespace, size_t namespace_len, phongo_bulkwrite_t* bulk_write, zval* zwriteConcern, uint32_t server_id, zval* return_value);
 bool phongo_execute_bulkwritecommand(zval* manager, phongo_bulkwritecommand_t* bwc, zval* zoptions, uint32_t server_id, zval* return_value);
-bool phongo_execute_command(zval* manager, phongo_command_type_t type, const char* db, zval* zcommand, zval* zreadPreference, uint32_t server_id, zval* return_value);
-bool phongo_execute_query(zval* manager, const char* namespace, zval* zquery, zval* zreadPreference, uint32_t server_id, zval* return_value);
+bool phongo_execute_command(zval* manager, phongo_command_type_t type, const char* db, size_t db_len, zval* zcommand, zval* zreadPreference, uint32_t server_id, zval* return_value);
+bool phongo_execute_query(zval* manager, const char* namespace, size_t namespace_len, zval* zquery, zval* zreadPreference, uint32_t server_id, zval* return_value);
 
 bool phongo_parse_read_preference(zval* options, zval** zreadPreference);
 bool phongo_parse_session(zval* options, mongoc_client_t* client, bson_t* mongoc_opts, zval** zsession);

--- a/src/phongo_util.c
+++ b/src/phongo_util.c
@@ -19,6 +19,7 @@
 
 #include <php.h>
 
+#include "phongo_error.h"
 #include "phongo_util.h"
 
 const char* phongo_bson_type_to_string(bson_type_t type)
@@ -105,6 +106,48 @@ bool phongo_split_namespace(const char* namespace, char** dbname, char** cname)
 	}
 	if (dbname) {
 		*dbname = estrndup(namespace, dot - namespace);
+	}
+
+	return true;
+}
+
+/* Rejects a namespace that contains a NUL byte. A NUL byte would truncate the
+ * database or collection name at the C-string layer before it reaches the
+ * server, silently retargeting the operation. A period is not rejected here: it
+ * separates the database and collection names, and a period is valid in a
+ * collection name. */
+bool phongo_validate_namespace(const char* namespace, size_t namespace_len)
+{
+	if (namespace == NULL) {
+		return true;
+	}
+
+	if (memchr(namespace, '\0', namespace_len) != NULL) {
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "%s", "Invalid namespace provided: namespaces may not contain a null byte");
+		return false;
+	}
+
+	return true;
+}
+
+/* Rejects a database name that contains a NUL byte or a period. A NUL byte
+ * would truncate the name at the C-string layer; a period would be interpreted
+ * by the server as a namespace separator and retarget the command to a
+ * different database. */
+bool phongo_validate_dbname(const char* db, size_t db_len)
+{
+	if (db == NULL) {
+		return true;
+	}
+
+	if (memchr(db, '\0', db_len) != NULL) {
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "%s", "Invalid database name provided: database names may not contain a null byte");
+		return false;
+	}
+
+	if (memchr(db, '.', db_len) != NULL) {
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "%s: %s", "Invalid database name provided: database names may not contain a '.' character", db);
+		return false;
 	}
 
 	return true;

--- a/src/phongo_util.h
+++ b/src/phongo_util.h
@@ -25,4 +25,7 @@ bool phongo_parse_int64(int64_t* retval, const char* data, size_t data_len);
 
 bool phongo_split_namespace(const char* namespace, char** dbname, char** cname);
 
+bool phongo_validate_namespace(const char* namespace, size_t namespace_len);
+bool phongo_validate_dbname(const char* db, size_t db_len);
+
 #endif /* PHONGO_UTIL_H */

--- a/tests/clientEncryption/clientEncryption-ctor_error-002.phpt
+++ b/tests/clientEncryption/clientEncryption-ctor_error-002.phpt
@@ -21,6 +21,10 @@ $tests = [
         // keyVaultNamespace requires a valid kmsProviders option
         'kmsProviders' => ['local' => ['key' => new MongoDB\BSON\Binary(CSFLE_LOCAL_KEY, 0)]],
     ] + $baseOptions,
+    [
+        'keyVaultNamespace' => "keyvault.data\0keys",
+        'kmsProviders' => ['local' => ['key' => new MongoDB\BSON\Binary(CSFLE_LOCAL_KEY, 0)]],
+    ] + $baseOptions,
     ['kmsProviders' => 'not_an_array_or_object'] + $baseOptions,
     ['tlsOptions' => 'not_an_array_or_object'] + $baseOptions,
 ];
@@ -55,6 +59,9 @@ Expected "keyVaultClient" option to be MongoDB\Driver\Manager, string given
 
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected "keyVaultNamespace" option to contain a full collection namespace
+
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Invalid namespace provided: namespaces may not contain a null byte
 
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Expected "kmsProviders" option to be an array or object, string given

--- a/tests/manager/manager-executeBulkWrite_error-012.phpt
+++ b/tests/manager/manager-executeBulkWrite_error-012.phpt
@@ -1,0 +1,36 @@
+--TEST--
+MongoDB\Driver\Manager::executeBulkWrite() rejects a null byte in the namespace
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_not_live(); ?>
+--FILE--
+<?php
+
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = create_test_manager();
+
+/* A null byte in the collection name would truncate the namespace at the
+ * C-string layer and silently retarget the write. */
+echo throws(function() use ($manager) {
+    $bulk = new MongoDB\Driver\BulkWrite();
+    $bulk->insert(['x' => 1]);
+    $manager->executeBulkWrite("database.col\0lection", $bulk);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+/* A null byte in the database name is rejected the same way. */
+echo throws(function() use ($manager) {
+    $bulk = new MongoDB\Driver\BulkWrite();
+    $bulk->insert(['x' => 1]);
+    $manager->executeBulkWrite("data\0base.collection", $bulk);
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Invalid namespace provided: namespaces may not contain a null byte
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Invalid namespace provided: namespaces may not contain a null byte
+===DONE===

--- a/tests/manager/manager-executeCommand_error-006.phpt
+++ b/tests/manager/manager-executeCommand_error-006.phpt
@@ -1,0 +1,45 @@
+--TEST--
+MongoDB\Driver\Manager::executeCommand() rejects a null byte or period in the database name
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_not_live(); ?>
+--FILE--
+<?php
+
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = create_test_manager();
+
+/* A null byte would truncate the database name at the C-string layer. */
+echo throws(function() use ($manager) {
+    $manager->executeCommand("data\0base", new MongoDB\Driver\Command(['ping' => 1]));
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+/* A period would be read by the server as a namespace separator and retarget
+ * the command to a different database. */
+echo throws(function() use ($manager) {
+    $manager->executeCommand("data.base", new MongoDB\Driver\Command(['ping' => 1]));
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+/* The same validation applies to executeReadCommand() and executeWriteCommand(). */
+echo throws(function() use ($manager) {
+    $manager->executeReadCommand("data.base", new MongoDB\Driver\Command(['ping' => 1]));
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+echo throws(function() use ($manager) {
+    $manager->executeWriteCommand("data.base", new MongoDB\Driver\Command(['ping' => 1]));
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Invalid database name provided: database names may not contain a null byte
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Invalid database name provided: database names may not contain a '.' character: data.base
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Invalid database name provided: database names may not contain a '.' character: data.base
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Invalid database name provided: database names may not contain a '.' character: data.base
+===DONE===

--- a/tests/manager/manager-executeQuery_error-004.phpt
+++ b/tests/manager/manager-executeQuery_error-004.phpt
@@ -1,0 +1,32 @@
+--TEST--
+MongoDB\Driver\Manager::executeQuery() rejects a null byte in the namespace
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_not_live(); ?>
+--FILE--
+<?php
+
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = create_test_manager();
+
+/* A null byte in the collection name would truncate the namespace at the
+ * C-string layer and silently retarget the query. */
+echo throws(function() use ($manager) {
+    $manager->executeQuery("database.col\0lection", new MongoDB\Driver\Query([]));
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+/* A null byte in the database name is rejected the same way. */
+echo throws(function() use ($manager) {
+    $manager->executeQuery("data\0base.collection", new MongoDB\Driver\Query([]));
+}, 'MongoDB\Driver\Exception\InvalidArgumentException'), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Invalid namespace provided: namespaces may not contain a null byte
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Invalid namespace provided: namespaces may not contain a null byte
+===DONE===

--- a/tests/manager/manager-namespace-dots.phpt
+++ b/tests/manager/manager-namespace-dots.phpt
@@ -1,0 +1,43 @@
+--TEST--
+MongoDB\Driver\Manager: a period in the collection name stays valid
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_not_live(); ?>
+<?php skip_if_not_clean(); ?>
+--FILE--
+<?php
+
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = create_test_manager();
+
+/* A period separates the database and the collection name at the first
+ * occurrence, so it stays valid inside a collection name. */
+$collectionName = COLLECTION_NAME . '.with.dots';
+$namespace = DATABASE_NAME . '.' . $collectionName;
+
+$bulk = new MongoDB\Driver\BulkWrite();
+$bulk->insert(['_id' => 1]);
+$result = $manager->executeBulkWrite($namespace, $bulk);
+printf("insertedCount: %d\n", $result->getInsertedCount());
+
+/* listCollections confirms the collection was created with the full name,
+ * including the periods, instead of splitting the namespace. */
+$cursor = $manager->executeCommand(DATABASE_NAME, new MongoDB\Driver\Command([
+    'listCollections' => 1,
+    'filter' => ['name' => $collectionName],
+]));
+$collections = $cursor->toArray();
+printf("matched collections: %d\n", count($collections));
+printf("name matches: %s\n", var_export($collections[0]->name === $collectionName, true));
+
+$manager->executeCommand(DATABASE_NAME, new MongoDB\Driver\Command(['drop' => $collectionName]));
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+insertedCount: 1
+matched collections: 1
+name matches: true
+===DONE===


### PR DESCRIPTION
Reject a null byte in a namespace, and a null byte or a period in a database name, in the low-level `Manager` and `Server` execute methods, before the command is sent. A period in a collection name stays valid.