### PR TITLE
Bump drivers-github-tools action to v3 in release workflows

### DIFF
--- a/.github/workflows/build-windows-packages.yml
+++ b/.github/workflows/build-windows-packages.yml
@@ -63,14 +63,14 @@ jobs:
 
     steps:
       - name: "Generate token and checkout repository"
-        uses: mongodb-labs/drivers-github-tools/secure-checkout@v2
+        uses: mongodb-labs/drivers-github-tools/secure-checkout@v3
         with:
           app_id: ${{ vars.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
           ref: ${{ inputs.ref }}
 
       - name: "Set up drivers-github-tools"
-        uses: mongodb-labs/drivers-github-tools/setup@v2
+        uses: mongodb-labs/drivers-github-tools/setup@v3
         with:
           aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
           aws_region_name: ${{ vars.AWS_REGION_NAME }}
@@ -84,7 +84,7 @@ jobs:
           merge-multiple: true
 
       - name: "Create detached signatures for packages"
-        uses: mongodb-labs/drivers-github-tools/gpg-sign@v2
+        uses: mongodb-labs/drivers-github-tools/gpg-sign@v3
         with:
           filenames: artifacts/php_mongodb*.zip
 

--- a/.github/workflows/create-release-artifacts.yml
+++ b/.github/workflows/create-release-artifacts.yml
@@ -40,14 +40,14 @@ jobs:
 
     steps:
       - name: "Generate token and checkout repository"
-        uses: mongodb-labs/drivers-github-tools/secure-checkout@v2
+        uses: mongodb-labs/drivers-github-tools/secure-checkout@v3
         with:
           app_id: ${{ vars.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
 
       # Sets the S3_ASSETS environment variable used later
       - name: "Set up drivers-github-tools"
-        uses: mongodb-labs/drivers-github-tools/setup@v2
+        uses: mongodb-labs/drivers-github-tools/setup@v3
         with:
           aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
           aws_region_name: ${{ vars.AWS_REGION_NAME }}
@@ -61,7 +61,7 @@ jobs:
         run: gh release download ${{ github.ref_name }} --dir ${{ env.RELEASE_ASSETS }}
 
       - name: "Generate SSDLC Reports"
-        uses: mongodb-labs/drivers-github-tools/full-report@v2
+        uses: mongodb-labs/drivers-github-tools/full-report@v3
         with:
           product_name: "MongoDB PHP Driver (extension)"
           release_version: ${{ github.ref_name }}
@@ -72,7 +72,7 @@ jobs:
         run: gh release upload ${{ github.ref_name }} ${{ env.S3_ASSETS }}/cyclonedx.sbom.json
 
       - name: Upload S3 assets
-        uses: mongodb-labs/drivers-github-tools/upload-s3-assets@v2
+        uses: mongodb-labs/drivers-github-tools/upload-s3-assets@v3
         with:
           version: ${{ github.ref_name }}
           product_name: mongo-php-driver

--- a/.github/workflows/create-release-packages.yml
+++ b/.github/workflows/create-release-packages.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: "Generate token and checkout repository"
-        uses: mongodb-labs/drivers-github-tools/secure-checkout@v2
+        uses: mongodb-labs/drivers-github-tools/secure-checkout@v3
         with:
           app_id: ${{ vars.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -32,7 +32,7 @@ jobs:
           submodules: true
 
       - name: "Set up drivers-github-tools"
-        uses: mongodb-labs/drivers-github-tools/setup@v2
+        uses: mongodb-labs/drivers-github-tools/setup@v3
         with:
           aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
           aws_region_name: ${{ vars.AWS_REGION_NAME }}
@@ -68,7 +68,7 @@ jobs:
           echo "PACKAGE_FILE=mongodb-${PACKAGE_VERSION}.tgz" >> "$GITHUB_ENV"
 
       - name: "Create detached signature for PECL package"
-        uses: mongodb-labs/drivers-github-tools/gpg-sign@v2
+        uses: mongodb-labs/drivers-github-tools/gpg-sign@v3
         with:
           filenames: ${{ env.PACKAGE_FILE }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,9 @@ on:
 
 env:
   default-release-message: |
-    The PHP team is happy to announce that version {0} of the [mongodb](https://pecl.php.net/package/mongodb) PHP extension is now available on PECL.
+    The PHP team is happy to announce that version {0} of the MongoDB PHP extension is now available.
+    - [mongodb/mongodb-extension](https://packagist.org/packages/mongodb/mongodb-extension#{0}) on Packagist.
+    - [mongodb](https://pecl.php.net/package/mongodb) on PECL
 
     **Release Highlights**
 
@@ -32,16 +34,10 @@ env:
     You can either download and install the source manually, or you can install the extension with:
 
     ```
-    pecl install mongodb-{0}
+    pie install mongodb/mongodb-extension:{0}
     ```
 
-    or update with:
-
-    ```
-    pecl upgrade mongodb-{0}
-    ```
-
-    Windows binaries are attached to the GitHub release notes.
+    Sources and Windows binaries are attached to the GitHub release notes.
 
 jobs:
   prepare-release:
@@ -64,7 +60,7 @@ jobs:
         run: echo '🎬 Release process for version ${{ inputs.version }} started by @${{ github.triggering_actor }}' >> $GITHUB_STEP_SUMMARY
 
       - name: "Generate token and checkout repository"
-        uses: mongodb-labs/drivers-github-tools/secure-checkout@v2
+        uses: mongodb-labs/drivers-github-tools/secure-checkout@v3
         with:
           app_id: ${{ vars.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -72,7 +68,7 @@ jobs:
           fetch-depth: 0
 
       - name: "Set up drivers-github-tools"
-        uses: mongodb-labs/drivers-github-tools/setup@v2
+        uses: mongodb-labs/drivers-github-tools/setup@v3
         with:
           aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
           aws_region_name: ${{ vars.AWS_REGION_NAME }}
@@ -84,7 +80,7 @@ jobs:
           php-version: "${{ matrix.php-version }}"
 
       - name: "Create package commit"
-        uses: mongodb-labs/drivers-github-tools/bump-version@v2
+        uses: mongodb-labs/drivers-github-tools/bump-version@v3
         with:
           version: ${{ inputs.version }}
           # Note: this script will fail and abort if the requested version can't be released
@@ -94,7 +90,7 @@ jobs:
           push_commit: false
 
       - name: "Create release tag"
-        uses: mongodb-labs/drivers-github-tools/tag-version@v2
+        uses: mongodb-labs/drivers-github-tools/tag-version@v3
         with:
           version: ${{ inputs.version }}
           tag_message_template: 'Release ${VERSION}'
@@ -102,7 +98,7 @@ jobs:
           push_tag: false
 
       - name: "Bump to next development release and commit"
-        uses: mongodb-labs/drivers-github-tools/bump-version@v2
+        uses: mongodb-labs/drivers-github-tools/bump-version@v3
         with:
           version: ${{ inputs.version }}
           version_bump_script: "./bin/update-release-version.php to-next-dev"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ env:
   default-release-message: |
     The PHP team is happy to announce that version {0} of the MongoDB PHP extension is now available.
     - [mongodb/mongodb-extension](https://packagist.org/packages/mongodb/mongodb-extension#{0}) on Packagist.
-    - [mongodb](https://pecl.php.net/package/mongodb) on PECL
+    - [mongodb](https://pecl.php.net/package/mongodb) on PECL.
 
     **Release Highlights**
 


### PR DESCRIPTION
The scheduled release of 1.21.6 failed at the "Set up drivers-github-tools" step:

```
Error: authenticating creds for "artifactory.corp.mongodb.com": pinging container registry
artifactory.corp.mongodb.com: Get "https://artifactory.corp.mongodb.com/v2/": tls: failed to
verify certificate: x509: certificate has expired or is not yet valid:
current time 2026-08-27T15:46:26Z is after 2025-09-23T23:59:59Z
```

Run: https://github.com/mongodb/mongo-php-driver/actions/runs/33089560223/job/98578387757

This branch still pins `mongodb-labs/drivers-github-tools@v2`, whose artifactory TLS certificate expired on 2025-09-23. The `v2.x` branch moved to `v3` in #1872. All four release workflows are updated here.

The release message is also aligned with `v2.x`: it announces Packagist and PECL, and uses `pie install` instead of `pecl install`.

Same fix as mongodb/mongo-php-library#1971.