### PR TITLE
Reduce local build noise and document rebuilding after a branch switch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,14 +8,17 @@ acinclude.m4
 aclocal.m4
 autom4te.cache
 /build
+compile_commands.json
 config.guess
 config.h
 config.h.in
+config.h.in~
 config.log
 config.nice
 config.status
 config.sub
 configure
+configure~
 configure.ac
 configure.in
 include

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,27 @@ will report `phpinfo()` output for the extension:
 $ php --ri mongodb
 ```
 
+### Switching branches
+
+Each branch pins its own libmongoc and libmongocrypt commits, and `git checkout`
+does not move submodules unless `submodule.recurse` is enabled. `.gitmodules`
+also sets `ignore = untracked`, so the drift stays invisible in `git status`.
+Since the source lists in `config.m4` are generated per branch by
+`scripts/update-submodule-sources.php`, a stale submodule leads to missing-file
+errors or links the wrong C driver version. Rebuild from scratch after every
+branch change:
+
+```
+$ git checkout <branch> && git submodule update --init && \
+phpize --clean && phpize && ./configure --enable-mongodb-developer-flags && \
+make clean && make all
+```
+
+Running `git config submodule.recurse true` makes `git checkout` update the
+submodules for you, which removes one step. For a deep clean, run
+`git submodule foreach 'git clean -xdq'`, because `configure` writes generated
+headers inside the submodules and those files survive a checkout.
+
 ## Generating arginfo from stub files
 
 Arginfo structures are generated from stub files using the `gen_stub.php`

--- a/config.m4
+++ b/config.m4
@@ -314,7 +314,13 @@ if test "$PHP_MONGODB" != "no"; then
   fi
 
   if test "$PHP_MONGODB_SYSTEM_LIBS" = "no"; then
-    PHP_MONGODB_BUNDLED_CFLAGS="$PHP_MONGODB_STD_CFLAGS -DBSON_COMPILATION -DMONGOC_COMPILATION"
+    dnl Bundled libmongocrypt sources return "false" from pointer-returning
+    dnl functions (see the CHECK_BOUNDS macro in src/mc-range-mincover.c and
+    dnl src/mongocrypt-ctx.c). Clang reports this under the -Wall inherited from
+    dnl PHP_MONGODB_STD_CFLAGS. The behavior is correct, since C treats "false"
+    dnl as a null pointer constant, so the warning is only noise. This flag can
+    dnl be removed once the sources are fixed upstream in libmongocrypt.
+    PHP_MONGODB_BUNDLED_CFLAGS="$PHP_MONGODB_STD_CFLAGS -DBSON_COMPILATION -DMONGOC_COMPILATION -Wno-bool-conversion"
 
     dnl CheckUtf8Proc.m4 will modify this when using bundled utf8proc
     PHP_MONGODB_UTF8PROC_CFLAGS=""


### PR DESCRIPTION
Three small independent commits improving the local build experience.

**Silence `-Wbool-conversion` from bundled libmongocrypt sources.** The bundled sources contain `return false;` in pointer-returning functions, in the `CHECK_BOUNDS` macro of `src/mc-range-mincover.c` and in `mongocrypt_ctx_mongo_db`. Clang reports these under the `-Wall` inherited from `PHP_MONGODB_STD_CFLAGS`, producing 16 warning lines on every build. The behavior is correct, since C treats `false` as a null pointer constant, so the warnings are pure noise for extension developers. The flag is added to `PHP_MONGODB_BUNDLED_CFLAGS` only, so the extension's own sources keep `-Werror` and full strictness through `PHP_MONGODB_DEV_CFLAGS`. Fixed upstream in https://github.com/mongodb/libmongocrypt/pull/1225 (MONGOCRYPT-985); the flag can be dropped once that lands and the submodule is bumped.

**Document rebuilding after a branch switch.** Each branch pins its own libmongoc and libmongocrypt commits, and `git checkout` does not move submodules unless `submodule.recurse` is set. `.gitmodules` sets `ignore = untracked`, so the drift stays invisible in `git status`. Since `config.m4` source lists are generated per branch, a stale submodule gives missing-file errors or links the wrong C driver version. CONTRIBUTING.md covered the initial clone but not this case.

**Ignore `compile_commands.json` and autoconf backup files.** `.gitignore` already covers `configure` and `config.h.in` but not `configure~` and `config.h.in~`, which autoconf leaves behind.

Verified with a full `phpize --clean && phpize && ./configure --enable-mongodb-developer-flags && make clean && make all`: warning lines drop from 29 to 14, with all 16 `-Wbool-conversion` gone. The remaining ones are pre-existing and macOS-specific (Cyrus SASL deprecations, `_GNU_SOURCE` redefinitions). Also confirmed that adding an unused variable to `php_phongo.c` still fails the build on `-Werror`, so extension strictness is unchanged.