### PR TITLE
Remove unused "install dependencies" step from Evergreen config

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -17,7 +17,6 @@ pre:
   - func: "prepare resources"
   - func: "fix absolute paths"
   - func: "init test-results"
-  - func: "install dependencies"
   - func: "fetch build"
 post:
   - func: "upload test results"

--- a/.evergreen/config/build-task-groups.yml
+++ b/.evergreen/config/build-task-groups.yml
@@ -3,7 +3,6 @@ variables:
     - func: "fetch source"
     - func: "prepare resources"
     - func: "fix absolute paths"
-    - func: "install dependencies"
   build_teardown: &build_teardown
     - func: "cleanup"
 

--- a/.evergreen/config/functions.yml
+++ b/.evergreen/config/functions.yml
@@ -245,16 +245,6 @@ functions:
           ${PREPARE_SHELL}
           echo '{"results": [{ "status": "FAIL", "test_file": "Build", "log_raw": "No test-results.json found was created"  } ]}' > ${PROJECT_DIRECTORY}/test-results.json
 
-  "install dependencies":
-    - command: shell.exec
-      params:
-        working_dir: "src"
-        script: |
-          ${PREPARE_SHELL}
-          file="${DRIVERS_TOOLS}/.evergreen/install-dependencies.sh"
-          # Don't use ${file} syntax here because evergreen treats it as an empty expansion.
-          [ -f "$file" ] && bash $file || echo "$file not available, skipping"
-
   "start load balancer":
     - command: shell.exec
       params:


### PR DESCRIPTION
Build tasks on Ubuntu variants repeatedly fail with `Hit exec timeout (10m0s)`, with the `install dependencies` step alone taking over 9 minutes:

```
[16:07:41] W: http://ppa.launchpad.net/git-core/ppa/... Key is stored in legacy trusted.gpg keyring
[16:15:36] Hit exec timeout (10m0s).
Command 'shell.exec' in function 'install dependencies' ... stopped early: context canceled
Finished command ... in 9m4.360644545s
```

The step runs `drivers-evergreen-tools/.evergreen/install-dependencies.sh`, which only does something on two platforms:

* `linux-ubuntu*`: `apt-get update` then `apt-get -qqy -o DPkg::Lock::Timeout=-1 install awscli`
* `sunos*`: `pkgutil -i sasl_dev`

Every other platform just echoes a message, which is why only Ubuntu hosts are affected.

Neither dependency is needed in this project:

* The `aws` CLI is never invoked anywhere in `.evergreen/`. S3 uploads and downloads use the native `s3.put` and `s3.get` commands, role assumption uses `ec2.assume_role`, and the only DET script we call that touches AWS, `secrets_handling/setup-secrets.sh`, uses the boto3 virtualenv instead of the CLI.
* There is no Solaris build variant.

The Ubuntu apt call passes `DPkg::Lock::Timeout=-1`, so it waits forever for the dpkg lock while `unattended-upgrades` runs on a freshly booted host. The task group sets `setup_task_timeout_secs: 1800`, but the global `exec_timeout_secs: 600` covers the whole task including setup, so the task is killed before compiling anything.

This is not specific to one PHP version. Within `build-all-php` (`max_hosts: 4`), whichever task lands on a fresh host pays the lock wait, while the others find a warm apt cache.

This removes the function and its two call sites. `evergreen validate` passes and the generated config does not reference the function.