### PR TITLE
Document `phpize --clean` in build instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,10 +16,14 @@ The following script may be used to build the driver:
 ```
 #!/bin/sh
 
-phpize > /dev/null && \
+phpize --clean > /dev/null && phpize > /dev/null && \
 ./configure --enable-mongodb-developer-flags > /dev/null && \
 make clean > /dev/null && make all > /dev/null && make install
 ```
+
+`phpize --clean` removes the copies of `run-tests.php` and the `build` directory
+made by an earlier run. Some package managers install those files read-only, so
+`phpize` cannot overwrite them and they go stale after a PHP upgrade.
 
 To verify that the installation was successful, run the following command, which
 will report `phpinfo()` output for the extension:


### PR DESCRIPTION
`phpize` copies `run-tests.php` and the `build` directory from the PHP installation. Some package managers, such as Homebrew, install those files read-only. `phpize` then cannot overwrite the copies it made during an earlier run, printing "Permission denied" errors, and the local copies go stale after a PHP upgrade.

Running `phpize --clean` first removes them, so the next `phpize` always writes files matching the PHP version in use.