### PR TITLE
Update package.xml maintainers list

### DIFF
--- a/bin/package.xml.in
+++ b/bin/package.xml.in
@@ -9,16 +9,34 @@ and PHP, implementing only fundamental and performance-critical components
 necessary to build a fully-functional MongoDB driver.
 </description>
  <lead>
+  <name>Jérôme Tamarelle</name>
+  <user>gromnan</user>
+  <email>jerome.tamarelle@mongodb.com</email>
+  <active>yes</active>
+ </lead>
+ <lead>
+  <name>Pauline Vos</name>
+  <user>synon</user>
+  <email>info@pauline-vos.nl</email>
+  <active>yes</active>
+ </lead>
+ <lead>
+  <name>Kevin Albertson</name>
+  <user>kevinalbs</user>
+  <email>kevin.albertson@mongodb.com</email>
+  <active>yes</active>
+ </lead>
+ <lead>
   <name>Andreas Braun</name>
   <user>alcaeus</user>
   <email>alcaeus@php.net</email>
-  <active>yes</active>
+  <active>no</active>
  </lead>
  <lead>
   <name>Jeremy Mikola</name>
   <user>jmikola</user>
   <email>jmikola@php.net</email>
-  <active>yes</active>
+  <active>no</active>
  </lead>
  <lead>
   <name>Derick Rethans</name>


### PR DESCRIPTION
Backport the maintainers list from v2.x: add Jérôme Tamarelle, Pauline Vos and Kevin Albertson as active leads, and mark Andreas Braun and Jeremy Mikola as inactive.