### PR TITLE
Fix release workflow failing on root-owned git objects

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,9 @@ jobs:
         with:
           app_id: ${{ vars.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
-          submodules: true
+          # This job only modifies phongo_version.h. Checked-out submodules make
+          # the tree look dirty after switching branches for the merge up.
+          submodules: false
           fetch-depth: 0
 
       - name: "Set up drivers-github-tools"
@@ -105,6 +107,11 @@ jobs:
           commit_template: 'Back to -dev'
           # Don't push commit, we still need to merge up
           push_commit: false
+
+      # The garasign container used by bump-version and tag-version runs as root
+      # and leaves root-owned objects in .git, which later steps cannot write to
+      - name: "Restore repository ownership"
+        run: sudo chown -R "$(id -u):$(id -g)" .git
 
       - name: "Determine branch to merge up to"
         id: get-next-branch


### PR DESCRIPTION
The garasign container used to create the release commit and signed tag runs as root, leaving root-owned objects in `.git` that later steps cannot write to, so restore ownership before the merge up and drop the submodules this job does not need.